### PR TITLE
Add user docs

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -31,6 +31,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - In-memory `ConcurrentDictionary` collections (Channels library); `IConversationStateManager` from `Ato.Copilot.State` (message persistence) (013-copilot-everywhere)
 - C# 13 / .NET 9.0 (server), TypeScript 5.3 (VS Code & M365 extensions) + Microsoft.Extensions.AI 9.4.0-preview, Azure.Identity 1.13.2, Azure.ResourceManager.* 1.x, Microsoft.EntityFrameworkCore 9.0, Microsoft.Graph 5.70.0, Serilog 4.2.0, System.Text.Json 9.0.5 (C#); axios 1.6.5, adaptivecards 3.0.1, express 4.18.2 (TS) (014-agent-ui-enrichment)
 - EF Core 9.0 dual-provider (SQLite dev / SQL Server prod); two DbContexts (`AtoCopilotContext` for compliance, `ChatDbContext` for chat); in-memory caching via `Microsoft.Extensions.Caching.Memory` (014-agent-ui-enrichment)
+- Markdown + MkDocs (Python-based static site generator) + MkDocs, mkdocs-material theme, mkdocs-search plugin (016-user-documentation)
+- N/A (static Markdown files in `docs/`) (016-user-documentation)
 
 - C# 13 / .NET 9.0 + Azure.Identity 1.13, Azure.ResourceManager 1.13, Microsoft.Extensions.AI 9.4-preview, Microsoft.EntityFrameworkCore 9.0, Serilog 4.2, xUnit 2.9, FluentAssertions 7.0, Moq 4.20 (001-core-compliance)
 
@@ -50,9 +52,9 @@ dotnet build Ato.Copilot.sln [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMAN
 C# .NET 9: Follow standard conventions
 
 ## Recent Changes
+- 016-user-documentation: Added Markdown + MkDocs (Python-based static site generator) + MkDocs, mkdocs-material theme, mkdocs-search plugin
 - 014-agent-ui-enrichment: Added [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 - 014-agent-ui-enrichment: Added C# 13 / .NET 9.0 (server), TypeScript 5.3 (VS Code & M365 extensions) + Microsoft.Extensions.AI 9.4.0-preview, Azure.Identity 1.13.2, Azure.ResourceManager.* 1.x, Microsoft.EntityFrameworkCore 9.0, Microsoft.Graph 5.70.0, Serilog 4.2.0, System.Text.Json 9.0.5 (C#); axios 1.6.5, adaptivecards 3.0.1, express 4.18.2 (TS)
-- 013-copilot-everywhere: Added C# 13 / .NET 9.0 (Channels library), TypeScript 5.x (VS Code extension), TypeScript 5.x / Node.js 20 LTS (M365 extension) + `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`, `System.Text.Json` (Channels); `@vscode/chat` API, `axios` (VS Code); `express`, `adaptivecards`, `axios` (M365)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/
 # Test results
 TestResults/
 coverage/
+
+# MkDocs output
+site/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,9 @@
 
 > Set up, build, and run the ATO Copilot MCP server for NIST 800-53 compliance on Azure Government.
 
+!!! tip "Looking for per-persona onboarding?"
+    If you are an ISSM, ISSO, SCA, AO, or Engineer looking for role-specific getting-started guidance, see the [Getting Started hub](getting-started/index.md).
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
@@ -324,8 +327,8 @@ The assessment will:
 
 ## Next Steps
 
-- [Architecture](architecture.md) — System design, project structure, and patterns
-- [Development](development.md) — Contributing, testing, and code conventions
+- [Architecture](architecture/overview.md) — System design, project structure, and patterns
+- [Development](dev/contributing.md) — Contributing, testing, and code conventions
 - [Deployment](deployment.md) — Production deployment, security, and operations
-- [Compliance Watch](compliance-watch.md) — Continuous monitoring and alerting
-- [Remediation Kanban](remediation-kanban.md) — Track and resolve compliance findings
+- [Compliance Watch](guides/compliance-watch.md) — Continuous monitoring and alerting
+- [Remediation Kanban](guides/remediation-kanban.md) — Track and resolve compliance findings

--- a/docs/getting-started/ao.md
+++ b/docs/getting-started/ao.md
@@ -1,0 +1,82 @@
+# Getting Started: Authorizing Official (AO)
+
+> First-time setup and orientation for Authorizing Official users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | CAC enrolled with `Compliance.AuthorizingOfficial` role (typically provisioned by Administrator) |
+| **Designation** | Designated as AO for one or more systems (O-6/GS-15+ per DoDI 8510.01) |
+| **Tools** | Microsoft Teams (primary — Adaptive Cards for authorization decisions) |
+
+## First-Time Setup
+
+1. **Verify your role**
+
+    ```
+    "What role am I logged in as?"
+    ```
+
+    Expected result: `Compliance.AuthorizingOfficial`.
+
+2. **View your portfolio**
+
+    ```
+    "Show the multi-system compliance dashboard"
+    ```
+
+    Expected result: Portfolio view of all systems under your authority with compliance scores, RMF phases, and ATO expiration dates.
+
+3. **Review an authorization package**
+
+    ```
+    "Show the authorization package summary for system {id}"
+    ```
+
+    Expected result: Package summary including SSP status, SAR/RAR availability, compliance score, finding breakdown by CAT level, and residual risk assessment.
+
+## Your First 3 Commands
+
+### 1. View Portfolio Dashboard
+
+> **"Show the multi-system compliance dashboard"**
+
+Expected result: Table of all systems under your authority — system name, compliance score, RMF phase, ATO expiration date, and alert indicators.
+
+### 2. Review Authorization Package
+
+> **"Show the authorization package summary for system {id}"**
+
+Expected result: Summary of the complete package — SSP completion, assessment results, risk analysis, open findings by CAT level, and whether the package is ready for decision.
+
+### 3. Issue an Authorization Decision
+
+> **"Issue an ATO for system {id} expiring January 15, 2028 with Low residual risk — all CAT I findings remediated, 2 CAT III findings accepted"**
+
+Expected result: Authorization decision recorded (ATO, ATOwC, IATT, or DATO), system transitioned to Monitor phase, expiration tracking enabled, and risk acceptance entries created.
+
+## Authorization Decision Types
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| **ATO** | Authority to Operate | All significant findings remediated |
+| **ATOwC** | ATO with Conditions | Acceptable risk with stipulations |
+| **IATT** | Interim Authority to Test | Limited scope testing authorization |
+| **DATO** | Denial of Authorization | Unacceptable risk — system cannot operate |
+
+## What's Next
+
+- [Full AO Guide](../guides/ao-quick-reference.md) — Complete Authorize workflow and risk acceptance
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable AO cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| "Role not recognized" or empty portfolio | Administrator has not provisioned `Compliance.AuthorizingOfficial` role | Contact your Administrator to assign the role via identity management |
+| "Package not ready for authorization" | SSP or SAR is incomplete — the system has not reached Authorize phase | Wait for the ISSM to advance the system to the Authorize phase |
+| "Cannot issue DATO" without justification | All authorization decisions require justification text | Include your rationale in the natural language command |

--- a/docs/getting-started/engineer.md
+++ b/docs/getting-started/engineer.md
@@ -1,0 +1,87 @@
+# Getting Started: Platform Engineer / System Owner
+
+> First-time setup and orientation for Platform Engineer and System Owner users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | CAC enrolled with `Compliance.PlatformEngineer` role (default if no explicit role mapping) |
+| **Tools** | VS Code with GitHub Copilot Chat extension installed |
+| **Infrastructure** | Azure subscription access for the system being authorized |
+
+## First-Time Setup
+
+1. **Verify your role**
+
+    ```
+    @ato "What role am I logged in as?"
+    ```
+
+    Expected result: `Compliance.PlatformEngineer`.
+
+2. **Check your assigned tasks**
+
+    ```
+    @ato "Show my assigned remediation tasks"
+    ```
+
+    Expected result: Kanban board of assigned findings and remediation tasks with priorities and deadlines.
+
+3. **Learn about your first control**
+
+    ```
+    @ato /knowledge "What does AC-2 mean for Azure?"
+    ```
+
+    Expected result: Plain-language explanation of the NIST control tailored to your Azure environment, with implementation guidance.
+
+## Your First 3 Commands
+
+### 1. Explain a Control
+
+> **@ato /knowledge "What does AC-2 mean for Azure?"**
+
+Expected result: NIST control description translated into Azure-specific implementation steps — what services to configure, what settings to enable, and what evidence to collect.
+
+### 2. Scan Your IaC for Compliance
+
+> **@ato "Scan my Bicep file for compliance issues"**
+
+Expected result: List of compliance findings in your Infrastructure as Code (Bicep/Terraform/ARM) with CAT severity levels and suggested fixes.
+
+### 3. Write a Control Narrative
+
+> **@ato "Suggest a narrative for control SC-7 on system {id}"**
+
+Expected result: AI-generated draft narrative with a confidence score. Review, edit if needed, then commit with:
+
+```
+@ato "Write the narrative for SC-7: 'Network boundary protection is implemented
+using Azure Firewall with default-deny rules...'"
+```
+
+## VS Code Integration
+
+ATO Copilot integrates directly into your VS Code workflow:
+
+- **IaC Diagnostics** — Compliance findings appear as squiggly underlines (CAT I/II → Error, CAT III → Warning)
+- **Quick Fix** — Lightbulb Code Actions to apply suggested fixes from STIG findings
+- **Hover Info** — Shows NIST control + STIG rule + CAT severity on hover
+- **`@ato` Chat Participant** — Ask compliance questions in natural language from the Copilot Chat panel
+
+## What's Next
+
+- [Full Engineer Guide](../guides/engineer-guide.md) — Complete Implement/Assess/Monitor workflows
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable Engineer cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| "No assigned tasks" returned | ISSO or ISSM has not yet created Kanban tickets for your system | Ask your ISSO to assign findings from the assessment or check that your system is in the Implement phase |
+| IaC scan finds no issues on an empty file | Scanner requires actual resource definitions to analyze | Add Bicep/Terraform resource blocks before scanning |
+| "Access denied" on authorization or assessment tools | `Compliance.PlatformEngineer` cannot assess controls or issue authorization | Assessment is done by the SCA; authorization by the AO — focus on implementation and remediation |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,89 @@
+# Getting Started
+
+> First-time setup and orientation for all ATO Copilot users.
+
+---
+
+## Choose Your Role
+
+ATO Copilot is organized by persona. Select your role below to see prerequisites, first-time setup, and your first 3 commands:
+
+| Persona | Role | Getting Started Guide |
+|---------|------|----------------------|
+| **ISSM** | Information System Security Manager | [ISSM Getting Started](issm.md) |
+| **ISSO** | Information System Security Officer | [ISSO Getting Started](isso.md) |
+| **SCA** | Security Control Assessor | [SCA Getting Started](sca.md) |
+| **AO** | Authorizing Official | [AO Getting Started](ao.md) |
+| **Engineer** | Platform Engineer / System Owner | [Engineer Getting Started](engineer.md) |
+
+---
+
+## General Prerequisites
+
+Before using ATO Copilot in any role, ensure you have:
+
+| Requirement | Details |
+|------------|---------|
+| **CAC Enrollment** | Common Access Card enrolled with ATO Copilot — mapped by thumbprint, Azure AD group, or Azure RBAC |
+| **Azure Subscription** | Access to the Azure Government subscription(s) being assessed |
+| **Interface Access** | At least one supported interface: VS Code, Microsoft Teams, MCP API, or CLI |
+
+## How RBAC Works
+
+Your role is automatically resolved from your CAC certificate through a 4-tier chain:
+
+1. **Explicit mapping** — Your CAC thumbprint is directly mapped to a role
+2. **Azure AD group** — You belong to an Azure AD group assigned a role
+3. **Azure RBAC** — Your Azure RBAC permissions on the subscription determine your role
+4. **Default** — If no mapping is found, you are assigned `Compliance.PlatformEngineer`
+
+To check your current role:
+
+```
+"What role am I logged in as?"
+```
+
+---
+
+## Supported Interfaces
+
+### VS Code (GitHub Copilot Chat)
+
+**Best for**: Engineers, ISSOs
+
+Type `@ato` in the GitHub Copilot Chat panel, then use slash commands:
+
+| Command | Purpose |
+|---------|---------|
+| `/compliance` | Compliance scanning, assessment, remediation |
+| `/knowledge` | NIST, STIG, RMF, FedRAMP knowledge queries |
+| `/config` | Server configuration and connection settings |
+
+### Microsoft Teams (M365 Bot)
+
+**Best for**: ISSMs, AOs, SCAs
+
+Message the ATO Copilot bot in Teams. Responses use Adaptive Cards for dashboards, assessments, and approvals.
+
+### MCP Server API
+
+**Best for**: Automation, scripting, CI/CD
+
+All tools are accessible via REST, Server-Sent Events (SSE), or stdio transport. Authentication uses CAC certificates.
+
+### CLI
+
+**Best for**: Engineers, ISSOs who prefer command-line workflows
+
+Direct MCP tool invocations for scripting and automation.
+
+---
+
+## What's Next
+
+After completing your persona-specific getting-started guide:
+
+- [Persona Guides](../personas/index.md) — Full workflow reference for your role
+- [RMF Phase Reference](../rmf-phases/index.md) — Step-by-step walkthrough of all 7 RMF phases
+- [NL Query Reference](../guides/nl-query-reference.md) — Natural language query examples
+- [Quick Reference Cards](../reference/quick-reference-cards.md) — Printable cheat sheets

--- a/docs/getting-started/issm.md
+++ b/docs/getting-started/issm.md
@@ -1,0 +1,74 @@
+# Getting Started: ISSM
+
+> First-time setup and orientation for Information System Security Manager users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | CAC enrolled with `Compliance.SecurityLead` role (thumbprint mapped or Azure AD group membership) |
+| **Tools** | Microsoft Teams (primary) or MCP API client |
+| **Knowledge** | Familiarity with NIST RMF lifecycle, DoDI 8510.01, and FIPS 199 categorization |
+
+## First-Time Setup
+
+1. **Verify your identity and role**
+
+    ```
+    "What role am I logged in as?"
+    ```
+
+    Expected result: `Compliance.SecurityLead`
+
+2. **Register your first system**
+
+    ```
+    "Register a new system called 'My System' as a Major Application
+     in Azure Government"
+    ```
+
+    Expected result: System registered with a unique ID, current RMF phase set to Prepare.
+
+3. **View the system you just created**
+
+    ```
+    "Show system details for {id}"
+    ```
+
+    Expected result: System summary showing name, type, hosting environment, RMF phase, and authorization boundary status.
+
+## Your First 3 Commands
+
+### 1. Register a System
+
+> **"Register a new system called 'ACME Portal' as a Major Application with mission-critical designation in Azure Government"**
+
+Expected result: System entity created with RMF phase = Prepare. You receive the system ID for all subsequent commands.
+
+### 2. Define the Authorization Boundary
+
+> **"Define the authorization boundary for system {id} — add the production VMs, SQL database, and Key Vault"**
+
+Expected result: Azure resource IDs added to the authorization boundary. ATO Copilot confirms the resource count.
+
+### 3. Assign RMF Roles
+
+> **"Assign Jane Smith as ISSO and Bob Jones as SCA for system {id}"**
+
+Expected result: RMF roles assigned. You can verify with "What roles are assigned to system {id}?"
+
+## What's Next
+
+- [Full ISSM Guide](../guides/issm-guide.md) — Complete 29-step RMF lifecycle workflow
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable ISSM cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| "Role not recognized" | CAC certificate not mapped to any RBAC role | Contact Administrator to map your CAC thumbprint, or verify Azure AD group membership |
+| "Cannot register system" | Missing `Compliance.SecurityLead` role | Verify your role with "What role am I logged in as?" — only SecurityLead can register systems |
+| "Subscription not found" | Azure subscription not linked to ATO Copilot | Verify the subscription ID and ensure the ATO Copilot service principal has Reader access |

--- a/docs/getting-started/isso.md
+++ b/docs/getting-started/isso.md
@@ -1,0 +1,77 @@
+# Getting Started: ISSO
+
+> First-time setup and orientation for Information System Security Officer users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | CAC enrolled with `Compliance.Analyst` role |
+| **Tools** | VS Code with GitHub Copilot Chat extension (primary), Microsoft Teams |
+| **Knowledge** | Assigned as ISSO to one or more systems by the ISSM (via `compliance_assign_rmf_role`) |
+
+## First-Time Setup
+
+1. **Verify your role and system assignments**
+
+    ```
+    @ato "What systems am I assigned to?"
+    ```
+
+    Expected result: List of systems where you are assigned as ISSO.
+
+2. **Check the current RMF phase for your system**
+
+    ```
+    @ato "Show system details for {id}"
+    ```
+
+    Expected result: System summary with current RMF phase, authorization status, and compliance score.
+
+3. **Start your primary workflow**
+
+    If your system is in the **Implement** phase:
+    ```
+    @ato "Show narrative progress for system {id}"
+    ```
+
+    If your system is in the **Monitor** phase:
+    ```
+    @ato "Show monitoring status for all subscriptions"
+    ```
+
+## Your First 3 Commands
+
+### 1. Check Narrative Progress
+
+> **"Show narrative progress for system {id}"**
+
+Expected result: Per-control-family completion percentages showing how many narratives are written vs. remaining.
+
+### 2. Auto-Populate Inherited Narratives
+
+> **"Auto-populate the inherited control narratives for system {id}"**
+
+Expected result: ~40–60% of narratives auto-filled from the embedded control catalog. Remaining customer controls need manual authoring.
+
+### 3. Enable Watch Monitoring
+
+> **"Enable daily monitoring for subscription {sub-id}"**
+
+Expected result: Compliance Watch enabled with daily scheduled scans. Alerts will appear for drift and violations.
+
+## What's Next
+
+- [Full ISSO Guide](../personas/isso.md) — Complete Implement/Assess/Monitor workflows
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable ISSO cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| "What systems am I assigned to?" returns empty | ISSM has not yet assigned you as ISSO | Ask your ISSM to run `compliance_assign_rmf_role` for the target system |
+| "Access denied: Compliance.Analyst cannot invoke watch_dismiss_alert" | ISSOs cannot dismiss alerts — only officers (ISSM) can | Escalate to your ISSM to dismiss false positive alerts |
+| AI narrative suggestions unavailable | Air-gapped environment without LLM endpoint | Write narratives manually using `compliance_write_narrative`; inherited narratives still auto-populate from the embedded catalog |

--- a/docs/getting-started/sca.md
+++ b/docs/getting-started/sca.md
@@ -1,0 +1,84 @@
+# Getting Started: Security Control Assessor (SCA)
+
+> First-time setup and orientation for Security Control Assessor users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | CAC enrolled with `Compliance.Auditor` role |
+| **Independence** | Organizationally independent from the implementation team (per DoDI 8510.01) |
+| **Tools** | Microsoft Teams (Adaptive Cards) or MCP API client |
+| **Knowledge** | Assigned as SCA to one or more systems by the ISSM |
+
+!!! warning "Read-Only Role"
+    As SCA you have **read-only** access. You cannot modify narratives, fix findings, or issue authorization decisions. If you attempt a write operation, ATO Copilot will return an RBAC denial with explanation.
+
+## First-Time Setup
+
+1. **Verify your identity and read-only role**
+
+    ```
+    "What role am I logged in as?"
+    ```
+
+    Expected result: `Compliance.Auditor`.
+
+2. **Review the system's SSP before assessment**
+
+    ```
+    "Show narrative progress for system {id}"
+    ```
+
+    Expected result: Per-control-family narrative completion percentages — this tells you how much of the SSP is written.
+
+    ```
+    "Show the baseline for system {id}"
+    ```
+
+    Expected result: Applied security control baseline (Low/Moderate/High) with control count.
+
+3. **Begin your first assessment**
+
+    ```
+    "Assess control AC-1 as Satisfied using the Examine method —
+     policy document reviewed and current"
+    ```
+
+    Expected result: Assessment recorded with NIST method, result, and justification. Date/time stamped.
+
+## Your First 3 Commands
+
+### 1. Assess a Control
+
+> **"Assess control AC-1 as Satisfied using the Examine method — policy document reviewed and current"**
+
+Expected result: Assessment recorded with finding result (Satisfied/Other Than Satisfied), method (Test/Interview/Examine), and assessor justification.
+
+### 2. Take a Compliance Snapshot
+
+> **"Take a snapshot of system {id} before assessment begins"**
+
+Expected result: Point-in-time snapshot captured. Use this to compare pre- vs. post-assessment state.
+
+### 3. Generate the SAR
+
+> **"Generate the Security Assessment Report for system {id}"**
+
+Expected result: SAR document generated with all assessed controls, findings, risk levels, and supporting evidence references.
+
+## What's Next
+
+- [Full SCA Guide](../guides/sca-guide.md) — Complete assessment workflows and DoD CAT severity
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable SCA cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| "Access denied: write operation not permitted for Compliance.Auditor" | SCA is a read-only role; you attempted a write operation (e.g., edit narrative) | Assessment recording is the only write you can perform; all other writes require ISSO or ISSM role |
+| "No systems found" | ISSM has not yet assigned you as SCA | Ask your ISSM to run `compliance_assign_rmf_role` with your identity |
+| Snapshot comparison fails | No prior snapshot exists to compare against | Take a baseline snapshot first, then take another after your assessment round |

--- a/docs/guides/ao-quick-reference.md
+++ b/docs/guides/ao-quick-reference.md
@@ -4,6 +4,9 @@
 
 This guide covers the Authorizing Official's tools for issuing authorization decisions, accepting risk, and reviewing the risk register.
 
+!!! tip "New to ATO Copilot?"
+    If this is your first time using ATO Copilot as an AO, start with the [AO Getting Started](../getting-started/ao.md) page for prerequisites, first-time setup, and your first 3 commands.
+
 ---
 
 ## Prerequisites
@@ -11,6 +14,31 @@ This guide covers the Authorizing Official's tools for issuing authorization dec
 - ATO Copilot MCP server access
 - `Compliance.AuthorizingOfficial` role assigned to the system
 - Assessment completed (SAR generated, POA&M items created)
+
+---
+
+## Portfolio View
+
+As an AO, you typically manage a portfolio of systems. Use the multi-system dashboard for portfolio-level visibility:
+
+**Natural Language Queries:**
+
+> **"Show the multi-system compliance dashboard"** — Portfolio view of all authorized systems
+
+> **"Show all systems with ATOs expiring in the next 90 days"** — Expiration alerts across portfolio
+
+> **"Which of my authorized systems have CAT I findings?"** — Risk-based portfolio filtering
+
+> **"Show risk acceptances expiring in the next 90 days across all systems"** — Upcoming risk acceptance expirations
+
+> **"Show authorization decisions I have issued this year"** — Decision history
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_multi_system_dashboard` | All systems in one view with scores and status |
+| `compliance_track_ato_expiration` | Graduated expiration alerts (90d/60d/30d/expired) |
+| `compliance_show_risk_register` | Review accepted risks approaching expiration |
+| `compliance_reauthorization_workflow` | Check triggers and initiate reauthorization |
 
 ---
 
@@ -186,3 +214,12 @@ Tool: `compliance_show_risk_register`
 | `Invalid decision_type` | Unrecognized type string | Use: `ATO`, `AtoWithConditions`, `IATT`, `DATO` |
 | `Invalid residual_risk_level` | Unrecognized level | Use: `Low`, `Medium`, `High`, `Critical` |
 | `Finding not found` | Invalid finding_id for risk acceptance | Verify finding exists |
+
+---
+
+## See Also
+
+- [AO Getting Started](../getting-started/ao.md) — First-time setup and first 3 commands
+- [Persona Overview](../personas/index.md) — All personas, RACI matrix, and role definitions
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable AO cheat sheet

--- a/docs/guides/compliance-watch.md
+++ b/docs/guides/compliance-watch.md
@@ -383,3 +383,25 @@ Access control is enforced via PIM (Privileged Identity Management). Use `pim_ac
 2. Check that the service principal has Reader access to Azure Activity Log
 3. Event polling interval is configurable (default: 120 seconds)
 4. Only compliance-relevant operations trigger scans (policy, RBAC, NSG, storage, Key Vault changes)
+
+---
+
+## Air-Gapped Environment Notes
+
+!!! warning "Disconnected / Air-Gapped Monitoring"
+    In air-gapped or disconnected environments, Compliance Watch operates with the following limitations:
+    
+    - **Event-driven monitoring** is unavailable (requires Azure Event Grid / Activity Log access). Use **scheduled-only mode** with local policy cache.
+    - **Notification channels**: External email and webhook channels are unavailable. Notifications are limited to local channels (VS Code notifications, audit log entries).
+    - **Auto-remediation**: Requires network access to Azure resources for write operations. In air-gapped environments, generate remediation scripts and apply manually.
+    - **Baseline capture**: Initial baseline capture requires one-time network access. Subsequent drift detection works against the cached baseline.
+    - **Alert data**: All alert storage, lifecycle management, and SLA tracking work fully offline.
+
+---
+
+## See Also
+
+- [ISSO Guide](../personas/isso.md) — ISSO workflows including Monitor phase
+- [ISSM Guide](issm-guide.md) — ISSM oversight and portfolio monitoring
+- [Remediation Kanban Guide](remediation-kanban.md) — Task management for findings
+- [RMF Phase Reference](../rmf-phases/index.md) — Monitor phase details

--- a/docs/guides/document-catalog.md
+++ b/docs/guides/document-catalog.md
@@ -1,0 +1,226 @@
+# Document Production Catalog
+
+> Complete reference of all documents ATO Copilot can produce, including format options, owning personas, and generation tools.
+
+---
+
+## Document Summary
+
+| Document | Abbreviation | Standard | Who Produces | When Produced | Output Formats |
+|----------|-------------|----------|-------------|---------------|----------------|
+| System Security Plan | SSP | NIST SP 800-18, DoDI 8510.01 | ISSO / ISSM | Implement phase | Markdown, PDF, DOCX |
+| Security Assessment Report | SAR | NIST SP 800-53A | SCA | Assess phase | Markdown, PDF, DOCX |
+| Risk Assessment Report | RAR | DoDI 8510.01 | SCA / ISSM | Assess phase | Markdown, PDF, DOCX |
+| Plan of Action & Milestones | POA&M | OMB A-130, DoDI 8510.01 | ISSM | Assess → Monitor | Markdown, PDF, Excel |
+| Customer Responsibility Matrix | CRM | FedRAMP, DoDI 8510.01 | ISSM | Select phase | Markdown, PDF, DOCX |
+| Authorization Decision Letter | ATO Letter | DoDI 8510.01 | AO (via tool) | Authorize phase | Markdown, PDF, DOCX |
+| Continuous Monitoring Report | ConMon | NIST SP 800-137 | ISSM | Monitor (periodic) | Markdown, PDF, DOCX |
+| Authorization Package | — | DoDI 8510.01 | ISSM | Authorize phase | ZIP bundle |
+| eMASS Export | — | DISA eMASS format | ISSM | Any phase | Excel (.xlsx) |
+| OSCAL Export | — | NIST OSCAL v1.0.6 | ISSM | Any phase | JSON |
+
+---
+
+## System Security Plan (SSP)
+
+**Tool**: `compliance_generate_ssp`
+
+The SSP is the primary authorization document containing system description, categorization, control baseline, and all control implementation narratives.
+
+### SSP Sections
+
+| Section | Content |
+|---------|---------|
+| 1. System Information | Name, type, mission criticality, hosting, RMF phase, boundary |
+| 2. Security Categorization | FIPS 199 notation, C/I/A impacts, DoD IL, info types |
+| 3. Control Baseline | Level, overlay, total controls, tailoring, inheritance coverage |
+| 4. Control Implementations | Per-family controls with narrative text, status, inheritance, STIG mappings |
+
+### Generation Options
+
+```
+"Generate the SSP for system {id}"                    → Markdown
+"Generate the SSP as PDF"                             → PDF via QuestPDF
+"Generate SSP using our DISA template"                → DOCX with custom template
+"Generate SSP sections: system_information,categorization" → Partial generation
+```
+
+---
+
+## Security Assessment Report (SAR)
+
+**Tool**: `compliance_generate_sar`
+
+The SAR documents the SCA's assessment of control effectiveness, including finding severity and overall risk posture.
+
+### SAR Sections
+
+| Section | Content |
+|---------|---------|
+| 1. Executive Summary | System ID, assessor, overall score, total findings |
+| 2. CAT Severity Breakdown | CAT I/II/III counts with risk categorization |
+| 3. Control Family Results | Per-family pass/fail with CAT mapping |
+| 4. Risk Summary | Assessment-to-authorization risk posture |
+| 5. Detailed Findings | Per-control determination, method, evidence, notes |
+
+---
+
+## Risk Assessment Report (RAR)
+
+**Tool**: `compliance_generate_rar`
+
+The RAR provides the risk analysis that informs the AO's authorization decision.
+
+### RAR Sections
+
+| Section | Content |
+|---------|---------|
+| 1. Executive Summary | Aggregate risk level, recommendation |
+| 2. Per-Family Risk | Risk score by NIST control family |
+| 3. Threat/Vulnerability Analysis | Finding counts by severity category |
+| 4. Residual Risk | Accepted risks, compensating controls |
+
+---
+
+## Plan of Action & Milestones (POA&M)
+
+**Tool**: `compliance_create_poam`, `compliance_list_poam`
+
+The POA&M tracks identified weaknesses and planned remediation activities.
+
+### DoD-Required Fields
+
+| Field | Description |
+|-------|-------------|
+| POA&M ID | Auto-generated identifier |
+| Weakness | Description of the finding |
+| Security Control | NIST 800-53 control ID |
+| CAT Severity | CAT I, CAT II, or CAT III |
+| Point of Contact | Responsible individual |
+| Resources Required | Budget, personnel, tools needed |
+| Scheduled Completion | Target remediation date |
+| Milestones | Target dates for intermediate steps |
+| Status | Ongoing, Completed, Delayed, Risk Accepted |
+
+---
+
+## Customer Responsibility Matrix (CRM)
+
+**Tool**: `compliance_generate_crm`
+
+The CRM documents which controls are inherited, shared, or customer-responsible, grouped by NIST control family.
+
+### Inheritance Categories
+
+| Type | Meaning |
+|------|---------|
+| **Inherited** | Fully satisfied by the Cloud Service Provider |
+| **Shared** | Partially CSP, partially customer |
+| **Customer** | Entirely the customer's responsibility |
+
+---
+
+## Authorization Decision Letter
+
+**Generated from**: `compliance_issue_authorization`
+
+The ATO Letter is automatically generated when the AO issues an authorization decision. It includes the decision type, residual risk level, justification, expiration date, and any terms and conditions.
+
+---
+
+## Continuous Monitoring Report (ConMon)
+
+**Tool**: `compliance_generate_conmon_report`
+
+Periodic reports generated per the ConMon plan (monthly, quarterly, or annual).
+
+### Report Contents
+
+- Compliance score and delta from previous period
+- New and resolved findings
+- POA&M status summary
+- Watch alert summary
+- Significant changes reported
+- Recommendations
+
+---
+
+## Authorization Package
+
+**Tool**: `compliance_bundle_authorization_package`
+
+Bundles all required documents into a single deliverable for the AO:
+
+| Included Document | Required |
+|------------------|----------|
+| SSP | Yes |
+| SAR | Yes |
+| RAR | Yes |
+| POA&M | Yes |
+| CRM | Yes |
+| ATO Letter | After decision |
+
+---
+
+## Export Formats
+
+### eMASS Export
+
+**Tool**: `compliance_export_emass`
+
+Generates an Excel spreadsheet in DISA eMASS-compatible format for import into the Enterprise Mission Assurance Support Service.
+
+!!! info "Air-Gapped Note"
+    `compliance_export_emass` generates the file locally. In air-gapped environments, manual transfer to eMASS via removable media is required.
+
+### OSCAL Export
+
+**Tool**: `compliance_export_oscal`
+
+Generates NIST OSCAL v1.0.6 JSON for interoperability with other GRC tools. Works fully offline.
+
+---
+
+## Template System
+
+ATO Copilot supports two template modes:
+
+### Default Format
+
+Built-in compliant format covering all DoDI 8510.01 required sections. Not locked to a specific DISA template revision.
+
+### Custom Organizational Templates
+
+Organizations can upload DOCX templates with merge field placeholders:
+
+| Merge Field | Data Source |
+|-------------|------------|
+| `{{system_name}}` | Registered system name |
+| `{{system_acronym}}` | System acronym |
+| `{{system_type}}` | System type classification |
+| `{{categorization}}` | FIPS 199 overall level |
+| `{{impact_level}}` | DoD Impact Level |
+| `{{fips_notation}}` | Full FIPS 199 notation |
+| `{{control_implementations}}` | All control narratives by family |
+| `{{baseline_summary}}` | Baseline level, count, tailoring |
+| `{{findings_summary}}` | Finding counts by CAT severity |
+| `{{poam_items}}` | POA&M items with status |
+| `{{risk_acceptances}}` | Active risk acceptances |
+
+**Template Workflow**:
+
+```
+1. Upload:   compliance_upload_template(name="DISA SSP v3", document_type="ssp", ...)
+2. List:     compliance_list_templates(document_type="ssp")
+3. Generate: compliance_generate_ssp(system_id="...", format="docx", template="<id>")
+```
+
+See the [Administrator Guide](../personas/administrator.md) for template management details.
+
+---
+
+## See Also
+
+- [RMF Phase Reference](../rmf-phases/index.md) — When each document is produced
+- [Persona Overview](../personas/index.md) — Who produces each document
+- [Administrator Guide](../personas/administrator.md) — Template management

--- a/docs/guides/engineer-guide.md
+++ b/docs/guides/engineer-guide.md
@@ -4,6 +4,9 @@
 
 This guide walks through the complete SSP authoring workflow using the MCP compliance tools, from initial system registration through SSP document generation.
 
+!!! tip "New to ATO Copilot?"
+    If this is your first time using ATO Copilot as an Engineer, start with the [Engineer Getting Started](../getting-started/engineer.md) page for prerequisites, first-time setup, and your first 3 commands.
+
 ---
 
 ## Prerequisites
@@ -219,3 +222,87 @@ Parameters:
 - **Service:** `ISspService` / `SspService` — business logic with `IProgress<string>` support for long-running operations
 - **Tools:** 5 MCP tools registered via DI in `ServiceCollectionExtensions.cs` and wired in `ComplianceMcpTools.cs`
 - **Tests:** 35 unit tests (`SspAuthoringToolTests.cs`) + 5 integration tests (`SspAuthoringIntegrationTests.cs`)
+
+---
+
+## Remediation Workflows
+
+ATO Copilot provides two remediation paths:
+
+| Path | Tools | When to Use |
+|------|-------|-------------|
+| **Standalone** | `compliance_generate_plan` → `compliance_remediate` → `compliance_validate_remediation` | Quick fixes by finding ID — no task tracking needed |
+| **Kanban** | `kanban_task_list` → `kanban_remediate_task` → `kanban_task_validate` | Task-managed remediation with assignment, audit trails, and POA&M export |
+
+### Standalone Remediation
+
+Use the standalone tools when you want to fix a finding directly without task tracking:
+
+| Step | Command | Tool | Purpose |
+|------|---------|------|---------|
+| 1 | Generate remediation plan | `compliance_generate_plan` | Prioritized plan for all findings on a subscription |
+| 2 | Remediate with dry run | `compliance_remediate` | Preview fix — `dry_run: true` by default |
+| 3 | Apply the fix | `compliance_remediate` | Set `dry_run: false` to apply |
+| 4 | Validate the fix | `compliance_validate_remediation` | Re-scan to confirm finding is resolved |
+
+!!! tip "Remediation workflow chaining"
+    After an assessment reveals findings, generate a remediation plan first (`compliance_generate_plan`), then fix individual findings (`compliance_remediate`). Always validate after applying (`compliance_validate_remediation`).
+
+### Kanban Remediation Workflow
+
+When the ISSO or ISSM creates a remediation board from assessment findings, engineers receive Kanban tasks to fix compliance issues.
+
+### Task Lifecycle
+
+```
+Backlog → ToDo → InProgress → InReview → Done
+                     ↕
+                  Blocked
+```
+
+### Common Commands
+
+| Command | Tool | Purpose |
+|---------|------|---------|
+| Show my assigned tasks | `kanban_task_list` | View assigned remediation tasks |
+| Show task details | `kanban_get_task` | Full details with control ID, resources, script |
+| Move to In Progress | `kanban_move_task` | Start working on a task |
+| Fix with dry run | `kanban_remediate_task` | Preview remediation before applying |
+| Validate the fix | `kanban_task_validate` | Re-scan resources to verify remediation |
+| Collect evidence | `kanban_collect_evidence` | Collect compliance evidence for the task |
+| Move to In Review | `kanban_move_task` | Submit for ISSO review |
+
+### Status Transition Rules
+
+| Transition | Rule |
+|-----------|------|
+| → Blocked | Requires blocker comment |
+| Blocked → | Requires resolution comment |
+| → Done | Requires validation pass (or officer override) |
+| → InProgress | Auto-assigns if unassigned |
+| → InReview | Triggers automatic validation scan |
+| Done → anything | Terminal — cannot reopen |
+
+---
+
+## VS Code IaC Diagnostics
+
+ATO Copilot integrates compliance checking directly into your VS Code editing experience:
+
+- **IaC Diagnostics** — Compliance findings appear as squiggly underlines in Bicep, Terraform, and ARM template files
+  - CAT I / CAT II findings → Error severity (red underline)
+  - CAT III findings → Warning severity (yellow underline)
+- **Quick Fix** — Lightbulb Code Actions suggest fixes based on STIG findings
+- **Hover Info** — Hovering over a flagged resource shows the NIST control, STIG rule, and CAT severity
+- **`@ato` Chat Participant** — Ask compliance questions in the Copilot Chat panel
+
+---
+
+## See Also
+
+- [Engineer Getting Started](../getting-started/engineer.md) — First-time setup and first 3 commands
+- [Persona Overview](../personas/index.md) — All personas, RACI matrix, and role definitions
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [Remediation Kanban Guide](remediation-kanban.md) — Full Kanban board documentation
+- [Compliance Watch Guide](compliance-watch.md) — Alert handling for drift findings
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable Engineer cheat sheet

--- a/docs/guides/issm-guide.md
+++ b/docs/guides/issm-guide.md
@@ -4,12 +4,15 @@
 
 This guide walks an Information System Security Manager (ISSM) through the system registration and RMF lifecycle workflow using the ATO Copilot MCP tools.
 
+!!! tip "New to ATO Copilot?"
+    If this is your first time using ATO Copilot as an ISSM, start with the [ISSM Getting Started](../getting-started/issm.md) page for prerequisites, first-time setup, and your first 3 commands.
+
 ---
 
 ## Prerequisites
 
 - Access to the ATO Copilot MCP server
-- Appropriate compliance role credentials
+- `Compliance.SecurityLead` role assigned (see [Persona Overview](../personas/index.md) for role details)
 - Knowledge of the system's Azure resource inventory
 
 ---
@@ -723,3 +726,27 @@ custom template for DOCX generation.
    compliance_generate_document(document_type="ssp",
      format="docx", system_id="sys-001", template="<template-id>")
 ```
+
+---
+
+## Air-Gapped Environment Notes
+
+!!! warning "Monitor Phase — Disconnected Environments"
+    In air-gapped or disconnected environments, the following limitations apply to ISSM Monitor phase workflows:
+    
+    - **eMASS export** (`compliance_export_emass`) generates the Excel file locally — manual transfer to eMASS via removable media is required.
+    - **Notifications** (`compliance_send_notification`) are limited to local channels (VS Code, audit log); external email/webhook notifications are unavailable.
+    - **OSCAL export** (`compliance_export_oscal`) works fully offline (file generation only).
+    - **Watch monitoring** requires network access to Azure Policy/Defender for event-driven mode — use **scheduled-only mode** with local policy cache.
+    - **ConMon reports** (`compliance_generate_conmon_report`) work fully offline using locally cached data.
+
+---
+
+## See Also
+
+- [ISSM Getting Started](../getting-started/issm.md) — First-time setup and first 3 commands
+- [Persona Overview](../personas/index.md) — All personas, RACI matrix, and role definitions
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [ISSO Guide](../personas/isso.md) — ISSO workflows for day-to-day operations
+- [Compliance Watch Guide](compliance-watch.md) — Detailed continuous monitoring documentation
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable ISSM cheat sheet

--- a/docs/guides/nl-query-reference.md
+++ b/docs/guides/nl-query-reference.md
@@ -1,0 +1,204 @@
+# Natural Language Query Reference
+
+> Complete reference of natural language queries organized by category. Use these examples as-is or adapt them to your specific system and context.
+
+---
+
+## How to Use This Reference
+
+ATO Copilot accepts natural language queries through all supported interfaces:
+
+- **VS Code**: `@ato "your query"` or `@ato /compliance "your query"`
+- **Microsoft Teams**: Message the ATO Copilot bot directly
+- **MCP API**: Send as tool invocations via any MCP client
+
+Replace `{id}`, `{sub-id}`, and similar placeholders with your actual system, subscription, or resource identifiers.
+
+---
+
+## 1. System Registration & Setup
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Register a new system called 'ACME Portal' as a Major Application, mission-critical, hosted in Azure Government | `compliance_register_system` | ISSM |
+| List all registered systems | `compliance_list_systems` | All |
+| Show system details for {id} | `compliance_get_system` | All |
+| What systems am I assigned to? | `compliance_list_systems` | ISSO, Engineer |
+| Add the production VMs and database to system {id}'s boundary | `compliance_define_boundary` | ISSM |
+| Exclude the shared logging service from system {id}'s boundary — it's under a separate ATO | `compliance_exclude_from_boundary` | ISSM |
+| Assign Jane Smith as ISSM for system {id} | `compliance_assign_rmf_role` | ISSM |
+| Who is assigned to system {id}? | `compliance_list_rmf_roles` | All |
+
+---
+
+## 2. Categorization
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| What information types should I use for a financial management system? | `compliance_suggest_info_types` | ISSM |
+| Categorize system {id} as Moderate confidentiality, High integrity, Moderate availability | `compliance_categorize_system` | ISSM |
+| What's the DoD Impact Level for system {id}? | `compliance_get_categorization` | All |
+| What's the FIPS 199 notation for system {id}? | `compliance_get_categorization` | All |
+| Re-categorize system {id} — we added PII data types | `compliance_categorize_system` | ISSM |
+
+---
+
+## 3. Baseline & Controls
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Select the NIST 800-53 baseline for system {id} | `compliance_select_baseline` | ISSM |
+| How many controls are in the High baseline? | `compliance_get_baseline` | All |
+| Apply the CNSSI 1253 overlay for IL5 | `compliance_select_baseline` | ISSM |
+| Remove PE-5 from the baseline — not applicable for cloud-only systems | `compliance_tailor_baseline` | ISSM |
+| Set AC-1 as inherited from Azure Government FedRAMP High | `compliance_set_inheritance` | ISSM |
+| Generate the Customer Responsibility Matrix | `compliance_generate_crm` | ISSM |
+| What STIG rules map to AC-2? | `compliance_show_stig_mapping` | All |
+| Show all controls in the AC family | `compliance_get_baseline` | All |
+| What controls require customer implementation? | `compliance_get_baseline` | All |
+
+---
+
+## 4. SSP Authoring
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Auto-populate inherited control narratives | `compliance_batch_populate_narratives` | ISSO, Engineer |
+| Suggest a narrative for AC-2 on system {id} | `compliance_suggest_narrative` | ISSO, Engineer |
+| Write the narrative for SC-7: "Network segmentation is..." | `compliance_write_narrative` | ISSO, Engineer |
+| What's the SSP completion percentage? | `compliance_narrative_progress` | All |
+| Show narrative progress for the IA family | `compliance_narrative_progress` | All |
+| Which controls still need narratives? | `compliance_narrative_progress` | All |
+| Generate the SSP for system {id} | `compliance_generate_ssp` | ISSM |
+| Generate SSP as PDF using our DISA template | `compliance_generate_ssp` | ISSM |
+
+---
+
+## 5. Assessment
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Assess control AC-2 as Satisfied — tested and verified | `compliance_assess_control` | SCA |
+| Assess AC-3 as Other Than Satisfied, CAT II — missing MAC enforcement | `compliance_assess_control` | SCA |
+| Take a snapshot of the current assessment state | `compliance_take_snapshot` | SCA |
+| Compare the before and after snapshots | `compliance_compare_snapshots` | SCA |
+| Is evidence complete for the AC family? | `compliance_check_evidence_completeness` | SCA, ISSO |
+| Has evidence {id} been tampered with? | `compliance_verify_evidence` | SCA |
+| Generate the Security Assessment Report | `compliance_generate_sar` | SCA |
+| What's the overall compliance score? | — | All |
+| How many CAT I findings are there? | — | All |
+
+---
+
+## 6. Authorization
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Bundle the authorization package for system {id} | `compliance_bundle_authorization_package` | ISSM |
+| Issue an ATO for system {id} expiring January 2028 with Low residual risk | `compliance_issue_authorization` | AO |
+| Issue ATO with conditions — MFA required within 90 days | `compliance_issue_authorization` | AO |
+| Accept risk on finding {id} for CM-6 — compensating control: monitoring alerts | `compliance_accept_risk` | AO |
+| Deny authorization — 3 unmitigated CAT I findings | `compliance_issue_authorization` | AO |
+| Show the risk register | `compliance_show_risk_register` | All |
+| What accepted risks are expiring soon? | `compliance_show_risk_register` | AO, ISSM |
+
+---
+
+## 7. Continuous Monitoring
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Create a ConMon plan with monthly assessments | `compliance_create_conmon_plan` | ISSM |
+| Generate the February 2026 ConMon report | `compliance_generate_conmon_report` | ISSM |
+| When does the ATO expire for system {id}? | `compliance_track_ato_expiration` | All |
+| Report a significant change: new VPN interconnection | `compliance_report_significant_change` | ISSM |
+| Check reauthorization triggers | `compliance_reauthorization_workflow` | ISSM |
+| Show the multi-system dashboard | `compliance_multi_system_dashboard` | ISSM, AO |
+| Which systems have expired ATOs? | `compliance_track_ato_expiration` | ISSM, AO |
+| Export to eMASS format | `compliance_export_emass` | ISSM |
+| Export OSCAL JSON | `compliance_export_oscal` | ISSM |
+
+---
+
+## 8. Compliance Watch
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Enable daily monitoring for subscription {sub-id} | `watch_enable_monitoring` | ISSO |
+| Show monitoring status | `watch_monitoring_status` | ISSO |
+| Show all critical alerts | `watch_show_alerts` | ISSO |
+| Show alerts from the last 7 days for the AC family | `watch_show_alerts` | ISSO |
+| What drifted this week? | `watch_show_alerts` | ISSO |
+| Acknowledge alert ALT-12345 | `watch_acknowledge_alert` | ISSO |
+| Fix alert ALT-12345 with dry run | `watch_fix_alert` | ISSO |
+| Dismiss alert ALT-12345 — false positive, documented in ticket SNOW-123 | `watch_dismiss_alert` | ISSM |
+| Show alert statistics for the last 30 days | `watch_show_alerts` | ISSO |
+| Show compliance trend for subscription {sub-id} | `watch_show_alerts` | ISSO |
+| Configure quiet hours from 22:00 to 06:00 weekdays | `watch_configure_quiet_hours` | ISSO |
+| Escalate Critical alerts to ISSM if not acknowledged in 30 minutes | `watch_configure_escalation` | ISSO |
+| Create a suppression rule for PE controls expiring March 31 | `watch_suppress_alerts` | ISSO |
+
+---
+
+## 9. Kanban & Remediation
+
+### Standalone Remediation
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Generate a remediation plan for subscription {sub-id} | `compliance_generate_plan` | ISSM, Engineer |
+| Remediate finding {finding-id} with dry run | `compliance_remediate` | Engineer |
+| Apply fix for finding {finding-id} | `compliance_remediate` | Engineer |
+| Validate remediation for finding {finding-id} | `compliance_validate_remediation` | Engineer |
+
+### Kanban Task Management
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| Create a remediation board from the latest assessment | `kanban_create_board` | ISSO |
+| Show the board overview | `kanban_board_show` | All |
+| Show my assigned tasks | `kanban_task_list` | Engineer |
+| Assign REM-003 to Bob Jones | `kanban_assign_task` | ISSO |
+| Move REM-005 to In Progress | `kanban_move_task` | Engineer |
+| Fix REM-005 with dry run | `kanban_remediate_task` | Engineer |
+| Validate REM-005 | `kanban_task_validate` | Engineer |
+| Collect evidence for REM-005 | `kanban_collect_evidence` | Engineer |
+| Move REM-005 to In Review | `kanban_move_task` | Engineer |
+| Show all overdue tasks | `kanban_task_list` | ISSO, ISSM |
+| Export the board as POA&M format | `kanban_export` | ISSM |
+| Bulk assign all High severity tasks to the security team | `kanban_bulk_update` | ISSO |
+
+---
+
+## 10. Knowledge & Education
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| What does NIST control AC-2 mean? | Knowledge Base | All |
+| Explain control SC-7 in terms of Azure implementation | Knowledge Base | Engineer |
+| What are the FedRAMP Moderate requirements for encryption at rest? | Knowledge Base | All |
+| What STIG rules apply to Azure SQL Database? | `compliance_show_stig_mapping` | Engineer |
+| What is a CAT I finding? | Knowledge Base | All |
+| Explain the difference between ATO and ATOwC | Knowledge Base | All |
+| What triggers reauthorization? | Knowledge Base | All |
+| What is a Customer Responsibility Matrix? | Knowledge Base | All |
+
+---
+
+## 11. PIM (Privileged Identity Management)
+
+| Query | Tool | Persona |
+|-------|------|---------|
+| What PIM roles am I eligible for? | PIM tools | All |
+| Activate the Reader role for subscription {sub-id} — running quarterly assessment | PIM tools | SCA, ISSO |
+| List my active PIM roles | PIM tools | All |
+| Deactivate the Contributor role — remediation complete | PIM tools | Engineer |
+| Show PIM activation history | PIM tools | All |
+
+---
+
+## See Also
+
+- [Getting Started](../getting-started/index.md) — Per-persona onboarding
+- [Persona Overview](../personas/index.md) — Role definitions and permissions
+- [Quick Reference Cards](../reference/quick-reference-cards.md) — Printable per-persona cheat sheets

--- a/docs/guides/portfolio-management.md
+++ b/docs/guides/portfolio-management.md
@@ -1,0 +1,129 @@
+# Portfolio Management Guide
+
+> Multi-system workflows for ISSMs and AOs managing portfolios of information systems.
+
+---
+
+## Overview
+
+ISSMs and AOs often manage portfolios of dozens of systems simultaneously. This guide covers workflows that span multiple systems — portfolio dashboards, bulk operations, delegation patterns, and AO portfolio views.
+
+---
+
+## Portfolio Dashboard
+
+The multi-system dashboard provides a single view of all registered systems with key metrics.
+
+### Natural Language Queries
+
+> **"Show the multi-system compliance dashboard"** — all systems with scores, phases, and alerts
+
+> **"Show all systems at the Assess phase"** — filtered by RMF phase
+
+> **"Which systems have compliance scores below 80%?"** — risk-based filtering
+
+> **"Show systems with expired or expiring ATOs"** — expiration urgency view
+
+> **"Compare compliance trends across all IL5 systems"** — trend analysis
+
+> **"Show portfolio risk summary"** — aggregate risk view
+
+### Dashboard Data Points Per System
+
+| Field | Description |
+|-------|-------------|
+| System Name | Registered name |
+| Impact Level | IL2–IL6 |
+| Current RMF Phase | Prepare through Monitor |
+| Authorization Status | ATO / ATOwC / IATT / DATO / None |
+| Expiration Date | ATO expiration with color-coded urgency |
+| Compliance Score | Latest assessment percentage |
+| Open Findings | CAT I / CAT II / CAT III counts |
+| POA&M Status | Overdue / On Track / Completed counts |
+| ConMon Status | Last report date, next due date |
+
+---
+
+## Bulk Operations
+
+### ISSM Bulk Workflows
+
+| Query | Tool | Purpose |
+|-------|------|---------|
+| Export all my systems to eMASS format | `compliance_export_emass` | Portfolio-wide eMASS export |
+| Generate ConMon reports for all Monitor phase systems, period 2026-02 | `compliance_generate_conmon_report` | Batch ConMon |
+| Show overdue POA&M items across all systems | `compliance_list_poam` | Cross-system POA&M tracking |
+| Bulk assign all High severity Kanban tasks in system {id} to the security team | `kanban_bulk_update` | Mass task assignment |
+| Check ATO expiration for all systems | `compliance_track_ato_expiration` | Portfolio expiration check |
+
+### Available Bulk Tools
+
+| Tool | Bulk Capability |
+|------|----------------|
+| `compliance_multi_system_dashboard` | All systems in one view |
+| `compliance_list_systems` | Filter/search across all systems |
+| `compliance_list_poam` | POA&M items across systems (when `systemId` omitted) |
+| `compliance_track_ato_expiration` | All systems' expiration status |
+| `kanban_bulk_update` | Bulk assign, move, or set due dates on tasks |
+| `kanban_export` | Export board as CSV or POA&M for portfolio reporting |
+| `compliance_export_emass` | Per-system export (loop for portfolio) |
+
+---
+
+## Delegation Patterns
+
+When an ISSM manages many systems, delegation to ISSOs is critical.
+
+### Delegation Model
+
+| Pattern | How It Works |
+|---------|-------------|
+| **System-level ISSO assignment** | Each system has a named ISSO via `compliance_assign_rmf_role` — that ISSO owns day-to-day operations |
+| **Alert routing** | Watch alerts route to the system's assigned ISSO first; escalation path goes to ISSM |
+| **Kanban task assignment** | ISSM creates boards; ISSOs assign tasks to engineers per system |
+| **ConMon responsibility** | ISSM sets the ConMon plan; ISSO executes monitoring and generates reports |
+| **Reporting rollup** | ISSM uses dashboard for portfolio view; drills into individual systems as needed |
+
+### Delegation Queries
+
+| Query | Purpose |
+|-------|---------|
+| Who is the ISSO for system {id}? | Check system assignment |
+| Show all systems where Bob Jones is the assigned ISSO | ISSO workload view |
+| Reassign ISSO role for system {id} from Bob Jones to Sarah Lee | Transfer responsibility |
+| Show alert summary grouped by ISSO | Delegation monitoring |
+| Which ISSOs have overdue tasks? | Accountability check |
+
+---
+
+## AO Portfolio View
+
+The AO typically authorizes many systems and needs portfolio-level risk visibility.
+
+### AO Portfolio Queries
+
+| Query | Purpose |
+|-------|---------|
+| Show all systems I have authorized | Authorization portfolio |
+| What is my total portfolio risk exposure? | Aggregate risk |
+| Show risk acceptances expiring in the next 90 days across all systems | Upcoming expirations |
+| Which of my authorized systems have CAT I findings? | Critical risk filter |
+| Show authorization decisions I have issued this year | Decision history |
+
+### AO Expiration Alerts
+
+| Days Remaining | Alert Level | Action |
+|----------------|-------------|--------|
+| ≤ 90 days | Info | Begin reauthorization planning |
+| ≤ 60 days | Warning | Submit reauthorization package |
+| ≤ 30 days | Urgent | Escalate immediately |
+| Expired | Critical | System operating without authorization |
+
+---
+
+## See Also
+
+- [ISSM Guide](issm-guide.md) — Full ISSM workflow documentation
+- [AO Guide](ao-quick-reference.md) — Authorization decisions and risk acceptance
+- [Compliance Watch Guide](compliance-watch.md) — Alert management and escalation
+- [Persona Overview](../personas/index.md) — Role definitions and RACI matrix

--- a/docs/guides/sca-guide.md
+++ b/docs/guides/sca-guide.md
@@ -4,11 +4,33 @@
 
 This guide walks Security Control Assessors through the assessment workflow using ATO Copilot's MCP tools.
 
+!!! tip "New to ATO Copilot?"
+    If this is your first time using ATO Copilot as an SCA, start with the [SCA Getting Started](../getting-started/sca.md) page for prerequisites, first-time setup, and your first 3 commands.
+
 ---
 
 ## Overview
 
 As an SCA, you record per-control effectiveness determinations, map findings to DoD CAT severity levels, take immutable assessment snapshots, verify evidence chain of custody, and generate Security Assessment Reports (SARs).
+
+!!! warning "Read-Only Role"
+    As SCA you have **read-only** access. You cannot modify narratives, fix findings, or issue authorization decisions. If you attempt a write operation, ATO Copilot will return an RBAC denial with explanation.
+
+### RBAC Constraints
+
+| Tool | Access | Notes |
+|------|--------|-------|
+| `compliance_assess_control` | ✅ Allowed | SCA's primary function |
+| `compliance_take_snapshot` | ✅ Allowed | Creates immutable records |
+| `compliance_verify_evidence` | ✅ Allowed | Evidence integrity verification |
+| `compliance_check_evidence_completeness` | ✅ Allowed | Coverage reporting |
+| `compliance_compare_snapshots` | ✅ Allowed | Trend analysis |
+| `compliance_generate_sar` | ✅ Allowed | SAR generation |
+| `compliance_generate_rar` | ✅ Allowed | RAR generation |
+| `compliance_write_narrative` | ❌ Denied | SCA cannot modify SSP |
+| `compliance_remediate` | ❌ Denied | SCA cannot fix findings |
+| `compliance_issue_authorization` | ❌ Denied | Only AO can authorize |
+| `watch_dismiss_alert` | ❌ Denied | Cannot dismiss alerts |
 
 ### Prerequisite Workflow
 
@@ -186,3 +208,33 @@ The SAR includes:
 | `compliance_check_evidence_completeness` | Any compliance role |
 | `compliance_compare_snapshots` | Any compliance role |
 | `compliance_generate_sar` | `Compliance.Auditor` |
+
+---
+
+## Evidence Integrity
+
+All evidence collected by ATO Copilot is integrity-protected:
+
+- **Collection**: Each evidence item receives a SHA-256 hash at collection time
+- **Verification**: `compliance_verify_evidence` recomputes the hash and compares it to the stored value
+- **Tamper detection**: If the hash differs, the evidence is flagged as `tampered`
+- **Immutable snapshots**: Assessment snapshots are immutable — they cannot be updated or deleted after creation
+
+---
+
+## Air-Gapped Environment Notes
+
+!!! info "Assess Phase — Disconnected Environments"
+    All SCA assessment tools work fully offline:
+    
+    - `compliance_assess_control`, `compliance_take_snapshot`, `compliance_verify_evidence`, `compliance_compare_snapshots`, `compliance_generate_sar`, `compliance_generate_rar` — all operate on locally stored assessment data.
+    - **Evidence collection** (`compliance_collect_evidence`) requires network access to Azure resources. In air-gapped environments, evidence must be imported from prior scans or manual artifact uploads.
+
+---
+
+## See Also
+
+- [SCA Getting Started](../getting-started/sca.md) — First-time setup and first 3 commands
+- [Persona Overview](../personas/index.md) — All personas, RACI matrix, and role definitions
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable SCA cheat sheet

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,95 @@
+# ATO Copilot Documentation
+
+> AI-powered NIST Risk Management Framework compliance assistant for DoD teams.
+
+---
+
+## What Is ATO Copilot?
+
+ATO Copilot is an AI-powered assistant that guides DoD teams through every step of the NIST Risk Management Framework (RMF) — from system registration through continuous monitoring. It combines real Azure compliance scanning with RMF workflow automation, natural language interaction, and document generation.
+
+**ATO Copilot IS:**
+
+- A copilot that knows the RMF process and guides users step by step
+- An assistant with the full NIST 800-53 Rev 5 catalog embedded (1,000+ controls)
+- A scanner that queries real Azure infrastructure via Policy, Defender, and ARM APIs
+- A document generator that produces SSP, SAR, RAR, POA&M, and CRM from actual assessment data
+- A remediation tracker with Kanban boards linked to compliance findings
+- A continuous monitor that detects compliance drift and creates graduated alerts
+- A natural language interface where each persona sees information tailored to their role
+
+**ATO Copilot is NOT:**
+
+- A replacement for eMASS (it exports *to* eMASS)
+- A GRC platform (it is a productivity copilot)
+- A vulnerability scanner (it orchestrates Azure Policy + Defender for Cloud)
+
+---
+
+## Choose Your Persona
+
+Select your role to get started:
+
+| Persona | Role | Start Here |
+|---------|------|------------|
+| **ISSM** | Information System Security Manager | [Getting Started](getting-started/issm.md) · [Full Guide](guides/issm-guide.md) |
+| **ISSO** | Information System Security Officer | [Getting Started](getting-started/isso.md) · [Full Guide](personas/isso.md) |
+| **SCA** | Security Control Assessor | [Getting Started](getting-started/sca.md) · [Full Guide](guides/sca-guide.md) |
+| **AO** | Authorizing Official | [Getting Started](getting-started/ao.md) · [Full Guide](guides/ao-quick-reference.md) |
+| **Engineer** | Platform Engineer / System Owner | [Getting Started](getting-started/engineer.md) · [Full Guide](guides/engineer-guide.md) |
+| **Administrator** | Copilot Infrastructure Management | [Full Guide](personas/administrator.md) |
+
+---
+
+## Supported Interfaces
+
+| Surface | Primary Users | How to Access |
+|---------|--------------|---------------|
+| **VS Code (GitHub Copilot Chat)** | Engineers, ISSOs | `@ato` participant with `/compliance`, `/knowledge`, `/config` slash commands |
+| **Microsoft Teams (M365 Bot)** | ISSMs, AOs, SCAs | Adaptive Cards for dashboards, assessments, approvals |
+| **MCP Server API** | All (via any MCP client) | REST + SSE + stdio transport — powers all surfaces above |
+| **CLI** | Engineers, ISSOs | Direct MCP tool invocations for scripting and automation |
+
+---
+
+## Applicable Standards
+
+| Standard | How ATO Copilot Uses It |
+|----------|------------------------|
+| DoDI 8510.01 | Defines the 7-step RMF lifecycle ATO Copilot implements |
+| NIST SP 800-37 Rev 2 | RMF framework including Step 0 (Prepare) |
+| NIST SP 800-53 Rev 5 | Full control catalog embedded (254K lines, sourced from OSCAL) |
+| NIST SP 800-60 Vol 1 & 2 | Information type catalog for FIPS 199 categorization |
+| FIPS 199 | Security categorization (C/I/A impact → Low/Moderate/High) |
+| CNSSI 1253 | DoD overlay controls mapped to Impact Levels (IL2–IL6) |
+| DISA STIGs | Technology-specific security configuration rules |
+
+---
+
+## RBAC Roles
+
+ATO Copilot enforces role-based access control at every tool invocation. Your role determines what you can do:
+
+| RBAC Role | Maps To | Access Level |
+|-----------|---------|-------------|
+| `Compliance.Administrator` | Administrator | Full infrastructure management, all tools |
+| `Compliance.SecurityLead` | ISSM | System registration, categorization, SSP, POA&M, ConMon, dashboards |
+| `Compliance.Analyst` | ISSO | Control narratives, evidence collection, remediation execution, monitoring |
+| `Compliance.Auditor` | SCA | Assessment, effectiveness determination, SAR/RAR generation (read-only) |
+| `Compliance.AuthorizingOfficial` | AO | Authorization decisions, risk acceptance, risk register |
+| `Compliance.PlatformEngineer` | Engineer | IaC scanning, STIG lookups, remediation tasks, evidence collection |
+| `Compliance.Viewer` | Stakeholder | Read-only access to dashboards and reports |
+
+**Role Resolution**: CAC certificate → 4-tier chain: (1) explicit mapping by thumbprint, (2) Azure AD group membership, (3) Azure RBAC on subscription, (4) default to PlatformEngineer.
+
+---
+
+## Quick Links
+
+- [RMF Phase Reference](rmf-phases/index.md) — Step-by-step walkthrough of all 7 RMF phases
+- [NL Query Reference](guides/nl-query-reference.md) — Natural language query examples by category
+- [Tool Inventory](reference/tool-inventory.md) — Complete list of 114 MCP tools
+- [Document Catalog](guides/document-catalog.md) — All documents ATO Copilot produces
+- [Troubleshooting](reference/troubleshooting.md) — Common errors and resolutions
+- [Quick Reference Cards](reference/quick-reference-cards.md) — Printable cheat sheets by persona
+- [Glossary](reference/glossary.md) — Terms and definitions

--- a/docs/personas/administrator.md
+++ b/docs/personas/administrator.md
@@ -1,0 +1,168 @@
+# Administrator Guide
+
+> ATO Copilot infrastructure management — templates, configuration, and separation of duties.
+
+---
+
+## Role Overview
+
+- **Full Title**: ATO Copilot Administrator
+- **Abbreviation**: Admin
+- **RBAC Role**: `Compliance.Administrator`
+- **Primary Interface**: MCP API, VS Code
+- **Key Responsibility**: Manage ATO Copilot server configuration, document templates, and infrastructure settings. This role is explicitly separated from the Authorizing Official role to enforce DoD separation of duties.
+
+!!! warning "Separation of Duties"
+    The `Compliance.Administrator` role **cannot** issue authorization decisions or accept risk. These capabilities are exclusive to `Compliance.AuthorizingOfficial`. This separation is required by DoDI 8510.01 to prevent conflicts of interest.
+
+---
+
+## Permissions
+
+| Capability | Allowed | Tool |
+|-----------|---------|------|
+| Upload document templates | ✅ | `compliance_upload_template` |
+| List document templates | ✅ | `compliance_list_templates` |
+| Update document templates | ✅ | `compliance_update_template` |
+| Delete document templates | ✅ | `compliance_delete_template` |
+| View system details | ✅ | `compliance_get_system`, `compliance_list_systems` |
+| Issue authorization decisions | ❌ | `compliance_issue_authorization` — AO only |
+| Accept risk | ❌ | `compliance_accept_risk` — AO only |
+| Assess controls | ❌ | `compliance_assess_control` — SCA only |
+| Dismiss alerts | ❌ | `watch_dismiss_alert` — ISSM only |
+
+---
+
+## Template Management
+
+The Administrator manages custom document templates used by ATO Copilot to generate SSPs, SARs, POA&Ms, and RARs.
+
+### Upload a Template
+
+> **"Upload our organization's SSP template"**
+
+```
+Tool: compliance_upload_template
+Parameters:
+  name: "Organization SSP Template v2.1"
+  document_type: "SSP"
+  content: <DOCX file content>
+```
+
+### List Templates
+
+> **"List all uploaded document templates"**
+
+```
+Tool: compliance_list_templates
+Parameters:
+  document_type: "SSP"  (optional filter)
+```
+
+### Update a Template
+
+> **"Update template {id} with new file content"**
+
+```
+Tool: compliance_update_template
+Parameters:
+  template_id: "<template-guid>"
+  name: "Organization SSP Template v2.2"
+  content: <updated DOCX file content>
+```
+
+### Delete a Template
+
+> **"Delete template {id}"**
+
+```
+Tool: compliance_delete_template
+Parameters:
+  template_id: "<template-guid>"
+```
+
+---
+
+## Template Merge Fields
+
+Templates use `{{field_name}}` placeholders that are automatically populated with system data during document generation:
+
+### System Information
+
+| Merge Field | Data Source |
+|-------------|------------|
+| `{{system_name}}` | Registered system name |
+| `{{system_acronym}}` | System acronym |
+| `{{system_type}}` | MajorApplication, GeneralSupportSystem, etc. |
+
+### Security Categorization
+
+| Merge Field | Data Source |
+|-------------|------------|
+| `{{categorization}}` | FIPS 199 overall level (Low/Moderate/High) |
+| `{{impact_level}}` | DoD Impact Level (IL2–IL6) |
+| `{{fips_notation}}` | Full FIPS 199 notation |
+
+### Compliance Content
+
+| Merge Field | Data Source |
+|-------------|------------|
+| `{{control_implementations}}` | All control narratives grouped by family |
+| `{{baseline_summary}}` | Baseline level, control count, tailoring summary |
+| `{{findings_summary}}` | Finding counts by CAT severity |
+| `{{poam_items}}` | All POA&M items with status and milestones |
+| `{{risk_acceptances}}` | Active risk acceptances from the AO |
+
+---
+
+## Supported Document Types
+
+| Type | Description | Default Format |
+|------|-------------|---------------|
+| **SSP** | System Security Plan | Markdown / DOCX |
+| **SAR** | Security Assessment Report | Markdown |
+| **RAR** | Risk Assessment Report | Markdown |
+| **POA&M** | Plan of Action & Milestones | Markdown |
+| **CRM** | Customer Responsibility Matrix | Markdown |
+| **ConMon** | Continuous Monitoring Report | Markdown |
+
+---
+
+## Infrastructure Configuration
+
+### Azure Subscription Connection
+
+Configure the Azure subscription used by ATO Copilot for compliance assessments and evidence collection:
+
+> **"Configure the Azure subscription connection"**
+
+### Proxy Configuration (Air-Gapped)
+
+For disconnected or air-gapped environments:
+
+> **"Set up proxy configuration for air-gapped environment"**
+
+!!! info "Air-Gapped Considerations"
+    In air-gapped environments:
+    
+    - AI narrative suggestions (`compliance_suggest_narrative`) are unavailable
+    - Watch event-driven monitoring requires local policy cache only
+    - eMASS export generates files locally — manual transfer via removable media
+    - Template management works fully offline (all operations are local)
+
+---
+
+## Cross-Persona Handoffs
+
+| From | To | Trigger | Data |
+|------|----|---------|------|
+| Administrator → ISSM | Templates uploaded | Template IDs, document types available |
+| ISSM → Administrator | Template update needed | Change request with document type and requirements |
+
+---
+
+## See Also
+
+- [Persona Overview](index.md) — All personas and RACI matrix
+- [Deployment Guide](../deployment.md) — Server deployment and configuration
+- [Architecture Overview](../architecture/overview.md) — System architecture

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -1,0 +1,98 @@
+# Persona Overview
+
+> ATO Copilot supports five primary personas aligned to NIST SP 800-37 RMF roles, plus an infrastructure Administrator role.
+
+---
+
+## Role Definitions
+
+| Persona | RBAC Role | Description | Primary Interface |
+|---------|-----------|-------------|-------------------|
+| **ISSM** | `Compliance.SecurityLead` | Manages the security program; owns the authorization package | Teams, MCP API |
+| **ISSO** | `Compliance.Analyst` | Day-to-day security operations — implements and monitors controls | VS Code (`@ato`), Teams |
+| **SCA** | `Compliance.Auditor` | Independent assessor of control effectiveness (read-only) | Teams, MCP API |
+| **AO** | `Compliance.AuthorizingOfficial` | Accepts risk and issues authorization decisions | Teams (Adaptive Cards) |
+| **Engineer** | `Compliance.PlatformEngineer` | Builds/operates the system; implements controls and fixes findings | VS Code (`@ato`) |
+| **Administrator** | `Compliance.Administrator` | Manages ATO Copilot templates and infrastructure configuration | MCP API, VS Code |
+
+---
+
+## RACI Matrix — Persona Responsibilities by RMF Phase
+
+| RMF Phase | ISSM | ISSO | SCA | AO | Engineer |
+|-----------|------|------|-----|-----|----------|
+| **Prepare** | **R** (Lead) | A (Support) | — | I (Informed) | A (Support) |
+| **Categorize** | **R** (Lead) | A (Support) | — | I (Informed) | C (Consulted) |
+| **Select** | **R** (Lead) | A (Support) | C (Review) | — | C (Consulted) |
+| **Implement** | I (Oversight) | **R** (Lead) | — | — | **R** (Lead) |
+| **Assess** | A (Support) | A (Support) | **R** (Lead) | I (Informed) | A (Support) |
+| **Authorize** | A (Package) | A (Support) | A (SAR delivery) | **R** (Decide) | — |
+| **Monitor** | **R** (Lead) | **R** (Day-to-day) | C (Periodic) | I (Escalation) | A (Remediation) |
+
+**Legend**: **R** = Responsible (does the work), **A** = Accountable (supports/assists), **C** = Consulted, **I** = Informed
+
+---
+
+## RBAC Role Resolution
+
+ATO Copilot resolves user roles through a 4-tier chain:
+
+1. **Custom Header** — `X-User-Roles` (used in development/testing)
+2. **Azure AD Group** — Mapped from group membership claims in JWT
+3. **System-Level RMF Assignment** — Per-system role from `compliance_assign_rmf_role`
+4. **Default** — `Compliance.PlatformEngineer` (if no explicit mapping exists)
+
+The most specific match wins. System-level assignments enable the same user to hold different roles on different systems (e.g., ISSO on System A, Engineer on System B).
+
+---
+
+## Separation of Duties
+
+ATO Copilot enforces separation between roles per DoDI 8510.01:
+
+| Constraint | Enforcement |
+|------------|-------------|
+| SCA independence | `Compliance.Auditor` is read-only — cannot modify SSP, fix findings, or authorize |
+| AO separation | `Compliance.AuthorizingOfficial` is distinct from `Compliance.Administrator` |
+| Officer-only dismissal | Only `Compliance.SecurityLead` (ISSM) can dismiss alerts via `watch_dismiss_alert` |
+| Assessment exclusivity | Only `Compliance.Auditor` (SCA) can record assessment determinations via `compliance_assess_control` |
+| Authorization exclusivity | Only `Compliance.AuthorizingOfficial` (AO) can issue decisions via `compliance_issue_authorization` |
+
+---
+
+## Persona Guides
+
+| Persona | Getting Started | Full Guide |
+|---------|----------------|------------|
+| ISSM | [Getting Started](../getting-started/issm.md) | [ISSM Guide](../guides/issm-guide.md) |
+| ISSO | [Getting Started](../getting-started/isso.md) | [ISSO Guide](isso.md) |
+| SCA | [Getting Started](../getting-started/sca.md) | [SCA Guide](../guides/sca-guide.md) |
+| AO | [Getting Started](../getting-started/ao.md) | [AO Guide](../guides/ao-quick-reference.md) |
+| Engineer | [Getting Started](../getting-started/engineer.md) | [Engineer Guide](../guides/engineer-guide.md) |
+| Administrator | — | [Administrator Guide](administrator.md) |
+
+---
+
+## Cross-Persona Handoff Summary
+
+| From | To | Trigger | What Transfers |
+|------|----|---------|----------------|
+| ISSM → ISSO | System registered, baseline selected | System ID, control list for narrative authoring |
+| ISSM → Engineer | Controls need implementation | Kanban tasks, STIG requirements |
+| ISSO → Engineer | Findings identified | Kanban remediation tasks with severity and SLA |
+| Engineer → ISSO | Remediation complete | Task moved to InReview, evidence collected |
+| ISSO → SCA | SSP ready for assessment | System ID, assessment scope, evidence |
+| SCA → ISSM | Assessment complete | SAR, RAR, effectiveness determinations |
+| ISSM → AO | Package ready for decision | Bundled authorization package |
+| AO → ISSM | Decision issued | Authorization decision, risk acceptances, conditions |
+| ISSO → ISSM | Significant change detected | Change record, reauthorization flag |
+| Watch → ISSO | Drift/violation detected | Alert with severity, control ID, resource ID |
+| ISSO → ISSM | SLA escalation | Unacknowledged critical/high alerts |
+
+---
+
+## See Also
+
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [Tool Inventory](../reference/tool-inventory.md) — Complete list of 114 MCP tools
+- [Quick Reference Cards](../reference/quick-reference-cards.md) — Per-persona cheat sheets

--- a/docs/personas/isso.md
+++ b/docs/personas/isso.md
@@ -1,0 +1,216 @@
+# ISSO Guide — Information System Security Officer
+
+> Day-to-day security operations — implements and monitors controls.
+
+---
+
+## Role Overview
+
+- **Full Title**: Information System Security Officer
+- **Abbreviation**: ISSO
+- **RBAC Role**: `Compliance.Analyst`
+- **Primary RMF Phases**: Implement (Lead), Assess (Support), Monitor (Day-to-day)
+- **Key Responsibility**: Author SSP narratives, collect evidence, manage Watch monitoring, triage alerts, and coordinate remediation with engineers.
+- **Reports to**: ISSM
+- **Primary Interface**: VS Code (`@ato`), Microsoft Teams
+
+---
+
+## Permissions
+
+| Capability | Allowed | Tool |
+|-----------|---------|------|
+| View system details | ✅ | `compliance_get_system`, `compliance_list_systems` |
+| View categorization | ✅ | `compliance_get_categorization` |
+| View baseline | ✅ | `compliance_get_baseline` |
+| Write narratives | ✅ | `compliance_write_narrative` |
+| Batch populate narratives | ✅ | `compliance_batch_populate_narratives` |
+| Suggest narratives (AI) | ✅ | `compliance_suggest_narrative` |
+| Track narrative progress | ✅ | `compliance_narrative_progress` |
+| Collect evidence | ✅ | `compliance_collect_evidence` |
+| Run compliance assessment | ✅ | `compliance_assess` |
+| Enable/manage Watch monitoring | ✅ | `watch_enable_monitoring`, `watch_configure_monitoring` |
+| View/acknowledge/fix alerts | ✅ | `watch_show_alerts`, `watch_acknowledge_alert`, `watch_fix_alert` |
+| Create remediation boards | ✅ | `kanban_create_board` |
+| Assign Kanban tasks | ✅ | `kanban_assign_task` |
+| Dismiss alerts | ❌ | `watch_dismiss_alert` — officer (ISSM) only |
+| Assess controls (SCA) | ❌ | `compliance_assess_control` — SCA only |
+| Issue authorization | ❌ | `compliance_issue_authorization` — AO only |
+| Accept risk | ❌ | `compliance_accept_risk` — AO only |
+
+---
+
+## Daily Activities
+
+- Write and review control implementation narratives
+- Collect evidence from Azure infrastructure
+- Monitor compliance Watch alerts and triage new findings
+- Coordinate remediation tasks with engineers on Kanban boards
+- Respond to drift alerts and configuration changes
+- Run periodic compliance assessments
+- Ensure monitoring is enabled and properly configured
+
+---
+
+## RMF Phase Workflows
+
+### Phase 3: Implement (ISSO Lead)
+
+**Objective**: Author SSP control narratives, batch-populate inherited controls, and get AI-assisted suggestions for customer controls.
+
+**Step-by-Step**:
+
+1. Auto-populate inherited narratives → Tool: `compliance_batch_populate_narratives`
+2. Get AI suggestions for customer controls → Tool: `compliance_suggest_narrative`
+3. Write/update narrative text → Tool: `compliance_write_narrative`
+4. Track completion by family → Tool: `compliance_narrative_progress`
+
+**Natural Language Queries**:
+
+> **"Auto-populate the inherited control narratives for system {id}"** → `compliance_batch_populate_narratives` — fills ~40–60% of narratives from the embedded control catalog
+
+> **"Suggest a narrative for AC-2 on system {id}"** → `compliance_suggest_narrative` — AI draft with confidence score
+
+> **"Write the narrative for AC-2: 'Account management is implemented using Azure AD...'"** → `compliance_write_narrative` — stores the narrative with Implemented status
+
+> **"What's the narrative completion for the SC family?"** → `compliance_narrative_progress` — per-family completion percentages
+
+> **"Show all controls missing narratives for system {id}"** → `compliance_narrative_progress` — lists controls without narratives
+
+**AI Suggestion Confidence Levels**:
+
+| Score | Meaning | Action |
+|-------|---------|--------|
+| ≥ 0.85 | High confidence (inherited controls) | Review and accept |
+| 0.70–0.84 | Good confidence (shared controls) | Review and customize |
+| 0.50–0.69 | Moderate confidence (customer controls) | Significant review needed |
+| < 0.50 | Low confidence — flagged | Write manually |
+
+**Documents Produced**:
+
+| Document | Format | Purpose |
+|----------|--------|---------|
+| SSP Narratives | Per-control records | Individual control implementation statements |
+
+!!! warning "Air-Gapped Note"
+    In disconnected environments, `compliance_suggest_narrative` and `compliance_batch_populate_narratives` (AI-generated suggestions) are **unavailable**. Write all narratives manually using `compliance_write_narrative`. Inherited control narratives can still be auto-populated from the embedded control catalog (no network required).
+
+---
+
+### Phase 4: Assess (ISSO Support)
+
+**Objective**: Collect evidence, support the SCA during assessment, and coordinate finding remediation.
+
+**Step-by-Step**:
+
+1. Collect evidence from Azure → Tool: `compliance_collect_evidence`
+2. Run compliance assessment → Tool: `compliance_assess`
+3. Create remediation Kanban board → Tool: `kanban_create_board`
+4. Assign remediation tasks to engineers → Tool: `kanban_assign_task`
+5. Fix alerts with optional dry-run → Tool: `watch_fix_alert`
+
+**Natural Language Queries**:
+
+> **"Collect evidence for the AC family on subscription {sub-id}"** → `compliance_collect_evidence` — collects Azure resource evidence with SHA-256 hashing
+
+> **"Run a compliance assessment on subscription {sub-id}"** → `compliance_assess` — runs NIST 800-53 compliance assessment
+
+> **"Create a remediation board from the latest assessment"** → `kanban_create_board` — creates Kanban board from findings
+
+> **"Assign task REM-003 to engineer Bob Jones"** → `kanban_assign_task` — assigns remediation task
+
+> **"Fix alert ALT-12345 with dry run first"** → `watch_fix_alert` — previews remediation before executing
+
+---
+
+### Phase 6: Monitor (ISSO Day-to-Day)
+
+**Objective**: Manage continuous monitoring, triage alerts, maintain baselines, and handle auto-remediation.
+
+**Step-by-Step**:
+
+1. Enable monitoring → Tool: `watch_enable_monitoring`
+2. View alerts → Tool: `watch_show_alerts`
+3. Acknowledge alerts → Tool: `watch_acknowledge_alert`
+4. Fix or escalate → Tool: `watch_fix_alert` / escalate to ISSM
+5. Track trends → Tool: `watch_show_alerts` with time filters
+
+**Natural Language Queries**:
+
+> **"Enable daily monitoring for subscription {sub-id}"** → `watch_enable_monitoring` — enables scheduled daily scans
+
+> **"Show all critical alerts from the last 7 days"** → `watch_show_alerts` — filtered alert list
+
+> **"Acknowledge alert ALT-12345"** → `watch_acknowledge_alert` — pauses SLA escalation timer
+
+> **"What drifted this week?"** → `watch_show_alerts` — shows drift alerts for recent period
+
+> **"Configure auto-remediation for Low severity drift alerts"** → auto-remediation rule creation
+
+> **"Set quiet hours from 22:00 to 06:00 on weekdays"** → `watch_configure_quiet_hours` — suppresses notifications during off-hours
+
+> **"Configure escalation: if Critical alert is not acknowledged in 30 minutes, notify the ISSM"** → `watch_configure_escalation` — defines escalation path
+
+**Watch Monitoring Tools**:
+
+| Tool | Purpose |
+|------|---------|
+| `watch_enable_monitoring` | Enable scheduled/event-driven/combined monitoring |
+| `watch_disable_monitoring` | Disable monitoring for a subscription |
+| `watch_configure_monitoring` | Update frequency or mode |
+| `watch_monitoring_status` | View all monitoring configurations |
+| `watch_show_alerts` | List alerts with severity/status/family/time filters |
+| `watch_get_alert` | Full alert details with history and correlations |
+| `watch_acknowledge_alert` | Acknowledge (pauses SLA escalation) |
+| `watch_fix_alert` | Remediate with optional dry-run |
+| `watch_create_rule` | Create custom alert rules |
+| `watch_list_rules` | List active alert rules |
+| `watch_suppress_alerts` | Suppress alert patterns with expiration |
+| `watch_configure_quiet_hours` | Set notification quiet hours |
+| `watch_configure_notifications` | Configure channels (Chat, Email, Webhook) |
+| `watch_configure_escalation` | Define escalation paths for SLA violations |
+
+**Alert Lifecycle**:
+
+```
+New → Acknowledged → InProgress → Resolved
+  ↓        ↓
+Dismissed  Escalated (SLA violation)
+```
+
+**SLA Due Dates by Severity**:
+
+| Severity | Due Date | Escalation |
+|----------|----------|------------|
+| Critical | 24 hours | After 30 min unacknowledged |
+| High | 7 days | After 4 hours unacknowledged |
+| Medium | 30 days | After 24 hours unacknowledged |
+| Low | 90 days | After 7 days unacknowledged |
+
+!!! info "Air-Gapped Note"
+    In disconnected environments, Watch **event-driven** monitoring is unavailable (requires Azure Event Grid). Use **scheduled-only mode** with local policy cache. Alert notifications are limited to local channels (VS Code, audit log) — external email/webhook channels are unavailable.
+
+---
+
+## Cross-Persona Handoffs
+
+| From | To | Trigger | Data |
+|------|----|---------|------|
+| ISSM → ISSO | System registered, baseline selected | System ID, control list for narrative authoring |
+| ISSO → Engineer | Findings identified | Kanban remediation tasks with severity and SLA |
+| Engineer → ISSO | Remediation complete | Task moved to InReview, evidence collected |
+| ISSO → SCA | SSP ready for assessment | System ID, assessment scope, evidence package |
+| ISSO → ISSM | Significant change detected | Change record, reauthorization flag |
+| ISSO → ISSM | SLA escalation | Unacknowledged critical/high alert details |
+| Watch → ISSO | Drift/violation detected | Alert with severity, control ID, resource ID |
+
+---
+
+## See Also
+
+- [Getting Started: ISSO](../getting-started/isso.md) — First-time setup and orientation
+- [RMF Phase Reference](../rmf-phases/index.md) — Phase-by-phase workflow details
+- [Quick Reference Card](../reference/quick-reference-cards.md) — Printable ISSO cheat sheet
+- [Compliance Watch Guide](../guides/compliance-watch.md) — Detailed monitoring documentation
+- [Remediation Kanban Guide](../guides/remediation-kanban.md) — Task management workflows
+- [SSP Authoring Guide](../guides/engineer-guide.md) — Narrative writing workflows

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -84,6 +84,7 @@
 
 | Term | Definition |
 |------|-----------|
+| **Kanban** | ATO Copilot's visual task management system for tracking remediation work through columns (Backlog → To Do → In Progress → Review → Done) |
 
 ## M
 
@@ -107,6 +108,7 @@
 | Term | Definition |
 |------|-----------|
 | **ODP** | Organization-Defined Parameter — Customizable values within NIST 800-53 controls |
+| **OSCAL** | Open Security Controls Assessment Language — NIST standard for machine-readable compliance data (v1.0.6 supported) |
 
 ## P
 
@@ -146,11 +148,13 @@
 
 | Term | Definition |
 |------|-----------|
+| **USCYBERCOM** | United States Cyber Command — combatant command that may direct cyber operations affecting system authorization |
 
 ## W
 
 | Term | Definition |
 |------|-----------|
+| **Watch** | ATO Copilot's Compliance Watch subsystem — real-time monitoring, alerting, and auto-remediation engine |
 
 ## X
 

--- a/docs/reference/quick-reference-cards.md
+++ b/docs/reference/quick-reference-cards.md
@@ -1,0 +1,234 @@
+# Quick Reference Cards
+
+> Printable cheat sheets for each persona — top NL queries, key tools, and phase responsibilities.
+
+---
+
+## ISSM Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                 ISSM Quick Reference                    │
+│          Role: Compliance.SecurityLead                  │
+├─────────────────────────────────────────────────────────┤
+│ REGISTER:  "Register system {name} as {type} in {env}" │
+│ BOUNDARY:  "Add resources to system {id}'s boundary"    │
+│ ROLES:     "Assign {name} as {role} for system {id}"    │
+│ CATEGORIZE:"Categorize system {id} with {info types}"   │
+│ BASELINE:  "Select baseline for system {id}"            │
+│ TAILOR:    "Remove {control} — {rationale}"             │
+│ SSP:       "Generate SSP for system {id}"               │
+│ POAM:      "Create POA&M for finding {id}"              │
+│ PACKAGE:   "Bundle authorization package"               │
+│ DASHBOARD: "Show multi-system dashboard"                │
+│ CONMON:    "Generate monthly report for system {id}"    │
+│ EMASS:     "Export system {id} to eMASS"                │
+├─────────────────────────────────────────────────────────┤
+│ Phases: R in ALL | A in Prepare, Categorize, Select     │
+│ Gate authority: Only ISSM can advance RMF phases        │
+└─────────────────────────────────────────────────────────┘
+```
+
+### ISSM Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_register_system` | Register new system |
+| `compliance_advance_rmf_step` | Move between RMF phases |
+| `compliance_categorize_system` | FIPS 199 categorization |
+| `compliance_select_baseline` | Choose control baseline |
+| `compliance_generate_ssp` | Generate SSP document |
+| `compliance_bundle_authorization_package` | Bundle for AO |
+| `compliance_multi_system_dashboard` | Portfolio overview |
+| `compliance_export_emass` | Export to eMASS |
+
+---
+
+## ISSO Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                 ISSO Quick Reference                    │
+│           Role: Compliance.Analyst                      │
+├─────────────────────────────────────────────────────────┤
+│ NARRATIVES:  "Auto-populate inherited narratives"       │
+│ SUGGEST:     "Suggest narrative for {control}"          │
+│ PROGRESS:    "What's the SSP completion percentage?"    │
+│ WATCH:       "Enable monitoring for subscription {id}"  │
+│ ALERTS:      "Show all unacknowledged alerts"           │
+│ ACK:         "Acknowledge alert ALT-{id}"               │
+│ FIX:         "Fix alert ALT-{id}"                       │
+│ EVIDENCE:    "Collect evidence for {control}"           │
+│ CONMON:      "Generate ConMon report for {period}"      │
+│ ASSIGN:      "Assign task REM-{id} to {engineer}"       │
+├─────────────────────────────────────────────────────────┤
+│ Phases: R in Implement, Monitor | C in Assess           │
+│ Lead: Day-to-day SSP authoring and ConMon execution     │
+└─────────────────────────────────────────────────────────┘
+```
+
+### ISSO Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_batch_populate_narratives` | Auto-fill inherited |
+| `compliance_suggest_narrative` | AI narrative generation |
+| `compliance_narrative_progress` | Track completion |
+| `watch_enable_monitoring` | Start monitoring |
+| `watch_show_alerts` | View alerts |
+| `watch_acknowledge_alert` | Acknowledge alert |
+| `compliance_generate_conmon_report` | Monthly ConMon |
+| `kanban_assign_task` | Assign remediation |
+
+---
+
+## SCA Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  SCA Quick Reference                    │
+│           Role: Compliance.Auditor                      │
+├─────────────────────────────────────────────────────────┤
+│ ASSESS:    "Assess {control} as {determination}"        │
+│ SNAPSHOT:  "Take assessment snapshot for system {id}"    │
+│ EVIDENCE:  "Verify evidence {id}"                       │
+│ COMPLETE:  "Check evidence completeness for {family}"   │
+│ COMPARE:   "Compare snapshots {a} and {b}"              │
+│ SAR:       "Generate SAR for system {id}"               │
+│ RAR:       "Generate RAR for system {id}"               │
+│                                                         │
+│ ⚠️ Read-only: Cannot modify system, fix findings,      │
+│    or issue authorization decisions                     │
+├─────────────────────────────────────────────────────────┤
+│ Phases: R in Assess only | Independence required        │
+│ Lead: Security assessment and SAR/RAR generation        │
+└─────────────────────────────────────────────────────────┘
+```
+
+### SCA Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_assess_control` | Record effectiveness |
+| `compliance_take_snapshot` | Immutable snapshot |
+| `compliance_verify_evidence` | Hash verification |
+| `compliance_check_evidence_completeness` | Coverage check |
+| `compliance_compare_snapshots` | Trend analysis |
+| `compliance_generate_sar` | SAR production |
+| `compliance_generate_rar` | RAR production |
+
+---
+
+## AO Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   AO Quick Reference                    │
+│       Role: Compliance.AuthorizingOfficial               │
+├─────────────────────────────────────────────────────────┤
+│ REVIEW:    "Show authorization package for system {id}" │
+│ AUTHORIZE: "Issue ATO for system {id} expiring {date}"  │
+│ CONDITIONS:"Issue ATOwC — {conditions}"                 │
+│ RISK:      "Accept risk on finding {id} — {rationale}"  │
+│ DENY:      "Deny authorization — {reason}"              │
+│ REGISTER:  "Show risk register for system {id}"         │
+│ DASHBOARD: "Show all my authorized systems"             │
+│ EXPIRATION:"What ATOs expire in the next 90 days?"      │
+├─────────────────────────────────────────────────────────┤
+│ Phases: R in Authorize only | I in Monitor              │
+│ Lead: Authorization decisions and risk acceptance        │
+└─────────────────────────────────────────────────────────┘
+```
+
+### AO Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_issue_authorization` | Issue ATO/ATOwC/IATT/DATO |
+| `compliance_accept_risk` | Accept residual risk |
+| `compliance_show_risk_register` | View risk register |
+| `compliance_multi_system_dashboard` | Portfolio overview |
+| `compliance_track_ato_expiration` | Expiration monitoring |
+
+---
+
+## Engineer Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│               Engineer Quick Reference                  │
+│        Role: Compliance.PlatformEngineer (default)      │
+├─────────────────────────────────────────────────────────┤
+│ LEARN:     "What does {control} mean for Azure?"        │
+│ STIG:      "What STIG rules apply to {technology}?"     │
+│ SCAN:      "Scan my Bicep file for compliance"          │
+│ NARRATIVE: "Suggest narrative for {control}"             │
+│ WRITE:     "Write narrative for {control}: {text}"      │
+│ TASKS:     "Show my assigned tasks"                     │
+│ FIX:       "Fix task REM-{id} with dry run"             │
+│ VALIDATE:  "Validate task REM-{id}"                     │
+│ EVIDENCE:  "Collect evidence for task REM-{id}"         │
+│ PROGRESS:  "Show narrative progress for {family}"       │
+│ PLAN:      "Generate remediation plan for {sub-id}"     │
+│ REMEDIATE: "Remediate finding {id} with dry run"        │
+│ VERIFY:    "Validate remediation for finding {id}"      │
+├─────────────────────────────────────────────────────────┤
+│ Phases: C in Implement | C in Assess (remediation)      │
+│ Lead: Technical remediation and IaC compliance          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Engineer Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_get_control_family` | Learn about controls |
+| `compliance_show_stig_mapping` | STIG cross-reference |
+| `compliance_suggest_narrative` | AI narrative suggestion |
+| `compliance_write_narrative` | Write narrative |
+| `kanban_task_list` | View assigned tasks |
+| `kanban_remediate_task` | Execute remediation |
+| `kanban_task_validate` | Validate fix |
+| `kanban_collect_evidence` | Collect evidence |
+| `compliance_generate_plan` | Generate remediation plan |
+| `compliance_remediate` | Fix finding directly |
+| `compliance_validate_remediation` | Verify fix applied |
+
+---
+
+## Administrator Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│             Administrator Quick Reference               │
+│          Role: Compliance.Administrator                  │
+├─────────────────────────────────────────────────────────┤
+│ UPLOAD:    "Upload SSP template from {file}"            │
+│ TEMPLATES: "List all document templates"                │
+│ UPDATE:    "Update the SSP template with {file}"        │
+│ DELETE:    "Delete template {id}"                       │
+│                                                         │
+│ ⚠️ Cannot: Register systems, assess controls, or       │
+│    issue authorization decisions (separation of duties) │
+├─────────────────────────────────────────────────────────┤
+│ Phases: No phase involvement — infrastructure only      │
+│ Lead: Template management and system configuration      │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Administrator Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_upload_template` | Upload DOCX template |
+| `compliance_list_templates` | List templates |
+| `compliance_update_template` | Update template |
+| `compliance_delete_template` | Delete template |
+
+---
+
+## See Also
+
+- [Tool Inventory](tool-inventory.md) — Complete 114-tool reference
+- [NL Query Reference](../guides/nl-query-reference.md) — Full query catalog
+- [Persona Overview](../personas/index.md) — Role definitions and RACI

--- a/docs/reference/tool-inventory.md
+++ b/docs/reference/tool-inventory.md
@@ -1,0 +1,230 @@
+# Tool Inventory
+
+> Complete reference of all 114 MCP tools available in ATO Copilot, grouped by category.
+
+---
+
+## How to Use This Reference
+
+Each tool listing includes the tool name, a short description, the RMF phase(s) where it applies, and which RBAC roles can invoke it.
+
+**RBAC Role Abbreviations**:
+
+| Abbreviation | RBAC Role |
+|--------------|-----------|
+| **ISSM** | `Compliance.SecurityLead` |
+| **ISSO** | `Compliance.Analyst` |
+| **SCA** | `Compliance.Auditor` |
+| **AO** | `Compliance.AuthorizingOfficial` |
+| **Eng** | `Compliance.PlatformEngineer` (default) |
+| **Admin** | `Compliance.Administrator` |
+
+---
+
+## Category 1: RMF Lifecycle Tools (34 tools)
+
+Tools that drive the seven-phase RMF lifecycle from Prepare through Authorize.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 1 | `compliance_register_system` | Register a new information system | Prepare | ISSM |
+| 2 | `compliance_list_systems` | List registered systems | All | All |
+| 3 | `compliance_get_system` | Get system details | All | All |
+| 4 | `compliance_advance_rmf_step` | Advance or regress RMF phase | All | ISSM |
+| 5 | `compliance_define_boundary` | Define authorization boundary | Prepare | ISSM |
+| 6 | `compliance_exclude_from_boundary` | Exclude resource from boundary | Prepare | ISSM |
+| 7 | `compliance_assign_rmf_role` | Assign RMF role to user | Prepare | ISSM |
+| 8 | `compliance_list_rmf_roles` | List role assignments | Prepare | ISSM, ISSO |
+| 9 | `compliance_categorize_system` | FIPS 199 categorization | Categorize | ISSM |
+| 10 | `compliance_get_categorization` | View categorization | Categorize | All |
+| 11 | `compliance_suggest_info_types` | AI-suggest SP 800-60 info types | Categorize | ISSM |
+| 12 | `compliance_select_baseline` | Select NIST 800-53 baseline | Select | ISSM |
+| 13 | `compliance_tailor_baseline` | Add/remove controls | Select | ISSM |
+| 14 | `compliance_set_inheritance` | Set control inheritance | Select | ISSM |
+| 15 | `compliance_get_baseline` | View baseline details | Select | All |
+| 16 | `compliance_generate_crm` | Generate CRM | Select | ISSM |
+| 17 | `compliance_write_narrative` | Write control narrative | Implement | ISSO, Eng |
+| 18 | `compliance_suggest_narrative` | AI-suggest narrative | Implement | ISSO, Eng |
+| 19 | `compliance_batch_populate_narratives` | Auto-fill inherited narratives | Implement | ISSO |
+| 20 | `compliance_narrative_progress` | Track SSP completion | Implement | ISSM, ISSO |
+| 21 | `compliance_generate_ssp` | Generate SSP document | Implement | ISSM, ISSO |
+| 22 | `compliance_assess_control` | Record control effectiveness | Assess | SCA |
+| 23 | `compliance_take_snapshot` | Immutable assessment snapshot | Assess | SCA |
+| 24 | `compliance_compare_snapshots` | Compare snapshots | Assess | SCA, ISSM |
+| 25 | `compliance_verify_evidence` | Evidence integrity check | Assess | SCA |
+| 26 | `compliance_check_evidence_completeness` | Evidence coverage report | Assess | SCA |
+| 27 | `compliance_generate_sar` | Generate SAR | Assess | SCA |
+| 28 | `compliance_issue_authorization` | Issue ATO/ATOwC/IATT/DATO | Authorize | AO |
+| 29 | `compliance_accept_risk` | Accept risk on finding | Authorize | AO |
+| 30 | `compliance_show_risk_register` | View risk register | Authorize | AO, ISSM |
+| 31 | `compliance_create_poam` | Create POA&M item | Assess | ISSM |
+| 32 | `compliance_list_poam` | List POA&M items | Assess | ISSM, ISSO |
+| 33 | `compliance_generate_rar` | Generate RAR | Assess | ISSM |
+| 34 | `compliance_bundle_authorization_package` | Bundle SSP+SAR+RAR+POA&M+CRM | Authorize | ISSM |
+
+---
+
+## Category 2: Continuous Monitoring Tools (7 tools)
+
+Tools for ConMon plans, reports, expiration tracking, and portfolio dashboards.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 35 | `compliance_create_conmon_plan` | Create/update ConMon plan | Monitor | ISSM |
+| 36 | `compliance_generate_conmon_report` | Generate periodic report | Monitor | ISSM, ISSO |
+| 37 | `compliance_track_ato_expiration` | Check expiration status | Monitor | ISSM, AO |
+| 38 | `compliance_report_significant_change` | Report significant change | Monitor | ISSM, ISSO |
+| 39 | `compliance_reauthorization_workflow` | Check/initiate reauthorization | Monitor | ISSM |
+| 40 | `compliance_multi_system_dashboard` | Portfolio dashboard | Monitor | ISSM, AO |
+| 41 | `compliance_send_notification` | Send notification via channels | Monitor | ISSM |
+
+---
+
+## Category 3: Interoperability Tools (4 tools)
+
+Tools for eMASS, OSCAL, and STIG cross-reference.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 42 | `compliance_export_emass` | Export to eMASS Excel format | All | ISSM |
+| 43 | `compliance_import_emass` | Import eMASS Excel with conflict resolution | All | ISSM |
+| 44 | `compliance_export_oscal` | Export OSCAL v1.0.6 JSON | All | ISSM |
+| 45 | `compliance_show_stig_mapping` | NIST-to-STIG cross-reference | All | All |
+
+---
+
+## Category 4: Template Management Tools (4 tools)
+
+Tools for custom document templates. **Administrator only**.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 46 | `compliance_upload_template` | Upload custom DOCX template | All | Admin |
+| 47 | `compliance_list_templates` | List templates by document type | All | Admin, ISSM |
+| 48 | `compliance_update_template` | Update template content | All | Admin |
+| 49 | `compliance_delete_template` | Delete template | All | Admin |
+
+---
+
+## Category 5: Core Compliance Tools (11 tools)
+
+General-purpose compliance tools from Features 001–014.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 50 | `compliance_assess` | Run NIST 800-53 assessment | Assess | SCA, ISSM |
+| 51 | `compliance_get_control_family` | Get control family info | All | All |
+| 52 | `compliance_generate_document` | Generate compliance documents | All | ISSM, ISSO |
+| 53 | `compliance_collect_evidence` | Collect Azure evidence | Assess | ISSO, Eng |
+| 54 | `compliance_remediate` | Remediate findings | Implement | Eng |
+| 55 | `compliance_validate_remediation` | Validate remediation | Implement | Eng, ISSO |
+| 56 | `compliance_generate_plan` | Generate remediation plan | Implement | ISSM, Eng |
+| 57 | `compliance_audit_log` | View audit trail | All | ISSM |
+| 58 | `compliance_history` | View compliance history | All | ISSM, ISSO |
+| 59 | `compliance_status` | Current compliance posture | All | All |
+| 60 | `compliance_monitoring` | Monitoring setup | Monitor | ISSM |
+
+---
+
+## Category 6: Compliance Watch Tools (23 tools)
+
+Real-time monitoring, alerting, auto-remediation, and trend analysis.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 61 | `watch_enable_monitoring` | Enable scheduled monitoring | Monitor | ISSM, ISSO |
+| 62 | `watch_disable_monitoring` | Disable monitoring | Monitor | ISSM |
+| 63 | `watch_configure_monitoring` | Update frequency/mode | Monitor | ISSM |
+| 64 | `watch_monitoring_status` | View monitoring status | Monitor | ISSM, ISSO |
+| 65 | `watch_show_alerts` | List alerts with filters | Monitor | All |
+| 66 | `watch_get_alert` | Get alert details | Monitor | All |
+| 67 | `watch_acknowledge_alert` | Acknowledge alert | Monitor | ISSO, ISSM |
+| 68 | `watch_fix_alert` | Remediate alert finding | Monitor | Eng, ISSO |
+| 69 | `watch_dismiss_alert` | Dismiss alert (officer only) | Monitor | ISSM |
+| 70 | `watch_create_rule` | Create custom alert rule | Monitor | ISSM |
+| 71 | `watch_list_rules` | List alert rules | Monitor | ISSM, ISSO |
+| 72 | `watch_suppress_alerts` | Suppress alert pattern | Monitor | ISSM |
+| 73 | `watch_list_suppressions` | List suppressions | Monitor | ISSM |
+| 74 | `watch_configure_quiet_hours` | Set notification quiet hours | Monitor | ISSM |
+| 75 | `watch_configure_notifications` | Configure channels | Monitor | ISSM |
+| 76 | `watch_configure_escalation` | Define escalation paths | Monitor | ISSM |
+| 77 | `watch_alert_history` | Natural language alert queries | Monitor | ISSM, ISSO |
+| 78 | `watch_compliance_trend` | Compliance score over time | Monitor | All |
+| 79 | `watch_alert_statistics` | Alert counts and metrics | Monitor | ISSM, ISSO |
+| 80 | `watch_auto_remediation_create` | Create auto-remediation rule | Monitor | ISSM |
+| 81 | `watch_auto_remediation_list` | List auto-remediation rules | Monitor | ISSM |
+| 82 | `watch_auto_remediation_status` | View execution status | Monitor | ISSM, ISSO |
+| 83 | `watch_capture_baseline` | Capture compliance baseline | Monitor | ISSM |
+
+---
+
+## Category 7: Kanban Remediation Tools (18 tools)
+
+Task management for remediation lifecycle tracking.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 84 | `kanban_create_board` | Create board from assessment | Assess | ISSM |
+| 85 | `kanban_board_show` | Display board overview | Assess | All |
+| 86 | `kanban_get_task` | Get task details | Assess | All |
+| 87 | `kanban_create_task` | Create remediation task | Assess | ISSM, ISSO |
+| 88 | `kanban_assign_task` | Assign/reassign task | Assess | ISSM, ISSO |
+| 89 | `kanban_move_task` | Move task between columns | Assess | All |
+| 90 | `kanban_task_list` | List/filter tasks | Assess | All |
+| 91 | `kanban_task_history` | View task audit trail | Assess | All |
+| 92 | `kanban_task_validate` | Validate remediation | Assess | Eng, ISSO |
+| 93 | `kanban_add_comment` | Add comment/@mention | Assess | All |
+| 94 | `kanban_task_comments` | List comments | Assess | All |
+| 95 | `kanban_edit_comment` | Edit comment (24hr window) | Assess | All |
+| 96 | `kanban_delete_comment` | Delete comment (1hr window) | Assess | All |
+| 97 | `kanban_remediate_task` | Execute remediation script | Assess | Eng |
+| 98 | `kanban_collect_evidence` | Collect evidence for task | Assess | Eng, ISSO |
+| 99 | `kanban_bulk_update` | Bulk assign/move/set dates | Assess | ISSM |
+| 100 | `kanban_export` | Export as CSV or POA&M | Assess | ISSM |
+| 101 | `kanban_archive_board` | Archive completed board | Assess | ISSM |
+
+---
+
+## Category 8: PIM & Authentication Tools (13 tools)
+
+Privileged Identity Management, just-in-time access, and CAC session management.
+
+| # | Tool | Description | Phase(s) | Roles |
+|---|------|-------------|----------|-------|
+| 102 | `pim_list_eligible` | List PIM-eligible roles | All | All |
+| 103 | `pim_list_active` | List active PIM roles | All | All |
+| 104 | `pim_activate_role` | Activate PIM role | All | All |
+| 105 | `pim_deactivate_role` | Deactivate PIM role | All | All |
+| 106 | `pim_extend_role` | Extend role activation | All | All |
+| 107 | `pim_approve_request` | Approve activation request | All | ISSM |
+| 108 | `pim_deny_request` | Deny activation request | All | ISSM |
+| 109 | `pim_history` | View activation history | All | ISSM |
+| 110 | `jit_request_access` | Request just-in-time access | All | All |
+| 111 | `jit_list_sessions` | List active JIT sessions | All | All |
+| 112 | `jit_revoke_access` | Revoke JIT session | All | ISSM |
+| 113 | `cac_status` | Check CAC session status | All | All |
+| 114 | `cac_sign_out` | Sign out CAC session | All | All |
+
+---
+
+## Tool Count Summary
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| RMF Lifecycle | 34 | Seven-phase lifecycle management |
+| Continuous Monitoring | 7 | ConMon, expiration, dashboards |
+| Interoperability | 4 | eMASS, OSCAL, STIG |
+| Template Management | 4 | Custom document templates |
+| Core Compliance | 11 | Assessment, evidence, remediation |
+| Compliance Watch | 23 | Real-time alerts and monitoring |
+| Kanban Remediation | 18 | Task lifecycle management |
+| PIM & Authentication | 13 | JIT access and CAC sessions |
+| **Total** | **114** | |
+
+---
+
+## See Also
+
+- [NL Query Reference](../guides/nl-query-reference.md) — Natural language queries mapped to tools
+- [RBAC Roles](../personas/index.md#rbac-role-resolution) — Role resolution and inheritance
+- [Troubleshooting](troubleshooting.md) — Common error scenarios

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,0 +1,129 @@
+# Troubleshooting
+
+> Common errors, causes, and resolutions for ATO Copilot organized by category.
+
+---
+
+## 1. RBAC / Authorization Errors
+
+Errors caused by insufficient permissions for the requested operation.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Access denied: Compliance.Auditor cannot invoke compliance_write_narrative` | SCA attempting to modify SSP (write operation) | SCA role is read-only by design. Ask the assigned ISSO or Engineer to write the narrative. |
+| `Access denied: Compliance.PlatformEngineer cannot invoke compliance_issue_authorization` | Engineer attempting to issue an ATO decision | Only the AO (`Compliance.AuthorizingOfficial`) can issue authorization decisions. |
+| `Access denied: Compliance.Analyst cannot invoke watch_dismiss_alert` | ISSO attempting to dismiss an alert | Only officers (`Compliance.SecurityLead` or above) can dismiss alerts. Escalate to ISSM. |
+| `Role not recognized` | CAC certificate not mapped to any RBAC role | Contact Administrator to map your CAC thumbprint, or verify Azure AD group membership. Default fallback is `PlatformEngineer`. |
+
+!!! tip "RBAC Role Chain"
+    Role resolution follows the 4-tier chain: **CAC → Azure AD → System Role → Default**.
+    If you're getting unexpected access denials, check each tier in order.
+    See the [Persona Overview](../personas/index.md#rbac-role-resolution) for details.
+
+---
+
+## 2. RMF Gate Validation Errors
+
+Errors when trying to advance between RMF phases without meeting gate conditions.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Cannot advance: Prepare → Categorize requires at least 1 RMF role and 1 boundary resource` | Tried to advance before assigning roles or defining boundary | Use `compliance_assign_rmf_role` and `compliance_define_boundary` first. |
+| `Cannot advance: Categorize → Select requires SecurityCategorization` | Tried to advance before categorizing | Use `compliance_categorize_system` with at least one information type. |
+| `Cannot advance: Select → Implement requires ControlBaseline` | Tried to advance before selecting baseline | Use `compliance_select_baseline` to select Low/Moderate/High baseline. |
+| `Cannot regress RMF step without force: true` | Tried to move backward in the RMF lifecycle | Add `force: true` parameter to `compliance_advance_rmf_step` (ISSM only). This is intentionally guarded. |
+| `System in DATO status: advancement blocked` | AO denied authorization; system is in read-only mode | The AO must issue a new authorization decision (ATO/ATOwC/IATT) before the system can advance. |
+
+!!! info "Gate Conditions Reference"
+    For the full list of gate conditions per phase, see [RMF Phase Overview](../rmf-phases/index.md).
+
+---
+
+## 3. Evidence & Integrity Errors
+
+Errors related to evidence collection, verification, and snapshots.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Evidence verification failed: hash mismatch` | Evidence artifact was modified after collection | Re-collect evidence using `compliance_collect_evidence`. If the modification was intentional, document the change and re-collect. |
+| `Evidence completeness: 12 controls missing evidence` | Not all controls in scope have associated evidence | Use `compliance_check_evidence_completeness` to identify gaps, then collect evidence for each missing control. |
+| `Snapshot creation failed: no assessment data` | Tried to take a snapshot before any controls were assessed | Assess at least one control using `compliance_assess_control` first. |
+
+---
+
+## 4. Authorization & Risk Errors
+
+Errors during the Authorize phase and risk management lifecycle.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Risk acceptance expired` | An accepted risk passed its expiration date | The AO must either re-accept the risk with a new expiration date or the finding reverts to active. Linked POA&M items revert to `Ongoing`. |
+| `Authorization superseded` | A new authorization decision deactivated the prior one | Expected behavior — only one active authorization per system. Review the new decision. |
+| `Cannot bundle: SAR not generated` | Tried to bundle authorization package before SCA generated the SAR | SCA must complete assessment and run `compliance_generate_sar` first. |
+| `Cannot bundle: SSP not generated` | SSP has not been generated yet | Run `compliance_generate_ssp` to produce the SSP before bundling. |
+
+---
+
+## 5. Azure Connectivity Errors
+
+Errors when connecting to Azure services for evidence collection or policy evaluation.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Azure Policy query failed: connection timeout` | Cannot reach Azure Resource Manager APIs | Check network connectivity. In air-gapped environments, use scheduled monitoring with local policy cache. |
+| `Defender for Cloud unavailable` | Azure Defender not enabled or unreachable | Verify Defender for Cloud is enabled on the subscription. In disconnected mode, assessment runs against cached policy data only. |
+| `Subscription not found: {sub-id}` | Subscription ID is incorrect or ATO Copilot lacks access | Verify the subscription ID and ensure the ATO Copilot service principal has Reader access. |
+
+!!! warning "Air-Gapped Environments"
+    In air-gapped (IL5+) environments, Azure connectivity errors are expected during offline periods.
+    Use scheduled monitoring mode (`watch_configure_monitoring` with `mode: "scheduled"`) and set
+    the interval to match your data-transfer window. See the [Compliance Watch Guide](../guides/compliance-watch.md)
+    for air-gapped configuration details.
+
+---
+
+## 6. Monitoring & Alert Errors
+
+Errors from the Compliance Watch system.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Monitoring already enabled for subscription {sub-id}` | Attempted to enable monitoring that is already active | Use `watch_configure_monitoring` to update frequency or mode instead. |
+| `Alert not found: ALT-{id}` | Alert ID is incorrect or alert has been archived | Use `watch_show_alerts` to list current alerts. Archived alerts are available via `watch_alert_history`. |
+| `Cannot dismiss: justification required` | Tried to dismiss alert without providing a reason | Include a justification string when calling `watch_dismiss_alert`. |
+| `SLA escalation triggered` | Alert remained unacknowledged beyond SLA threshold | Acknowledge the alert immediately. Review escalation configuration with `watch_configure_escalation`. |
+| `Quiet hours active: notification suppressed` | Notification not delivered due to quiet hours configuration | Alert is still recorded — check `watch_show_alerts` after quiet hours end. Adjust with `watch_configure_quiet_hours`. |
+
+---
+
+## 7. Kanban & Remediation Errors
+
+Errors in the remediation task lifecycle.
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Cannot move to Done: validation failed` | Task remediation did not pass re-scan validation | Review the validation results, fix remaining issues, and re-validate with `kanban_task_validate`. An officer can override with `force: true`. |
+| `Cannot move from Blocked: resolution comment required` | Tried to unblock a task without explaining the resolution | Add a comment explaining how the blocker was resolved before moving the task. |
+| `Cannot reopen: Done is terminal` | Tried to move a completed task back to an earlier column | Create a new task if additional work is needed on the same finding. |
+| `Dry run completed: no changes applied` | Used `dryRun: true` on remediation | Expected behavior — review the dry run output, then re-run without `dryRun` to apply changes. |
+
+---
+
+## General Troubleshooting Steps
+
+If you encounter an error not listed above:
+
+1. **Check your role** — Run `pim_list_active` to verify your current RBAC role
+2. **Check system phase** — Run `compliance_get_system` to verify the system's current RMF phase
+3. **Check audit log** — Run `compliance_audit_log` to see the full audit trail of recent actions
+4. **Retry with verbose output** — Some tools support additional detail when errors occur
+5. **Contact ISSM** — If the issue persists, the ISSM can review the audit trail and escalate
+
+---
+
+## See Also
+
+- [Tool Inventory](tool-inventory.md) — All 114 tools with RBAC roles
+- [Persona Overview](../personas/index.md) — Role definitions and RBAC resolution
+- [RMF Phase Overview](../rmf-phases/index.md) — Gate conditions per phase
+- [Compliance Watch Guide](../guides/compliance-watch.md) — Monitoring and alert management

--- a/docs/rmf-phases/assess.md
+++ b/docs/rmf-phases/assess.md
@@ -1,0 +1,209 @@
+# RMF Phase 4: Assess
+
+> Assess the controls to determine if they are implemented correctly, operating as intended, and producing the desired outcome.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 4 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.5 |
+| **Lead Persona** | SCA |
+| **Supporting Personas** | ISSO (evidence/remediation), ISSM (POA&M/package), Engineer (remediation) |
+| **Key Outcome** | Controls assessed, SAR and RAR generated, POA&M items created |
+
+---
+
+## Assessment Approaches
+
+The Assess phase uses **two distinct assessment tools** that serve different purposes:
+
+| Tool | Purpose | Who Runs It | How It Works |
+|------|---------|-------------|--------------|
+| `compliance_assess` | **Automated scan** — runs NIST 800-53 assessment against live Azure resources | ISSO or ISSM | Queries Azure Policy, Defender for Cloud, and resource configurations; produces machine-generated findings |
+| `compliance_assess_control` | **Manual determination** — records SCA's formal effectiveness finding per control | SCA | SCA evaluates evidence (test/interview/examine), then records Satisfied or Other Than Satisfied with CAT severity |
+
+**Typical workflow**: The ISSO runs `compliance_assess` first to generate automated findings, then the SCA reviews those findings and records formal determinations using `compliance_assess_control`.
+
+!!! tip "Scan Types for `compliance_assess`"
+    - **quick** — Fast summary of compliance posture (minutes)
+    - **policy** — Azure Policy evaluation with NIST 800-53 control mapping
+    - **full** — Deep scan with remediation recommendations (may take longer)
+
+---
+
+## Persona Responsibilities
+
+### SCA (Lead — Assessment)
+
+**Tasks in this phase**:
+
+1. Assess each control → Tool: `compliance_assess_control`
+2. Take assessment snapshots → Tool: `compliance_take_snapshot`
+3. Verify evidence integrity → Tool: `compliance_verify_evidence`
+4. Check evidence completeness → Tool: `compliance_check_evidence_completeness`
+5. Compare assessment cycles → Tool: `compliance_compare_snapshots`
+6. Generate SAR → Tool: `compliance_generate_sar`
+7. Generate RAR → Tool: `compliance_generate_rar`
+
+**Natural Language Queries**:
+
+> **"Assess control AC-2 as Satisfied using the Test method — account management procedures verified"** → `compliance_assess_control` — records determination with method and justification
+
+> **"Assess control AC-3 as Other Than Satisfied, CAT II — mandatory access control checks missing"** → `compliance_assess_control` — records finding with DoD CAT severity
+
+> **"Take a snapshot of system {id} before assessment begins"** → `compliance_take_snapshot` — creates immutable SHA-256-hashed snapshot
+
+> **"Verify evidence {evidence-id} hasn't been tampered with"** → `compliance_verify_evidence` — recomputes hash, returns verified or tampered
+
+> **"Compare snapshot {snap-1} with snapshot {snap-2}"** → `compliance_compare_snapshots` — shows score delta, new/resolved findings
+
+> **"Generate the Security Assessment Report for system {id}"** → `compliance_generate_sar` — SAR with executive summary and CAT breakdown
+
+> **"Generate the Risk Assessment Report for system {id}"** → `compliance_generate_rar` — RAR with per-family risk breakdown
+
+!!! info "Air-Gapped Note"
+    All SCA assessment tools work fully offline — they operate on locally stored assessment data. Evidence collection (`compliance_collect_evidence`) requires network access to Azure resources; in air-gapped environments, evidence must be imported from prior scans or manual artifact uploads.
+
+### Assessment Methods
+
+| Method | When to Use | Examples |
+|--------|-------------|---------|
+| **Test** | Execute procedures, observe behavior | Run scans, test access controls |
+| **Interview** | Question personnel about practices | Ask admin about account review |
+| **Examine** | Review documentation and artifacts | Review SSP, audit logs, policies |
+
+### DoD CAT Severity Mapping
+
+| CAT Level | Severity | Impact |
+|-----------|----------|--------|
+| **CAT I** | Critical/High | Direct loss of C/I/A — immediate exploitation risk |
+| **CAT II** | Medium | Potential for system compromise |
+| **CAT III** | Low | Administrative or documentation gaps |
+
+### ISSO (Support — Evidence, Automated Scan & Remediation)
+
+**Tasks in this phase**:
+
+1. Run automated compliance assessment → Tool: `compliance_assess`
+2. Collect evidence → Tool: `compliance_collect_evidence`
+3. Create remediation board → Tool: `kanban_create_board`
+4. Assign tasks to engineers → Tool: `kanban_assign_task`
+5. Fix alerts → Tool: `watch_fix_alert`
+
+**Natural Language Queries**:
+
+> **"Run a full NIST 800-53 assessment on subscription {sub-id}"** → `compliance_assess` — automated scan across all control families against live Azure resources
+
+> **"Run a quick compliance scan on subscription {sub-id} for the AC and IA families"** → `compliance_assess` — scoped quick scan for specific families
+
+> **"Collect evidence for the AC family on subscription {sub-id}"** → `compliance_collect_evidence` — collects Azure resource evidence with SHA-256 hashing
+
+> **"Create a remediation board from the latest assessment"** → `kanban_create_board` — creates Kanban board from findings
+
+> **"Assign task REM-003 to engineer Bob Jones"** → `kanban_assign_task` — assigns remediation work
+
+### ISSM (Support — POA&M & Package)
+
+**Tasks in this phase**:
+
+1. Create POA&M items → Tool: `compliance_create_poam`
+2. List/track POA&M → Tool: `compliance_list_poam`
+3. Generate RAR → Tool: `compliance_generate_rar`
+
+**Natural Language Queries**:
+
+> **"Create a POA&M item for the missing MFA finding on IA-2(1) — assign to John Smith, due June 30"** → `compliance_create_poam` — formal POA&M with milestones and CAT severity
+
+> **"List overdue POA&M items for system {id}"** → `compliance_list_poam` — filtered POA&M list
+
+### Engineer (Support — Remediation)
+
+Engineers can remediate findings using **standalone tools** (direct finding remediation) or **Kanban tools** (task-managed remediation). Both paths are valid — Kanban adds task tracking and audit trails.
+
+**Standalone remediation tools**:
+
+1. Generate remediation plan → Tool: `compliance_generate_plan`
+2. Remediate finding → Tool: `compliance_remediate`
+3. Validate fix → Tool: `compliance_validate_remediation`
+
+**Kanban-managed remediation tools**:
+
+4. View assigned tasks → Tool: `kanban_task_list`
+5. Fix findings → Tool: `kanban_remediate_task`
+6. Validate fixes → Tool: `kanban_task_validate`
+7. Collect evidence → Tool: `kanban_collect_evidence`
+
+**Natural Language Queries**:
+
+> **"Generate a remediation plan for subscription {sub-id}"** → `compliance_generate_plan` — prioritized plan across findings
+
+> **"Remediate finding {finding-id} with dry run"** → `compliance_remediate` — preview fix before applying
+
+> **"Validate remediation for finding {finding-id}"** → `compliance_validate_remediation` — re-scan to confirm fix
+
+> **"Show my assigned remediation tasks"** → `kanban_task_list` — filtered to assigned user
+
+> **"Fix task REM-005 with dry run first"** → `kanban_remediate_task` — preview before applying
+
+> **"Validate task REM-005"** → `kanban_task_validate` — re-scan to verify remediation
+
+---
+
+## Typical SCA Assessment Cycle
+
+```
+ 1. compliance_assess              ← ISSO runs automated scan (quick/policy/full)
+ 2. compliance_collect_evidence    ← ISSO collects evidence from Azure
+ 3. compliance_assess_control      ← SCA formally assesses each control (batch)
+ 4. compliance_take_snapshot       ← SCA snapshots current state
+ 5. compliance_verify_evidence     ← SCA spot-checks evidence integrity
+ 6. compliance_check_evidence_completeness ← SCA verifies coverage
+ 7. compliance_generate_sar        ← SCA generates SAR
+    ── (Remediation occurs) ──
+ 8. compliance_assess              ← ISSO re-runs automated scan
+ 9. compliance_assess_control      ← SCA re-assesses remediated controls
+10. compliance_take_snapshot       ← SCA snapshots after remediation
+11. compliance_compare_snapshots   ← SCA shows improvement
+12. compliance_generate_sar        ← SCA produces updated SAR for AO
+13. compliance_generate_rar        ← SCA/ISSM produces final RAR
+```
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| Security Assessment Report (SAR) | SCA | Markdown | Advisory (Assess → Authorize) |
+| Risk Assessment Report (RAR) | SCA / ISSM | Markdown | Advisory |
+| Plan of Action & Milestones (POA&M) | ISSM | Markdown | Informational |
+| Assessment Snapshots | SCA | Immutable records | Informational |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Advisory | No hard block — advancement allowed regardless of assessment completion | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` (advisory gate) | Assess | Authorize | SAR, RAR, POA&M bundled for AO decision |
+
+---
+
+## See Also
+
+- [Previous Phase: Implement](implement.md)
+- [Next Phase: Authorize](authorize.md)
+- [SCA Guide](../guides/sca-guide.md) — Full SCA assessment workflow
+- [ISSO Guide](../personas/isso.md) — Evidence collection and remediation
+- [Remediation Kanban Guide](../guides/remediation-kanban.md) — Task management

--- a/docs/rmf-phases/authorize.md
+++ b/docs/rmf-phases/authorize.md
@@ -1,0 +1,143 @@
+# RMF Phase 5: Authorize
+
+> Provide accountability by requiring a senior official to determine if the security and privacy risk is acceptable.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 5 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.6 |
+| **Lead Persona** | AO |
+| **Supporting Personas** | ISSM (package preparation), SCA (SAR delivery), ISSO (support) |
+| **Key Outcome** | Authorization decision issued (ATO, ATOwC, IATT, or DATO) |
+
+---
+
+## Persona Responsibilities
+
+### AO (Lead — Decision)
+
+**Tasks in this phase**:
+
+1. Review authorization package → Tool: `compliance_bundle_authorization_package`
+2. Review risk register → Tool: `compliance_show_risk_register`
+3. Issue authorization decision → Tool: `compliance_issue_authorization`
+4. Accept risk on findings → Tool: `compliance_accept_risk`
+
+**Natural Language Queries**:
+
+> **"Show the authorization package summary for system {id}"** → `compliance_bundle_authorization_package` — reviews bundled package (SSP + SAR + RAR + POA&M + CRM)
+
+> **"What's the compliance score and finding breakdown for system {id}?"** → score and CAT I/II/III counts
+
+> **"Issue an ATO for system {id} expiring January 15, 2028 with Low residual risk — all CAT I findings remediated, 2 CAT III findings accepted"** → `compliance_issue_authorization` — records decision, transitions system to Monitor
+
+> **"Issue an ATO with conditions for system {id} — MFA enforcement must be completed within 90 days"** → `compliance_issue_authorization` — ATOwC with tracked conditions
+
+> **"Accept risk on finding {finding-id} for control CM-6 (CAT III) — configuration deviation documented"** → `compliance_accept_risk` — risk acceptance with compensating control and expiration
+
+> **"Deny authorization for system {id} — 3 unmitigated CAT I findings"** → `compliance_issue_authorization` — DATO, system enters read-only mode
+
+> **"Show the risk register for system {id}"** → `compliance_show_risk_register` — active/expired risk acceptances
+
+> **"What risks have I accepted that are expiring soon?"** → `compliance_show_risk_register` — filtered by expiration
+
+### Authorization Decision Types
+
+| Type | Description | Expiration | System State After |
+|------|-------------|------------|-------------------|
+| **ATO** | Authority to Operate — full authorization | Required (typically 3 years) | Monitor phase |
+| **ATOwC** | ATO with Conditions — with stipulations | Required | Monitor phase (conditions tracked) |
+| **IATT** | Interim Authority to Test — limited scope | Required (typically 6 months) | Monitor phase (limited) |
+| **DATO** | Denial of Authorization — cannot operate | None | Read-only mode, advancement blocked |
+
+### Key Authorization Behaviors
+
+- **Supersedes prior decisions**: Any existing active authorization is automatically deactivated
+- **Compliance score captured**: Score at decision time is recorded permanently
+- **RMF advancement**: System moves to Monitor phase on ATO/ATOwC/IATT
+- **Open findings recorded**: All open findings at decision time are captured in the record
+- **DATO effects**: System enters read-only mode, generates persistent alert, blocks RMF advancement
+
+### Risk Acceptance Lifecycle
+
+1. AO accepts risk with justification + compensating control + expiration date
+2. Risk acceptance is active → finding severity is documented but accepted
+3. Expiration date arrives → acceptance auto-expires, finding reverts to active
+4. Linked POA&M items revert from `RiskAccepted` to `Ongoing`
+5. Alert sent to both AO and ISSM
+
+### ISSM (Package Preparation)
+
+**Tasks in this phase**:
+
+1. Bundle authorization package → Tool: `compliance_bundle_authorization_package`
+2. Review risk register → Tool: `compliance_show_risk_register`
+
+**Natural Language Queries**:
+
+> **"Bundle the authorization package for system {id} including evidence"** → `compliance_bundle_authorization_package` — bundles SSP + SAR + RAR + POA&M + CRM + ATO Letter
+
+> **"What documents are ready for the authorization package?"** → document readiness check
+
+### SCA (SAR Delivery)
+
+- Deliver final SAR to ISSM for inclusion in authorization package
+- Available for questions from the AO during risk review
+
+### ISSO (Support)
+
+- Provide additional evidence or clarification on findings as requested
+
+---
+
+## Authorization Package Contents
+
+| Document | Source | Required |
+|----------|--------|----------|
+| System Security Plan (SSP) | `compliance_generate_ssp` | Yes |
+| Security Assessment Report (SAR) | `compliance_generate_sar` | Yes |
+| Risk Assessment Report (RAR) | `compliance_generate_rar` | Yes |
+| Plan of Action & Milestones (POA&M) | `compliance_list_poam` | Yes |
+| Customer Responsibility Matrix (CRM) | `compliance_generate_crm` | Yes |
+| ATO Letter | Generated from authorization decision | After AO decision |
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| Authorization Decision Letter | AO | Generated | Authorize → Monitor |
+| Risk Acceptance Memorandum | AO | Generated | Informational |
+| Terms & Conditions (ATOwC) | AO | Generated | Informational |
+| Authorization Package (bundled) | ISSM | ZIP | Informational |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Authorization issued | An authorization decision has been recorded | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` after ATO/ATOwC/IATT | Authorize | Monitor | Authorization active, ConMon plan needed |
+| DATO issued | Authorize | — (blocked) | System in read-only mode, remediation required |
+
+---
+
+## See Also
+
+- [Previous Phase: Assess](assess.md)
+- [Next Phase: Monitor](monitor.md)
+- [AO Guide](../guides/ao-quick-reference.md) — Full AO workflow documentation
+- [ISSM Guide](../guides/issm-guide.md) — Package preparation workflows

--- a/docs/rmf-phases/categorize.md
+++ b/docs/rmf-phases/categorize.md
@@ -1,0 +1,95 @@
+# RMF Phase 1: Categorize
+
+> Categorize the system and the information processed, stored, and transmitted by the system using FIPS 199 and SP 800-60 information types.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 1 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.2 |
+| **Lead Persona** | ISSM |
+| **Supporting Personas** | ISSO, Engineer (consulted) |
+| **Key Outcome** | FIPS 199 categorization with C/I/A high-water mark and DoD Impact Level |
+
+---
+
+## Persona Responsibilities
+
+### ISSM (Lead)
+
+**Tasks in this phase**:
+
+1. Get AI-suggested information types → Tool: `compliance_suggest_info_types`
+2. Apply categorization → Tool: `compliance_categorize_system`
+3. Review categorization → Tool: `compliance_get_categorization`
+4. Advance to Select → Tool: `compliance_advance_rmf_step`
+
+**Natural Language Queries**:
+
+> **"Suggest information types for system {id} — it's a financial management and audit logging system"** → `compliance_suggest_info_types` — AI suggests SP 800-60 information types with confidence scores
+
+> **"Categorize system {id} with these information types: Financial Management (C: Moderate, I: Moderate, A: Low), Information Security (C: Moderate, I: High, A: Moderate)"** → `compliance_categorize_system` — applies info types and computes high-water mark
+
+> **"What is the current categorization for system {id}?"** → `compliance_get_categorization` — shows FIPS 199 notation and DoD IL
+
+> **"What DoD Impact Level was derived for system {id}?"** → `compliance_get_categorization` — IL2–IL6 derived from categorization + NSS flag
+
+> **"Advance to the Select phase"** → `compliance_advance_rmf_step` — transitions to Select (gate-checked)
+
+### ISSO (Support)
+
+- Assist with identifying information types processed by the system
+- Review categorization for accuracy
+
+### Engineer (Consulted)
+
+- Provide domain knowledge about data types and processing activities
+- Confirm hosting environment details affecting IL derivation
+
+---
+
+## Key Outputs
+
+| Output | Description |
+|--------|-------------|
+| FIPS 199 Notation | `SC System = {(confidentiality, MODERATE), (integrity, HIGH), (availability, MODERATE)}` |
+| Overall Categorization | High (the maximum across C/I/A) |
+| DoD Impact Level | IL5 (derived from categorization + NSS flag) |
+| NIST Baseline | High (determined by overall categorization) |
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| FIPS 199 Categorization Report | ISSM | Embedded in SSP | Required before Select |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Categorization exists | System has been categorized with FIPS 199 | `compliance_advance_rmf_step` |
+| Information types defined | At least one information type assigned | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` with gate pass | Categorize | Select | Categorization determines baseline level |
+
+---
+
+## See Also
+
+- [Previous Phase: Prepare](prepare.md)
+- [Next Phase: Select](select.md)
+- [ISSM Guide](../guides/issm-guide.md) — Full ISSM workflow documentation
+- [Impact Levels Reference](../reference/impact-levels.md) — DoD IL details

--- a/docs/rmf-phases/implement.md
+++ b/docs/rmf-phases/implement.md
@@ -1,0 +1,133 @@
+# RMF Phase 3: Implement
+
+> Implement the controls in the security and privacy plans and document the implementation details.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 3 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.4 |
+| **Lead Persona** | ISSO and Engineer (shared) |
+| **Supporting Personas** | ISSM (oversight) |
+| **Key Outcome** | SSP narratives authored, SSP document generated |
+
+---
+
+## Persona Responsibilities
+
+### ISSO (Lead — Narrative Authoring)
+
+**Tasks in this phase**:
+
+1. Auto-populate inherited narratives → Tool: `compliance_batch_populate_narratives`
+2. Get AI suggestions → Tool: `compliance_suggest_narrative`
+3. Write/update narratives → Tool: `compliance_write_narrative`
+4. Track completion → Tool: `compliance_narrative_progress`
+
+**Natural Language Queries**:
+
+> **"Auto-populate the inherited control narratives for system {id}"** → `compliance_batch_populate_narratives` — fills ~40–60% of narratives from the embedded control catalog
+
+> **"Suggest a narrative for AC-2 on system {id}"** → `compliance_suggest_narrative` — AI draft with confidence score
+
+> **"Write the narrative for AC-2: 'Account management is implemented using Azure AD...'"** → `compliance_write_narrative` — stores narrative with status
+
+> **"What's the narrative completion for the SC family?"** → `compliance_narrative_progress` — per-family completion percentages
+
+> **"Show all controls missing narratives for system {id}"** → `compliance_narrative_progress` — lists controls without narratives
+
+!!! warning "Air-Gapped Note"
+    In disconnected environments, `compliance_suggest_narrative` and AI-generated narratives in `compliance_batch_populate_narratives` are **unavailable**. Write all narratives manually using `compliance_write_narrative`. Inherited control narratives can still be auto-populated from the embedded control catalog (no network required).
+
+### Engineer (Lead — Technical Implementation)
+
+**Tasks in this phase**:
+
+1. Learn about controls → Tool: `compliance_get_control` / Knowledge Base
+2. Scan IaC for compliance → Tool: IaC diagnostics
+3. View STIG findings → Tool: `compliance_show_stig_mapping`
+4. Write implementation narratives → Tool: `compliance_write_narrative`
+5. Auto-populate inherited narratives → Tool: `compliance_batch_populate_narratives`
+6. Generate remediation plan → Tool: `compliance_generate_plan`
+7. Remediate findings → Tool: `compliance_remediate`
+8. Validate remediation → Tool: `compliance_validate_remediation`
+
+**Natural Language Queries**:
+
+> **"What does NIST control AC-2 mean for Azure?"** → Knowledge Base — plain-language explanation tailored to Azure
+
+> **"Show STIG findings for Azure SQL Database"** → `compliance_show_stig_mapping` — DISA STIG requirements mapped to NIST controls
+
+> **"Scan my Bicep file for compliance issues"** → IaC diagnostics — findings with CAT severity
+
+> **"Suggest a narrative for control SC-7 on system {id}"** → `compliance_suggest_narrative` — AI draft based on system context
+
+> **"Auto-populate inherited control narratives for system {id}"** → `compliance_batch_populate_narratives` — batch fill
+
+> **"Generate a remediation plan for subscription {sub-id}"** → `compliance_generate_plan` — prioritized plan across all findings
+
+> **"Remediate finding {finding-id} with dry run"** → `compliance_remediate` — preview fix before applying (`dry_run: true` by default)
+
+> **"Validate remediation for finding {finding-id}"** → `compliance_validate_remediation` — re-scan to confirm fix was applied
+
+### ISSM (Oversight)
+
+**Tasks in this phase**:
+
+1. Track SSP completion → Tool: `compliance_narrative_progress`
+2. Generate SSP document → Tool: `compliance_generate_ssp`
+
+**Natural Language Queries**:
+
+> **"What's the SSP completion status for system {id}?"** → `compliance_narrative_progress` — overall completion
+
+> **"Generate the System Security Plan for system {id}"** → `compliance_generate_ssp` — formal SSP document
+
+> **"Generate the SSP as PDF"** → `compliance_generate_ssp` with format parameter
+
+---
+
+## AI Suggestion Confidence Levels
+
+| Score | Meaning | Action |
+|-------|---------|--------|
+| ≥ 0.85 | High confidence (inherited controls) | Review and accept |
+| 0.70–0.84 | Good confidence (shared controls) | Review and customize |
+| 0.50–0.69 | Moderate confidence (customer controls) | Significant review needed |
+| < 0.50 | Low confidence — flagged | Write manually |
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| System Security Plan (SSP) | ISSO / ISSM | Markdown, PDF, DOCX | Advisory (Implement → Assess) |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Advisory | No hard block — advancement allowed regardless of SSP completion | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` (advisory gate) | Implement | Assess | SSP and evidence package ready for SCA assessment |
+
+---
+
+## See Also
+
+- [Previous Phase: Select](select.md)
+- [Next Phase: Assess](assess.md)
+- [ISSO Guide](../personas/isso.md) — Full ISSO workflow documentation
+- [Engineer Guide](../guides/engineer-guide.md) — SSP authoring and IaC diagnostics

--- a/docs/rmf-phases/index.md
+++ b/docs/rmf-phases/index.md
@@ -1,0 +1,103 @@
+# RMF Phase Reference
+
+> The Risk Management Framework (RMF) lifecycle as implemented by ATO Copilot.
+
+---
+
+## Lifecycle Overview
+
+The RMF defines seven phases that take an information system from initial registration through continuous monitoring. ATO Copilot supports all seven phases with MCP tools, natural language queries, and automated workflows.
+
+```
+┌──────────┐   ┌────────────┐   ┌──────────┐   ┌───────────┐
+│  Prepare │──▶│ Categorize │──▶│  Select  │──▶│ Implement │
+│ (Phase 0)│   │ (Phase 1)  │   │ (Phase 2)│   │ (Phase 3) │
+└──────────┘   └────────────┘   └──────────┘   └───────────┘
+                                                      │
+                                                      ▼
+┌──────────┐   ┌───────────┐   ┌──────────┐   ┌───────────┐
+│ Monitor  │◀──│ Authorize │◀──│  Assess  │◀──│     │     │
+│ (Phase 6)│   │ (Phase 5) │   │ (Phase 4)│   └───────────┘
+└──────────┘   └───────────┘   └──────────┘
+      │
+      └──▶ (Reauthorization triggers loop back to Prepare or Assess)
+```
+
+---
+
+## Phase Summary
+
+| Phase | Name | Lead Persona | Key Outcome | Gate Tool |
+|-------|------|-------------|-------------|-----------|
+| 0 | [Prepare](prepare.md) | ISSM | System registered, boundary defined, roles assigned | `compliance_advance_rmf_step` |
+| 1 | [Categorize](categorize.md) | ISSM | FIPS 199 categorization, DoD IL derived | `compliance_advance_rmf_step` |
+| 2 | [Select](select.md) | ISSM | NIST 800-53 baseline selected, tailored, inheritance set | `compliance_advance_rmf_step` |
+| 3 | [Implement](implement.md) | ISSO / Engineer | SSP narratives authored, document generated | `compliance_advance_rmf_step` |
+| 4 | [Assess](assess.md) | SCA | Controls assessed, SAR/RAR generated | `compliance_advance_rmf_step` |
+| 5 | [Authorize](authorize.md) | AO | Authorization decision issued | `compliance_advance_rmf_step` |
+| 6 | [Monitor](monitor.md) | ISSM / ISSO | Continuous monitoring, ConMon reports, reauthorization | — |
+
+---
+
+## Gate Summary
+
+Each phase transition is guarded by gate conditions enforced by `compliance_advance_rmf_step`:
+
+| Transition | Gate Conditions |
+|-----------|----------------|
+| Prepare → Categorize | ≥ 1 RMF role assigned + ≥ 1 boundary resource |
+| Categorize → Select | Categorization exists + ≥ 1 information type |
+| Select → Implement | Baseline exists |
+| Implement → Assess | Advisory only (no hard block) |
+| Assess → Authorize | Advisory only (no hard block) |
+| Authorize → Monitor | Authorization decision issued |
+
+---
+
+## Tool Mapping by Phase
+
+| Phase | Primary Tools |
+|-------|--------------|
+| Prepare | `compliance_register_system`, `compliance_define_boundary`, `compliance_assign_rmf_role`, `compliance_list_rmf_roles` |
+| Categorize | `compliance_suggest_info_types`, `compliance_categorize_system`, `compliance_get_categorization` |
+| Select | `compliance_select_baseline`, `compliance_tailor_baseline`, `compliance_set_inheritance`, `compliance_generate_crm`, `compliance_show_stig_mapping` |
+| Implement | `compliance_batch_populate_narratives`, `compliance_suggest_narrative`, `compliance_write_narrative`, `compliance_narrative_progress`, `compliance_generate_ssp` |
+| Assess | `compliance_assess_control`, `compliance_take_snapshot`, `compliance_verify_evidence`, `compliance_check_evidence_completeness`, `compliance_compare_snapshots`, `compliance_generate_sar`, `compliance_generate_rar`, `compliance_create_poam` |
+| Authorize | `compliance_bundle_authorization_package`, `compliance_issue_authorization`, `compliance_accept_risk`, `compliance_show_risk_register` |
+| Monitor | `compliance_create_conmon_plan`, `compliance_generate_conmon_report`, `compliance_track_ato_expiration`, `compliance_report_significant_change`, `compliance_reauthorization_workflow`, `compliance_multi_system_dashboard`, `compliance_export_emass`, `compliance_export_oscal`, Watch tools |
+
+---
+
+## Persona Responsibilities by Phase
+
+| Phase | ISSM | ISSO | SCA | AO | Engineer |
+|-------|------|------|-----|-----|----------|
+| Prepare | **Lead** | Support | — | Informed | Support |
+| Categorize | **Lead** | Support | — | Informed | Consulted |
+| Select | **Lead** | Support | Review | — | Consulted |
+| Implement | Oversight | **Lead** | — | — | **Lead** |
+| Assess | Support | Support | **Lead** | Informed | Support |
+| Authorize | Package prep | Support | SAR delivery | **Decide** | — |
+| Monitor | **Lead** | **Day-to-day** | Periodic | Escalation | Remediation |
+
+---
+
+## Documents Produced by Phase
+
+| Phase | Documents | Owner |
+|-------|-----------|-------|
+| Prepare | — (informational only) | — |
+| Categorize | FIPS 199 Categorization Report | ISSM |
+| Select | Customer Responsibility Matrix (CRM) | ISSM |
+| Implement | System Security Plan (SSP) | ISSO / ISSM |
+| Assess | SAR, RAR, POA&M, Assessment Snapshots | SCA / ISSM |
+| Authorize | Authorization Decision Letter, Risk Acceptance Memo, Terms & Conditions | AO |
+| Monitor | ConMon Reports, Reauthorization Package | ISSM / ISSO |
+
+---
+
+## See Also
+
+- [Persona Overview](../personas/index.md) — Role definitions and RACI matrix
+- [Tool Inventory](../reference/tool-inventory.md) — Complete list of 114 MCP tools
+- [NIST Controls Reference](../reference/nist-controls.md) — Control baseline details

--- a/docs/rmf-phases/monitor.md
+++ b/docs/rmf-phases/monitor.md
@@ -1,0 +1,173 @@
+# RMF Phase 6: Monitor
+
+> Maintain ongoing situational awareness about the security and privacy posture of the system and the organization.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 6 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.7 |
+| **Lead Persona** | ISSM (oversight) and ISSO (day-to-day) |
+| **Supporting Personas** | AO (escalation), SCA (periodic assessment), Engineer (remediation) |
+| **Key Outcome** | Continuous monitoring established, ConMon reports generated, reauthorization tracked |
+
+---
+
+## Persona Responsibilities
+
+### ISSM (Lead — Oversight)
+
+**Tasks in this phase**:
+
+1. Create ConMon plan → Tool: `compliance_create_conmon_plan`
+2. Generate ConMon reports → Tool: `compliance_generate_conmon_report`
+3. Track ATO expiration → Tool: `compliance_track_ato_expiration`
+4. Report significant changes → Tool: `compliance_report_significant_change`
+5. Check reauthorization triggers → Tool: `compliance_reauthorization_workflow`
+6. View portfolio dashboard → Tool: `compliance_multi_system_dashboard`
+7. Send notifications → Tool: `compliance_send_notification`
+8. Export to eMASS → Tool: `compliance_export_emass`
+9. Export OSCAL → Tool: `compliance_export_oscal`
+
+**Natural Language Queries**:
+
+> **"Create a ConMon plan for system {id} with monthly assessments and annual review on June 15"** → `compliance_create_conmon_plan` — establishes monitoring cadence
+
+> **"Generate a monthly ConMon report for system {id}, period 2026-02"** → `compliance_generate_conmon_report` — report with score delta, findings, POA&M status
+
+> **"Check ATO expiration for system {id}"** → `compliance_track_ato_expiration` — graduated alerts (90d/60d/30d/expired)
+
+> **"Report a significant change for system {id}: New Interconnection — added VPN tunnel to partner organization"** → `compliance_report_significant_change` — records change, flags for reauthorization
+
+> **"Check reauthorization triggers for system {id}"** → `compliance_reauthorization_workflow` — checks expiration, significant changes, score drift
+
+> **"Show the multi-system compliance dashboard"** → `compliance_multi_system_dashboard` — portfolio view of all systems
+
+> **"Show all systems with expired ATOs"** → `compliance_multi_system_dashboard` — filtered portfolio view
+
+> **"Export system {id} data to eMASS format"** → `compliance_export_emass` — eMASS-compatible Excel
+
+> **"Export OSCAL JSON for system {id}"** → `compliance_export_oscal` — OSCAL v1.0.6 JSON
+
+### ISSO (Lead — Day-to-Day)
+
+**Tasks in this phase**:
+
+1. Enable monitoring → Tool: `watch_enable_monitoring`
+2. View/triage alerts → Tool: `watch_show_alerts`, `watch_get_alert`
+3. Acknowledge alerts → Tool: `watch_acknowledge_alert`
+4. Fix alerts → Tool: `watch_fix_alert`
+5. Configure notifications → Tool: `watch_configure_notifications`
+6. Configure escalation → Tool: `watch_configure_escalation`
+7. Set quiet hours → Tool: `watch_configure_quiet_hours`
+
+**Natural Language Queries**:
+
+> **"Enable daily monitoring for subscription {sub-id}"** → `watch_enable_monitoring` — enables scheduled daily scans
+
+> **"Show all critical alerts from the last 7 days"** → `watch_show_alerts` — filtered alert list
+
+> **"Acknowledge alert ALT-12345"** → `watch_acknowledge_alert` — pauses SLA escalation
+
+> **"What drifted this week?"** → `watch_show_alerts` — drift alerts for recent period
+
+> **"Configure escalation: if Critical alert is not acknowledged in 30 minutes, notify the ISSM"** → `watch_configure_escalation` — defines escalation path
+
+### AO (Escalation)
+
+**Tasks in this phase**:
+
+- Receive escalated alerts and expiration notifications
+- Review risk acceptances approaching expiration
+- Re-evaluate authorization when reauthorization triggers fire
+
+**Natural Language Queries**:
+
+> **"Show all systems with ATOs expiring in the next 90 days"** → `compliance_track_ato_expiration` — portfolio expiration view
+
+> **"What significant changes have been reported for system {id}?"** → change records and reauthorization flags
+
+### SCA (Periodic Assessment)
+
+- Conduct periodic assessments as specified in the ConMon plan
+- Uses the same assessment tools as Phase 4 (Assess)
+
+### Engineer (Remediation)
+
+- Fix drift findings surfaced by Watch alerts  
+- Uses Kanban tools and `watch_fix_alert` for remediation
+
+---
+
+## Expiration Alert Levels
+
+| Days Remaining | Alert Level | Severity | Action Required |
+|----------------|-------------|----------|-----------------|
+| ≤ 90 days | Info | Low | Begin reauthorization planning |
+| ≤ 60 days | Warning | Medium | Submit reauthorization package |
+| ≤ 30 days | Urgent | High | Escalate to AO immediately |
+| Expired | Expired | Critical | System operating without authorization |
+
+---
+
+## Significant Change Types
+
+| # | Change Type | Example |
+|---|------------|---------|
+| 1 | New Interconnection | Added VPN tunnel to partner |
+| 2 | Major Upgrade | OS or platform version upgrade |
+| 3 | Data Type Change | New PII data processing |
+| 4 | Architecture Change | Moved from VMs to containers |
+| 5 | Security Policy Change | New encryption requirements |
+| 6 | Boundary Change | Added/removed cloud services |
+| 7 | Key Personnel Change | New ISSO or AO assignment |
+| 8 | Incident Response | Security incident on the system |
+| 9 | Compliance Drop | Score decreased below threshold |
+| 10 | Configuration Drift | Auto-detected by Watch service |
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| ConMon Reports (monthly/quarterly/annual) | ISSM / ISSO | Markdown | Ongoing (per ConMon plan) |
+| Reauthorization Package | ISSM | Bundled | Triggers loop back to Assess |
+
+---
+
+## Phase Gates
+
+This is a continuous phase — there is no outbound transition gate. Reauthorization triggers loop back to earlier phases:
+
+| Trigger | Action |
+|---------|--------|
+| ATO expiration | Initiate reauthorization (loop to Assess or Prepare) |
+| Significant change (reauth-triggering) | Initiate reauthorization |
+| Compliance score drift below threshold | Investigate and potentially reauthorize |
+
+---
+
+## Air-Gapped Considerations
+
+!!! warning "Disconnected / Air-Gapped Monitor Phase"
+    In air-gapped or disconnected environments:
+    
+    - **eMASS export** (`compliance_export_emass`) generates Excel locally — manual transfer via removable media required.
+    - **Notifications** (`compliance_send_notification`) limited to local channels (VS Code, audit log).
+    - **OSCAL export** (`compliance_export_oscal`) works fully offline.
+    - **Watch monitoring** — event-driven mode unavailable; use **scheduled-only mode** with local policy cache.
+    - **ConMon reports** (`compliance_generate_conmon_report`) work fully offline using cached data.
+
+---
+
+## See Also
+
+- [Previous Phase: Authorize](authorize.md)
+- [ISSM Guide](../guides/issm-guide.md) — Portfolio management and oversight
+- [ISSO Guide](../personas/isso.md) — Day-to-day monitoring workflows
+- [Compliance Watch Guide](../guides/compliance-watch.md) — Detailed Watch documentation
+- [AO Guide](../guides/ao-quick-reference.md) — Reauthorization and risk decisions

--- a/docs/rmf-phases/prepare.md
+++ b/docs/rmf-phases/prepare.md
@@ -1,0 +1,87 @@
+# RMF Phase 0: Prepare
+
+> Establish the context and priority for managing security and privacy risk. Register the system, define the authorization boundary, and assign RMF roles.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 0 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.1 |
+| **Lead Persona** | ISSM |
+| **Supporting Personas** | ISSO, Engineer |
+| **Key Outcome** | System registered with boundary and roles assigned |
+
+---
+
+## Persona Responsibilities
+
+### ISSM (Lead)
+
+**Tasks in this phase**:
+
+1. Register the system → Tool: `compliance_register_system`
+2. Define the authorization boundary → Tool: `compliance_define_boundary`
+3. Exclude shared/inherited resources → Tool: `compliance_exclude_from_boundary`
+4. Assign RMF roles → Tool: `compliance_assign_rmf_role`
+5. Verify role assignments → Tool: `compliance_list_rmf_roles`
+6. Advance to Categorize → Tool: `compliance_advance_rmf_step`
+
+**Natural Language Queries**:
+
+> **"Register a new system called 'ACME Portal' as a Major Application with mission-critical designation in Azure Government"** → `compliance_register_system` — creates system entity with RMF step = Prepare
+
+> **"Define the authorization boundary for system {id} — add the production VMs, SQL database, and Key Vault"** → `compliance_define_boundary` — adds Azure resource IDs to the boundary
+
+> **"Assign Jane Smith as ISSM and Bob Jones as ISSO for system {id}"** → `compliance_assign_rmf_role` — assigns named personnel to RMF roles
+
+> **"Show me all registered systems"** → `compliance_list_systems` — lists all systems with RMF phase and status
+
+> **"What roles are assigned to system {id}?"** → `compliance_list_rmf_roles` — shows all role assignments
+
+> **"Advance system {id} to the Categorize phase"** → `compliance_advance_rmf_step` — transitions to next phase (gate-checked)
+
+### ISSO (Support)
+
+- Assist with boundary definition by identifying Azure resources
+- Verify role assignments are accurate
+
+### Engineer (Support)
+
+- Provide Azure resource inventory for boundary definition
+- Confirm system type and hosting environment details
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| — | — | — | None (informational artifacts only) |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Roles assigned | At least one RMF role assigned to the system | `compliance_advance_rmf_step` |
+| Boundary defined | At least one resource in the authorization boundary | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` with gate pass | Prepare | Categorize | System ID with boundary and roles ready for categorization |
+
+---
+
+## See Also
+
+- [Next Phase: Categorize](categorize.md)
+- [ISSM Guide](../guides/issm-guide.md) — Full ISSM workflow documentation
+- [Persona Overview](../personas/index.md) — Role definitions

--- a/docs/rmf-phases/select.md
+++ b/docs/rmf-phases/select.md
@@ -1,0 +1,111 @@
+# RMF Phase 2: Select
+
+> Select, tailor, and document the controls necessary to protect the system based on the categorization results.
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | 2 |
+| **NIST Reference** | SP 800-37 Rev. 2, §3.3 |
+| **Lead Persona** | ISSM |
+| **Supporting Personas** | ISSO, SCA (review), Engineer (consulted) |
+| **Key Outcome** | NIST 800-53 baseline selected, tailored, inheritance declared, CRM generated |
+
+---
+
+## Persona Responsibilities
+
+### ISSM (Lead)
+
+**Tasks in this phase**:
+
+1. Select baseline → Tool: `compliance_select_baseline`
+2. Tailor controls → Tool: `compliance_tailor_baseline`
+3. Declare inheritance → Tool: `compliance_set_inheritance`
+4. Review baseline → Tool: `compliance_get_baseline`
+5. Generate CRM → Tool: `compliance_generate_crm`
+6. View STIG mappings → Tool: `compliance_show_stig_mapping`
+7. Advance to Implement → Tool: `compliance_advance_rmf_step`
+
+**Natural Language Queries**:
+
+> **"Select the control baseline for system {id} with CNSSI 1253 overlay"** → `compliance_select_baseline` — selects Low/Moderate/High baseline with optional CNSSI 1253 overlay
+
+> **"Remove control PE-5 from the baseline — not applicable, system is 100% cloud-hosted"** → `compliance_tailor_baseline` — removes control with documented rationale
+
+> **"Set AC-1 as inherited from Azure Government FedRAMP High"** → `compliance_set_inheritance` — marks control as fully inherited
+
+> **"Set AC-2 as shared with Azure Government — customer configures access policies"** → `compliance_set_inheritance` — marks control as shared with CSP
+
+> **"Generate the Customer Responsibility Matrix for system {id}"** → `compliance_generate_crm` — generates CRM grouped by control family
+
+> **"Show me the STIG mappings for AC-2"** → `compliance_show_stig_mapping` — shows DISA STIG IDs mapped to NIST controls
+
+> **"How many controls are in the baseline for system {id}?"** → `compliance_get_baseline` — baseline summary with control count
+
+### SCA (Review)
+
+- Review baseline selection for completeness
+- Verify tailoring rationale is documented
+
+### Engineer (Consulted)
+
+- Provide technical input on control applicability
+- Confirm cloud service responsibilities
+
+---
+
+## Baseline Control Counts
+
+| Baseline | Typical Count | DoD IL |
+|----------|--------------|--------|
+| Low | ~152 controls | IL2 |
+| Moderate | ~329 controls | IL4 |
+| High | ~400 controls | IL5/IL6 |
+
+---
+
+## Inheritance Types
+
+| Type | Meaning | SSP Narrative |
+|------|---------|---------------|
+| **Inherited** | Fully satisfied by CSP (e.g., physical security) | Auto-populated standard statement |
+| **Shared** | Partially CSP, partially customer | Requires customer responsibility documentation |
+| **Customer** | Entirely the customer's responsibility | Requires full human-authored narrative |
+
+---
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| Customer Responsibility Matrix (CRM) | ISSM | Markdown | Informational (not gate-blocking) |
+
+---
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| Baseline exists | A security control baseline has been selected | `compliance_advance_rmf_step` |
+
+---
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| `compliance_advance_rmf_step` with gate pass | Select | Implement | Baseline and inheritance ready for narrative authoring |
+
+---
+
+## See Also
+
+- [Previous Phase: Categorize](categorize.md)
+- [Next Phase: Implement](implement.md)
+- [ISSM Guide](../guides/issm-guide.md) — Full ISSM workflow documentation
+- [NIST Controls Reference](../reference/nist-controls.md) — Control details
+- [STIG Coverage Reference](../reference/stig-coverage.md) — DISA STIG mappings

--- a/docs/scenarios/full-lifecycle.md
+++ b/docs/scenarios/full-lifecycle.md
@@ -1,0 +1,465 @@
+# End-to-End Scenario: ACME Portal
+
+> Full RMF lifecycle walkthrough — from system registration through continuous monitoring.
+
+---
+
+## Scenario Overview
+
+**System**: ACME Portal — a mission-critical Major Application hosted in Azure Government (IL5).
+
+This scenario follows five personas through every RMF phase, demonstrating natural language queries and tool interactions at each step.
+
+| Property | Value |
+|----------|-------|
+| System Name | ACME Portal |
+| System Type | Major Application |
+| Environment | Azure Government |
+| Impact Level | IL5 |
+| Overall Impact | HIGH |
+| ISSM | Jane Smith |
+| ISSO | Bob Jones |
+| SCA | Dr. Alice Chen |
+| AO | COL Davis |
+
+---
+
+## Day 1 — Prepare: ISSM Registers the System
+
+### Step 1: Register
+
+```text
+User (ISSM):
+  Register a new system called 'ACME Portal' as a Major Application
+  with mission-critical designation in Azure Government IL5
+
+ATO Copilot:
+  ✅ System registered: ACME Portal (ID: sys-acme-001)
+  Current RMF Phase: Prepare
+  Next steps:
+  1. Define the authorization boundary
+  2. Assign RMF roles
+  3. Advance to Categorize phase
+```
+
+### Step 2: Define Boundary
+
+```text
+User (ISSM):
+  Define the authorization boundary — add 3 production VMs, the SQL
+  database, Key Vault, and the App Service
+
+ATO Copilot:
+  ✅ Authorization boundary updated: 6 resources added
+  Resources: 3× Virtual Machine, 1× SQL Database, 1× Key Vault, 1× App Service
+```
+
+### Step 3: Assign Roles
+
+```text
+User (ISSM):
+  Assign Jane Smith as ISSM, Bob Jones as ISSO, Dr. Alice Chen as SCA,
+  and COL Davis as Authorizing Official
+
+ATO Copilot:
+  ✅ Roles assigned:
+  • Jane Smith → ISSM (Compliance.SecurityLead)
+  • Bob Jones → ISSO (Compliance.Analyst)
+  • Dr. Alice Chen → SCA (Compliance.Auditor)
+  • COL Davis → AO (Compliance.AuthorizingOfficial)
+```
+
+### Step 4: Advance to Categorize
+
+```text
+User (ISSM):
+  Advance to Categorize
+
+ATO Copilot:
+  ✅ Phase advanced: Prepare → Categorize
+  Gate conditions met: ✓ 4 RMF roles assigned, ✓ 6 boundary resources
+```
+
+---
+
+## Day 2 — Categorize: ISSM Classifies the System
+
+### Step 1: Suggest Information Types
+
+```text
+User (ISSM):
+  Suggest information types for ACME Portal — it handles financial
+  transactions and stores PII
+
+ATO Copilot:
+  Suggested types (confidence scores):
+  1. C.3.1.4 Financial Management (0.92)
+  2. C.2.4.1 General Information (0.87)
+  3. C.3.5.8 Information Security (0.85)
+```
+
+### Step 2: Categorize
+
+```text
+User (ISSM):
+  Categorize with Financial Management (C:High, I:High, A:Moderate)
+  and Information Security (C:Moderate, I:High, A:Moderate)
+
+ATO Copilot:
+  ✅ Categorization complete:
+  FIPS 199: SC ACME Portal = {(C, HIGH), (I, HIGH), (A, MODERATE)}
+  Overall: HIGH | DoD IL: IL5 | Baseline: High (400 controls)
+```
+
+### Step 3: Advance to Select
+
+```text
+User (ISSM):
+  Advance to Select
+
+ATO Copilot:
+  ✅ Phase advanced: Categorize → Select
+  Gate conditions met: ✓ FIPS 199 categorization recorded
+```
+
+---
+
+## Days 3–5 — Select: ISSM Tailors Controls
+
+### Step 1: Select Baseline
+
+```text
+User (ISSM):
+  Select the High baseline with CNSSI 1253 overlay
+
+ATO Copilot:
+  ✅ Baseline selected: High (400 controls)
+  Overlay applied: CNSSI 1253
+  Total controls in scope: 412
+```
+
+### Step 2: Set Inheritance
+
+```text
+User (ISSM):
+  Set all physical security controls as inherited from Azure Government
+
+ATO Copilot:
+  ✅ Inheritance set for 23 controls:
+  PE-1 through PE-23 → Fully Inherited from Azure Government
+  Provider: Azure Government FedRAMP High P-ATO
+```
+
+### Step 3: Generate CRM
+
+```text
+User (ISSM):
+  Generate the CRM
+
+ATO Copilot:
+  ✅ CRM generated: 412 controls mapped
+  • Fully Inherited: 23 controls
+  • Shared: 89 controls
+  • Customer Responsible: 300 controls
+```
+
+### Step 4: Advance to Implement
+
+```text
+User (ISSM):
+  Advance to Implement
+
+ATO Copilot:
+  ✅ Phase advanced: Select → Implement
+  Gate conditions met: ✓ Baseline selected with 412 controls
+```
+
+---
+
+## Weeks 2–6 — Implement: ISSO and Engineers Author SSP
+
+### ISSO: Auto-Populate Inherited Narratives
+
+```text
+User (ISSO):
+  Auto-populate inherited control narratives
+
+ATO Copilot:
+  ✅ 112 narratives auto-populated:
+  • Fully Inherited: 23 narratives from Azure Gov P-ATO
+  • Shared (provider portion): 89 narratives
+  Remaining: 300 customer narratives needed
+```
+
+### ISSO: AI-Suggested Narratives
+
+```text
+User (ISSO):
+  Suggest narratives for all AC family customer controls
+
+ATO Copilot:
+  Generated 20 narrative suggestions for AC family:
+  • AC-1: Access Control Policy (confidence: 0.91) ✅
+  • AC-2: Account Management (confidence: 0.88) ✅
+  • AC-3: Access Enforcement (confidence: 0.85) ✅
+  • ... (17 more)
+  ⚠️ All suggestions require human review before acceptance
+```
+
+### Engineer: Write Technical Narrative
+
+```text
+User (Engineer):
+  Write the narrative for SC-7: "Network boundary protection is implemented
+  using Azure Firewall Premium with TLS inspection, default-deny egress
+  rules, and Azure DDoS Protection Standard. All inbound traffic routes
+  through Azure Front Door with WAF policy v2..."
+
+ATO Copilot:
+  ✅ Narrative saved for SC-7 (Boundary Protection)
+  Author: Engineer | Status: Draft
+  Word count: 287 | Sections: Implementation, Evidence
+```
+
+### ISSO: Track Progress
+
+```text
+User (ISSO):
+  What's the SSP completion percentage?
+
+ATO Copilot:
+  SSP Progress: 78% complete
+  ├─ AC: 18/20 ██████████████████░░ 90%
+  ├─ AU: 12/14 █████████████████░░░ 86%
+  ├─ SC: 15/22 ██████████████░░░░░░ 68%
+  └─ (14 more families...)
+  Missing: 88 narratives across 14 families
+```
+
+---
+
+## Weeks 7–8 — Assess: SCA Evaluates Controls
+
+### SCA: Assess Controls
+
+```text
+User (SCA):
+  Assess AC-2 as Satisfied — tested Azure AD account management against
+  STIG checklist, all 15 sub-requirements met
+
+ATO Copilot:
+  ✅ AC-2 assessed: Satisfied
+  Method: Test | Evidence: Azure AD audit logs, STIG checklist
+```
+
+```text
+User (SCA):
+  Assess AC-3 as Other Than Satisfied, CAT II — missing mandatory access
+  control for 3 storage accounts
+
+ATO Copilot:
+  ✅ AC-3 assessed: Other Than Satisfied (CAT II)
+  Finding: Missing MAC for 3 storage accounts
+  POA&M recommended: Yes
+```
+
+### SCA: Take Snapshot
+
+```text
+User (SCA):
+  Take an assessment snapshot
+
+ATO Copilot:
+  ✅ Snapshot created: SNAP-2026-02-15-001
+  Controls assessed: 412 | Score: 87.3%
+  Findings: 0 CAT I, 12 CAT II, 31 CAT III
+  Hash: sha256:a1b2c3d4... (immutable)
+```
+
+### SCA: Generate SAR
+
+```text
+User (SCA):
+  Generate the Security Assessment Report
+
+ATO Copilot:
+  ✅ SAR generated: SAR-ACME-2026-001
+  Sections: Executive Summary, Methodology, Findings (43), Recommendations
+  Overall Score: 87.3%
+  Findings: 0 CAT I, 12 CAT II, 31 CAT III
+  Recommendation: Conditional authorization pending CAT II remediation
+```
+
+---
+
+## Week 9 — ISSM Prepares Authorization Package
+
+### Create POA&M
+
+```text
+User (ISSM):
+  Create POA&M items for all 12 CAT II findings
+
+ATO Copilot:
+  ✅ 12 POA&M items created:
+  • POA&M-001: AC-3 — Missing MAC for storage accounts (90 days)
+  • POA&M-002: AU-6 — Incomplete audit review process (60 days)
+  • ... (10 more)
+  Total estimated remediation: 90 days
+```
+
+### Generate RAR
+
+```text
+User (ISSM):
+  Generate the RAR
+
+ATO Copilot:
+  ✅ RAR generated: RAR-ACME-2026-001
+  Sections: Risk Summary, Residual Risks (43), Recommendations
+  Overall Risk Level: Medium
+```
+
+### Bundle Package
+
+```text
+User (ISSM):
+  Bundle the authorization package with evidence
+
+ATO Copilot:
+  ✅ Authorization package bundled: PKG-ACME-2026-001
+  Contents:
+  • System Security Plan (SSP)
+  • Security Assessment Report (SAR)
+  • Risk Assessment Report (RAR)
+  • Plan of Action & Milestones (12 items)
+  • Customer Responsibility Matrix (CRM)
+  • Evidence artifacts (SHA-256 verified)
+```
+
+---
+
+## Week 10 — Authorize: AO Issues Decision
+
+### AO: Review Package
+
+```text
+User (AO):
+  Review the authorization package for ACME Portal
+
+ATO Copilot:
+  Authorization Package: PKG-ACME-2026-001
+  ┌──────────────────────────────────────┐
+  │ System: ACME Portal (IL5)            │
+  │ Score: 87.3% | Risk: Medium          │
+  │ CAT I: 0 | CAT II: 12 | CAT III: 31 │
+  │ POA&M: 12 items (90-day plan)        │
+  │ SCA Recommendation: ATOwC            │
+  └──────────────────────────────────────┘
+```
+
+### AO: Issue Authorization
+
+```text
+User (AO):
+  Issue ATO with conditions — CAT II findings must be remediated within
+  90 days, quarterly POA&M reviews required. Expiration: January 15, 2029.
+  Accept risk on 5 CAT III findings with compensating controls.
+
+ATO Copilot:
+  ✅ Authorization Issued: ATO with Conditions
+  System: ACME Portal | Expires: 2029-01-15
+  Risk Level: Medium | Score at Decision: 87.3%
+  Conditions: CAT II remediation within 90 days
+  Risk Acceptances: 5 findings accepted (expires 2027-01-15)
+  System moved to Monitor phase
+```
+
+---
+
+## Ongoing — Monitor: Continuous Monitoring
+
+### ISSM: Create ConMon Plan
+
+```text
+User (ISSM):
+  Create a ConMon plan with monthly assessments, annual review June 15
+
+ATO Copilot:
+  ✅ ConMon plan created:
+  • Monthly assessment: 1st of each month
+  • Annual review: June 15
+  • POA&M review: Quarterly
+  • ATO expiration: January 15, 2029
+```
+
+### ISSM: Generate Monthly Report
+
+```text
+User (ISSM):
+  Generate the February 2026 ConMon report
+
+ATO Copilot:
+  ✅ ConMon report generated: ConMon-ACME-2026-02
+  Score: 89.1% (↑1.8% from January)
+  POA&M: 3 of 12 items closed
+  New findings: 0 | Resolved: 3
+  Next report due: March 1, 2026
+```
+
+### ISSM: Portfolio Dashboard
+
+```text
+User (ISSM):
+  Show the multi-system dashboard
+
+ATO Copilot:
+  ┌──────────────┬─────┬─────────┬───────┬─────────┬──────┐
+  │ System       │ IL  │ Phase   │ Auth  │ Score   │ Exp  │
+  ├──────────────┼─────┼─────────┼───────┼─────────┼──────┤
+  │ ACME Portal  │ IL5 │ Monitor │ ATOwC │  89.1%  │ 2029 │
+  │ HR System    │ IL4 │ Monitor │ ATO   │  94.2%  │ 2028 │
+  │ Log Analyzer │ IL2 │ Assess  │ None  │  72.4%  │  —   │
+  └──────────────┴─────┴─────────┴───────┴─────────┴──────┘
+```
+
+### Automated: Expiration Alert
+
+```text
+ATO Copilot (automated):
+  ⚠️ Alert: ATO for ACME Portal expires in 90 days
+  Action: Begin reauthorization planning
+```
+
+### Automated: Drift Detection
+
+```text
+ATO Copilot (automated):
+  🔴 Alert: Configuration drift detected — 7 resources drifted beyond
+  threshold. Significant change auto-reported.
+  Action required: ISSO must review and ISSM must determine if
+  reauthorization is needed.
+```
+
+---
+
+## Scenario Summary
+
+| Phase | Duration | Lead | Key Outputs |
+|-------|----------|------|-------------|
+| Prepare | Day 1 | ISSM | System registered, boundary defined, roles assigned |
+| Categorize | Day 2 | ISSM | FIPS 199: HIGH, IL5, 400-control baseline |
+| Select | Days 3–5 | ISSM | 412 controls, 23 inherited, CRM generated |
+| Implement | Weeks 2–6 | ISSO/Eng | SSP at 100% completion (412 narratives) |
+| Assess | Weeks 7–8 | SCA | SAR: 87.3%, 0 CAT I, 12 CAT II, 31 CAT III |
+| Authorize | Week 10 | AO | ATOwC issued, expires 2029-01-15 |
+| Monitor | Ongoing | ISSM/ISSO | Monthly ConMon, Watch alerts, POA&M tracking |
+
+---
+
+## See Also
+
+- [RMF Phase Overview](../rmf-phases/index.md) — Phase-by-phase documentation
+- [Persona Overview](../personas/index.md) — Role definitions
+- [NL Query Reference](../guides/nl-query-reference.md) — Full query catalog
+- [Getting Started Hub](../getting-started/index.md) — Per-persona onboarding

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,113 @@
+site_name: ATO Copilot Documentation
+site_description: Comprehensive user documentation for ATO Copilot — AI-powered NIST RMF compliance assistant
+site_url: ""
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - toc.integrate
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+use_directory_urls: false
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - def_list
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Overview: getting-started/index.md
+    - ISSM: getting-started/issm.md
+    - ISSO: getting-started/isso.md
+    - SCA: getting-started/sca.md
+    - AO: getting-started/ao.md
+    - Engineer: getting-started/engineer.md
+  - Personas:
+    - Overview: personas/index.md
+    - ISSM Guide: guides/issm-guide.md
+    - ISSO Guide: personas/isso.md
+    - SCA Guide: guides/sca-guide.md
+    - AO Guide: guides/ao-quick-reference.md
+    - Engineer Guide: guides/engineer-guide.md
+    - Administrator: personas/administrator.md
+  - RMF Phases:
+    - Overview: rmf-phases/index.md
+    - Prepare: rmf-phases/prepare.md
+    - Categorize: rmf-phases/categorize.md
+    - Select: rmf-phases/select.md
+    - Implement: rmf-phases/implement.md
+    - Assess: rmf-phases/assess.md
+    - Authorize: rmf-phases/authorize.md
+    - Monitor: rmf-phases/monitor.md
+  - Guides:
+    - Compliance Watch: guides/compliance-watch.md
+    - Remediation Kanban: guides/remediation-kanban.md
+    - Portfolio Management: guides/portfolio-management.md
+    - Document Catalog: guides/document-catalog.md
+    - NL Query Reference: guides/nl-query-reference.md
+    - Teams Bot: guides/teams-bot-guide.md
+    - Chat App: guides/chat-app.md
+    - Knowledge Base: guides/knowledgebase.md
+  - Reference:
+    - Glossary: reference/glossary.md
+    - Tool Inventory: reference/tool-inventory.md
+    - Troubleshooting: reference/troubleshooting.md
+    - Quick Reference Cards: reference/quick-reference-cards.md
+    - RMF Process: reference/rmf-process.md
+    - NIST Controls: reference/nist-controls.md
+    - NIST Coverage: reference/nist-coverage.md
+    - Impact Levels: reference/impact-levels.md
+    - STIG Coverage: reference/stig-coverage.md
+  - Scenarios:
+    - Full RMF Lifecycle: scenarios/full-lifecycle.md
+  - Developer:
+    - Code Style: dev/code-style.md
+    - Contributing: dev/contributing.md
+    - Testing: dev/testing.md
+    - Release: dev/release.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Data Model: architecture/data-model.md
+    - Agent & Tool Catalog: architecture/agent-tool-catalog.md
+    - RMF Step Map: architecture/rmf-step-map.md
+    - Security: architecture/security.md
+  - API:
+    - MCP Server: api/mcp-server.md
+    - VS Code Extension: api/vscode-extension.md
+  - Deployment: deployment.md

--- a/specs/016-user-documentation/contracts/README.md
+++ b/specs/016-user-documentation/contracts/README.md
@@ -1,0 +1,14 @@
+# Contract: Page Templates
+
+**Date**: 2026-02-28
+
+This directory defines the content contracts for each page type in the documentation site. Every page must conform to its template to ensure consistency.
+
+## Template Index
+
+| Template | Used By | File |
+|----------|---------|------|
+| Persona Guide | ISSM, ISSO, SCA, AO, Engineer, Admin guides | [persona-guide.md](persona-guide.md) |
+| RMF Phase Page | Prepare through Monitor | [rmf-phase.md](rmf-phase.md) |
+| Getting Started | Per-persona onboarding | [getting-started.md](getting-started.md) |
+| Reference Page | Glossary, Tool Inventory, Troubleshooting | [reference.md](reference.md) |

--- a/specs/016-user-documentation/contracts/getting-started.md
+++ b/specs/016-user-documentation/contracts/getting-started.md
@@ -1,0 +1,72 @@
+# Template: Getting Started Page
+
+## Contract
+
+Every per-persona getting-started page MUST include these sections in order.
+
+---
+
+```markdown
+# Getting Started: {Persona Name}
+
+> First-time setup and orientation for {persona abbreviation} users.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Access** | {what accounts/roles needed} |
+| **Tools** | {VS Code, Teams, CLI — whichever applies} |
+| **Knowledge** | {assumed background} |
+
+## First-Time Setup
+
+1. {Step 1 — e.g., verify RBAC role assignment}
+   ```
+   {example command or NL query}
+   ```
+2. {Step 2 — e.g., configure default system}
+3. {Step 3 — e.g., verify connectivity}
+
+## Your First 3 Commands
+
+### 1. {Action Name}
+
+> **"{natural language query}"**
+
+Expected result: {what the user will see}
+
+### 2. {Action Name}
+
+> **"{natural language query}"**
+
+Expected result: {what the user will see}
+
+### 3. {Action Name}
+
+> **"{natural language query}"**
+
+Expected result: {what the user will see}
+
+## What's Next
+
+- [Full {Persona} Guide]({path}) — Complete workflow reference
+- [RMF Phase Reference]({path}) — Phase-by-phase details
+- [Quick Reference Card]({path}) — Printable cheat sheet
+
+## Common First-Day Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| {symptom} | {why} | {resolution} |
+```
+
+## Validation Rules
+
+1. Prerequisites MUST specify the exact RBAC role name
+2. First 3 commands MUST use natural language queries (not raw tool calls)
+3. Expected results MUST be realistic
+4. "What's Next" links MUST resolve to existing pages
+5. Common issues MUST cover RBAC permission errors for the persona's role

--- a/specs/016-user-documentation/contracts/persona-guide.md
+++ b/specs/016-user-documentation/contracts/persona-guide.md
@@ -1,0 +1,72 @@
+# Template: Persona Guide Page
+
+## Contract
+
+Every persona guide page MUST include these sections in order.
+
+---
+
+```markdown
+# {Persona Name} Guide
+
+> One-line role description from NIST SP 800-37 or organizational definition.
+
+---
+
+## Role Overview
+
+- **Full Title**: {e.g., Information System Security Manager}
+- **Abbreviation**: {e.g., ISSM}
+- **RBAC Role**: `{role_constant}` (from ComplianceRoles.cs)
+- **Primary RMF Phases**: {comma-separated list}
+- **Key Responsibility**: {one sentence}
+
+## Permissions
+
+| Capability | Allowed | Tool |
+|-----------|---------|------|
+| {action}  | ✅ / ❌  | `{tool_name}` |
+
+## RMF Phase Workflows
+
+### Phase N: {Phase Name}
+
+**Objective**: {what the persona accomplishes in this phase}
+
+**Step-by-Step**:
+
+1. {Action} → Tool: `{tool_name}`
+2. {Action} → Tool: `{tool_name}`
+
+**Natural Language Queries**:
+
+> **"{query}"** → `{tool_name}` — {result description}
+
+**Documents Produced**:
+
+| Document | Format | Purpose |
+|----------|--------|---------|
+| {name}   | {type} | {why}   |
+
+🔒 **Air-Gapped Note**: {modifications for disconnected environments, if any}
+
+## Cross-Persona Handoffs
+
+| From | To | Trigger | Data |
+|------|----|---------|------|
+| {persona} | {persona} | {event} | {what transfers} |
+
+## See Also
+
+- [Getting Started]({path})
+- [RMF Phase Reference]({path})
+- [Quick Reference Card]({path})
+```
+
+## Validation Rules
+
+1. Every persona guide MUST list all tools available to that persona's RBAC role
+2. Every RMF phase section MUST include at least one NL query example
+3. Air-gapped notes are REQUIRED for ISSO (Implement), ISSM (Monitor), SCA (Assess)
+4. Cross-persona handoffs MUST be bidirectional (if ISSM hands to ISSO, ISSO guide shows receiving)
+5. Tool names MUST match the exact MCP tool identifiers from the codebase

--- a/specs/016-user-documentation/contracts/reference.md
+++ b/specs/016-user-documentation/contracts/reference.md
@@ -1,0 +1,72 @@
+# Template: Reference Page
+
+## Contract
+
+Reference pages serve as lookup resources. They MUST prioritize scannability over narrative.
+
+---
+
+```markdown
+# {Reference Topic}
+
+> {One-line description of what this reference covers.}
+
+---
+
+## Overview
+
+{2-3 sentences explaining the scope and how to use this reference.}
+
+## {Primary Content Section}
+
+{Tables, definition lists, or alphabetical entries — NOT prose paragraphs.}
+
+| Column 1 | Column 2 | Column 3 |
+|----------|----------|----------|
+| {data}   | {data}   | {data}   |
+
+## {Additional Sections as needed}
+
+## See Also
+
+- [{Related reference}]({path})
+- [{Related guide}]({path})
+```
+
+## Page-Specific Contracts
+
+### Tool Inventory (`reference/tool-inventory.md`)
+
+MUST include:
+- All 114 MCP tools grouped by category (8 categories)
+- Each tool: name, description, required RBAC role, RMF phase applicability
+- Search-friendly format (one row per tool)
+
+### Troubleshooting (`reference/troubleshooting.md`)
+
+MUST include:
+- 7 error categories from spec Appendix F
+- Each entry: error message/symptom, cause, resolution
+- 25+ error scenarios minimum
+- Cross-references to relevant persona guides
+
+### Quick Reference Cards (`reference/quick-reference-cards.md`)
+
+MUST include:
+- One card per persona (5 personas + admin)
+- Each card: top 5 NL queries, key tools, phase responsibilities
+- Designed for printing (clean formatting, no deep nesting)
+
+### Glossary (`reference/glossary.md`)
+
+MUST include:
+- Alphabetical entries
+- Each term: definition, context/usage, related terms
+- All terms from spec Appendix C plus existing glossary entries
+
+## Validation Rules
+
+1. Reference pages MUST use tables or definition lists as primary format
+2. No section should require reading previous sections to understand
+3. All tool names MUST match codebase identifiers exactly
+4. Cross-references MUST use relative links that resolve in MkDocs

--- a/specs/016-user-documentation/contracts/rmf-phase.md
+++ b/specs/016-user-documentation/contracts/rmf-phase.md
@@ -1,0 +1,74 @@
+# Template: RMF Phase Page
+
+## Contract
+
+Every RMF phase page MUST include these sections in order.
+
+---
+
+```markdown
+# RMF Phase {N}: {Phase Name}
+
+> {NIST SP 800-37 definition of this phase}
+
+---
+
+## Phase Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Phase Number** | {0–6} |
+| **NIST Reference** | SP 800-37 Rev. 2, §{section} |
+| **Lead Persona** | {primary persona} |
+| **Supporting Personas** | {comma-separated} |
+| **Key Outcome** | {one sentence} |
+
+## Persona Responsibilities
+
+### {Persona Name} ({Abbreviation})
+
+**Tasks in this phase**:
+
+1. {Task} → Tool: `{tool_name}`
+2. {Task} → Tool: `{tool_name}`
+
+**Natural Language Queries**:
+
+> **"{query}"** → `{tool_name}` — {result}
+
+### {Next Persona}...
+
+## Documents Produced
+
+| Document | Owner | Format | Gate Dependency |
+|----------|-------|--------|----------------|
+| {name}   | {persona} | {type} | {which gate requires this} |
+
+## Phase Gates
+
+| Gate | Condition | Checked By |
+|------|-----------|-----------|
+| {gate name} | {what must be true} | `{tool_name}` |
+
+## Transition to Next Phase
+
+| Trigger | From Phase | To Phase | Handoff |
+|---------|-----------|----------|---------|
+| {event} | {current} | {next}   | {what transfers} |
+
+🔒 **Air-Gapped Considerations**: {if applicable}
+
+## See Also
+
+- [Previous Phase: {name}]({path})
+- [Next Phase: {name}]({path})
+- [{Lead Persona} Guide]({path})
+```
+
+## Validation Rules
+
+1. Every persona with responsibilities in this phase MUST have a subsection
+2. Phase gates MUST reference the actual tool that enforces them
+3. Document ownership MUST align with the persona's RBAC permissions
+4. Transition triggers MUST match the gate conditions
+5. Previous/Next phase links MUST be present (except Prepare has no previous, Monitor has no next)

--- a/specs/016-user-documentation/data-model.md
+++ b/specs/016-user-documentation/data-model.md
@@ -1,0 +1,152 @@
+# Data Model: Feature 016 — Documentation Site Structure
+
+**Date**: 2026-02-28
+
+## Overview
+
+This feature produces no runtime data models. The "data model" for a documentation-only feature is the **site structure** — the hierarchy of pages, their relationships, and content types.
+
+## Entity: Documentation Page
+
+Each page in the documentation site follows this structure:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | File path relative to `docs/` |
+| `title` | string | H1 heading — one per file |
+| `section` | enum | Top-level section: `getting-started`, `personas`, `rmf-phases`, `guides`, `reference`, `scenarios` |
+| `persona_scope` | enum[] | Which personas this page serves: `ISSM`, `ISSO`, `SCA`, `AO`, `Engineer`, `Administrator`, `All` |
+| `status` | enum | `existing` (preserved), `enhanced` (existing + new content), `new` (created from scratch) |
+| `priority` | enum | `P0` (launch-blocking), `P1` (full coverage), `P2` (nice-to-have) |
+
+## Site Navigation Model
+
+```yaml
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Overview: getting-started/index.md
+    - ISSM: getting-started/issm.md
+    - ISSO: getting-started/isso.md
+    - SCA: getting-started/sca.md
+    - AO: getting-started/ao.md
+    - Engineer: getting-started/engineer.md
+  - Personas:
+    - Overview: personas/index.md
+    - ISSM Guide: guides/issm-guide.md          # existing file
+    - ISSO Guide: personas/isso.md               # new
+    - SCA Guide: guides/sca-guide.md             # existing file
+    - AO Guide: guides/ao-quick-reference.md     # existing file
+    - Engineer Guide: guides/engineer-guide.md   # existing file
+    - Administrator: personas/administrator.md   # new
+  - RMF Phases:
+    - Overview: rmf-phases/index.md
+    - Prepare: rmf-phases/prepare.md
+    - Categorize: rmf-phases/categorize.md
+    - Select: rmf-phases/select.md
+    - Implement: rmf-phases/implement.md
+    - Assess: rmf-phases/assess.md
+    - Authorize: rmf-phases/authorize.md
+    - Monitor: rmf-phases/monitor.md
+  - Guides:
+    - Compliance Watch: guides/compliance-watch.md
+    - Remediation Kanban: guides/remediation-kanban.md
+    - Portfolio Management: guides/portfolio-management.md
+    - Document Catalog: guides/document-catalog.md
+    - NL Query Reference: guides/nl-query-reference.md
+    - Teams Bot: guides/teams-bot-guide.md
+    - Chat App: guides/chat-app.md
+    - Knowledge Base: guides/knowledgebase.md
+  - Reference:
+    - Glossary: reference/glossary.md
+    - Tool Inventory: reference/tool-inventory.md
+    - Troubleshooting: reference/troubleshooting.md
+    - Quick Reference Cards: reference/quick-reference-cards.md
+    - RMF Process: reference/rmf-process.md
+    - NIST Controls: reference/nist-controls.md
+    - NIST Coverage: reference/nist-coverage.md
+    - Impact Levels: reference/impact-levels.md
+    - STIG Coverage: reference/stig-coverage.md
+  - Scenarios:
+    - Full RMF Lifecycle: scenarios/full-lifecycle.md
+  - Developer:
+    - Code Style: dev/code-style.md
+    - Contributing: dev/contributing.md
+    - Testing: dev/testing.md
+    - Release: dev/release.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Data Model: architecture/data-model.md
+    - Agent & Tool Catalog: architecture/agent-tool-catalog.md
+    - RMF Step Map: architecture/rmf-step-map.md
+    - Security: architecture/security.md
+  - API:
+    - MCP Server: api/mcp-server.md
+    - VS Code Extension: api/vscode-extension.md
+  - Deployment: deployment.md
+```
+
+## Page Inventory
+
+### New Pages (16 files)
+
+| # | Path | Section | Personas | Source from Spec |
+|---|------|---------|----------|-----------------|
+| 1 | `docs/index.md` | Home | All | §1 Overview |
+| 2 | `docs/getting-started/index.md` | Getting Started | All | §3.2–§7.2 |
+| 3 | `docs/getting-started/issm.md` | Getting Started | ISSM | §3.2 |
+| 4 | `docs/getting-started/isso.md` | Getting Started | ISSO | §4.2 |
+| 5 | `docs/getting-started/sca.md` | Getting Started | SCA | §5.2 |
+| 6 | `docs/getting-started/ao.md` | Getting Started | AO | §6.2 |
+| 7 | `docs/getting-started/engineer.md` | Getting Started | Engineer | §7.2 |
+| 8 | `docs/personas/index.md` | Personas | All | §2 |
+| 9 | `docs/personas/isso.md` | Personas | ISSO | §4 |
+| 10 | `docs/personas/administrator.md` | Personas | Admin | §8 |
+| 11 | `docs/rmf-phases/index.md` | RMF Phases | All | §10 |
+| 12 | `docs/rmf-phases/prepare.md` | RMF Phases | ISSM, ISSO | §3.4 Phase 0 |
+| 13 | `docs/rmf-phases/categorize.md` | RMF Phases | ISSM | §3.4 Phase 1 |
+| 14 | `docs/rmf-phases/select.md` | RMF Phases | ISSM | §3.4 Phase 2 |
+| 15 | `docs/rmf-phases/implement.md` | RMF Phases | ISSO, Eng | §3.4 Phase 3, §4.4, §7.4 |
+| 16 | `docs/rmf-phases/assess.md` | RMF Phases | SCA, ISSO | §5.5, §4.4 |
+| 17 | `docs/rmf-phases/authorize.md` | RMF Phases | AO, ISSM | §6.4 |
+| 18 | `docs/rmf-phases/monitor.md` | RMF Phases | ISSM, ISSO | §3.4 Phase 6, §4.4 |
+| 19 | `docs/guides/portfolio-management.md` | Guides | ISSM, AO | §9.4 |
+| 20 | `docs/guides/document-catalog.md` | Guides | All | §11 |
+| 21 | `docs/guides/nl-query-reference.md` | Guides | All | §12 |
+| 22 | `docs/reference/tool-inventory.md` | Reference | All | Appendix A |
+| 23 | `docs/reference/troubleshooting.md` | Reference | All | Appendix F |
+| 24 | `docs/reference/quick-reference-cards.md` | Reference | All | Appendix D |
+| 25 | `docs/scenarios/full-lifecycle.md` | Scenarios | All | Appendix B |
+| 26 | `mkdocs.yml` | Config | N/A | Research R5 |
+
+### Enhanced Pages (6 files)
+
+| # | Path | Enhancement |
+|---|------|-------------|
+| 1 | `docs/guides/issm-guide.md` | Add air-gapped notes, cross-links to getting-started and rmf-phases |
+| 2 | `docs/guides/sca-guide.md` | Add RBAC constraints table, evidence integrity notes |
+| 3 | `docs/guides/ao-quick-reference.md` | Add portfolio view section, risk expiration queries |
+| 4 | `docs/guides/engineer-guide.md` | Add Kanban remediation, VS Code IaC diagnostics |
+| 5 | `docs/guides/compliance-watch.md` | Add air-gapped monitoring notes |
+| 6 | `docs/reference/glossary.md` | Add ~10 new terms from spec Appendix C |
+
+### Preserved Pages (9 files — no changes)
+
+All files in `docs/architecture/`, `docs/api/`, `docs/dev/`, and `docs/deployment.md` are included in the MkDocs navigation but require no content changes.
+
+## Cross-Reference Map
+
+| From Page | Links To | Relationship |
+|-----------|----------|-------------|
+| `index.md` | All getting-started pages | Entry point |
+| `getting-started/issm.md` | `guides/issm-guide.md` | "Next: Full Guide" |
+| `getting-started/sca.md` | `guides/sca-guide.md` | "Next: Full Guide" |
+| `personas/index.md` | All persona guides | Hub page |
+| `rmf-phases/prepare.md` | `guides/issm-guide.md` | ISSM lead |
+| `rmf-phases/assess.md` | `guides/sca-guide.md` | SCA lead |
+| `rmf-phases/authorize.md` | `guides/ao-quick-reference.md` | AO lead |
+| `rmf-phases/implement.md` | `guides/engineer-guide.md` | Engineer lead |
+| `rmf-phases/monitor.md` | `guides/compliance-watch.md` | Watch integration |
+| `guides/portfolio-management.md` | `reference/tool-inventory.md` | Bulk tool references |
+| `reference/troubleshooting.md` | All persona guides | Error resolution |
+| `reference/quick-reference-cards.md` | All persona guides | Cheat sheets |

--- a/specs/016-user-documentation/plan.md
+++ b/specs/016-user-documentation/plan.md
@@ -1,0 +1,255 @@
+# Implementation Plan: Feature 016 — Comprehensive User & Persona Documentation
+
+**Branch**: `016-user-documentation` | **Date**: 2026-02-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/016-user-documentation/spec.md`
+
+## Summary
+
+Create comprehensive, all-encompassing user documentation for ATO Copilot organized by persona (ISSM, ISSO, SCA, AO, Engineer, Administrator). The documentation covers natural language interaction patterns, RMF phase workflows, document production, assessment guidance, cross-persona collaboration, portfolio management, air-gapped operations, onboarding, and troubleshooting. Delivered as a static documentation site (MkDocs) generated from Markdown files in `docs/`.
+
+**Technical Approach**: Restructure and expand the existing `docs/guides/` Markdown files into a comprehensive documentation site using MkDocs with Material theme. No production code changes — this is a documentation-only feature. Existing guides are preserved and enhanced; new pages are added for gaps identified in the spec (getting started, portfolio management, troubleshooting, NL query reference, document catalog).
+
+## Technical Context
+
+**Language/Version**: Markdown + MkDocs (Python-based static site generator)
+**Primary Dependencies**: MkDocs, mkdocs-material theme, mkdocs-search plugin
+**Storage**: N/A (static Markdown files in `docs/`)
+**Testing**: Link validation (markdown-link-check), spell check, build verification (`mkdocs build --strict`)
+**Target Platform**: Static HTML site hosted alongside repo (GitHub Pages or internal web server)
+**Project Type**: Documentation site
+**Performance Goals**: N/A (static site)
+**Constraints**: Must work in air-gapped environments (offline-capable static site), all content must be unclassified
+**Scale/Scope**: ~30 documentation pages, 6 persona guides, 114 tool references, 7 RMF phase walkthroughs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applicable? | Status | Notes |
+|-----------|-------------|--------|-------|
+| I. Documentation as Source of Truth | ✅ Yes | **PASS** | This feature *is* documentation. All content follows `/docs/` conventions. |
+| II. BaseAgent/BaseTool Architecture | ❌ N/A | **PASS** | No agent/tool code changes. |
+| III. Testing Standards | ✅ Yes | **PASS** | Documentation build verification (`mkdocs build --strict`), link validation, and spell check serve as "tests" for this feature. No code changes require unit tests. |
+| IV. Azure Government & Compliance First | ✅ Yes | **PASS** | Air-gapped operation notes included per spec clarification. All content unclassified. |
+| V. Observability & Structured Logging | ❌ N/A | **PASS** | No runtime code. |
+| VI. Code Quality & Maintainability | ✅ Yes | **PASS** | Markdown files follow consistent structure, naming conventions, and cross-reference patterns. |
+| VII. User Experience Consistency | ✅ Yes | **PASS** | Consistent navigation, persona-based organization, glossary, and quick-reference cards ensure predictable UX. |
+| VIII. Performance Requirements | ❌ N/A | **PASS** | Static site — no runtime performance concerns. |
+
+**Gate Result**: ✅ **PASS** — No violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-user-documentation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (documentation site structure)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (page templates/conventions)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source — Documentation Site Layout
+
+```text
+docs/
+├── index.md                          # Landing page / overview
+├── getting-started/
+│   ├── index.md                      # General onboarding overview
+│   ├── issm.md                       # ISSM first-time setup
+│   ├── isso.md                       # ISSO first-time setup
+│   ├── sca.md                        # SCA first-time setup
+│   ├── ao.md                         # AO first-time setup
+│   └── engineer.md                   # Engineer first-time setup
+├── personas/
+│   ├── index.md                      # Persona overview & responsibility matrix
+│   ├── issm.md                       # ISSM comprehensive guide (expanded from issm-guide.md)
+│   ├── isso.md                       # ISSO comprehensive guide (new)
+│   ├── sca.md                        # SCA comprehensive guide (expanded from sca-guide.md)
+│   ├── ao.md                         # AO comprehensive guide (expanded from ao-quick-reference.md)
+│   ├── engineer.md                   # Engineer guide (expanded from engineer-guide.md)
+│   └── administrator.md             # Administrator guide (new)
+├── rmf-phases/
+│   ├── index.md                      # RMF lifecycle overview
+│   ├── prepare.md                    # Phase 0: Prepare
+│   ├── categorize.md                 # Phase 1: Categorize
+│   ├── select.md                     # Phase 2: Select
+│   ├── implement.md                  # Phase 3: Implement
+│   ├── assess.md                     # Phase 4: Assess
+│   ├── authorize.md                  # Phase 5: Authorize
+│   └── monitor.md                    # Phase 6: Monitor
+├── guides/                           # Existing guides (preserved, cross-linked)
+│   ├── compliance-watch.md           # Existing — enhanced with air-gapped notes
+│   ├── remediation-kanban.md         # Existing — enhanced
+│   ├── teams-bot-guide.md            # Existing
+│   ├── chat-app.md                   # Existing
+│   ├── knowledgebase.md              # Existing
+│   ├── portfolio-management.md       # NEW — multi-system workflows
+│   ├── document-catalog.md           # NEW — all documents produced
+│   └── nl-query-reference.md        # NEW — natural language query examples
+├── reference/                        # Existing reference docs (preserved)
+│   ├── glossary.md                   # Existing — expanded with new terms
+│   ├── tool-inventory.md            # NEW — complete 114-tool reference
+│   ├── troubleshooting.md           # NEW — error scenarios & resolution
+│   ├── quick-reference-cards.md     # NEW — per-persona cheat sheets
+│   ├── rmf-process.md               # Existing
+│   ├── nist-controls.md             # Existing
+│   ├── nist-coverage.md             # Existing
+│   ├── impact-levels.md             # Existing
+│   └── stig-coverage.md             # Existing
+├── scenarios/
+│   └── full-lifecycle.md            # NEW — end-to-end ACME Portal scenario
+├── api/                              # Existing API docs (preserved)
+├── architecture/                     # Existing arch docs (preserved)
+├── deployment.md                     # Existing
+├── dev/                              # Existing dev docs (preserved)
+└── getting-started.md               # Existing (becomes redirect to getting-started/index.md)
+```
+
+**Structure Decision**: Documentation-only feature using the existing `docs/` directory. New pages are added under `getting-started/`, `personas/`, `rmf-phases/`, `scenarios/`, and `reference/`. Existing `docs/guides/` files are preserved in-place and cross-linked from persona pages. A `mkdocs.yml` configuration file is added at the repo root.
+
+## Complexity Tracking
+
+No constitution violations — no tracking needed.
+
+---
+
+## Phased Implementation Plan
+
+### Phase 1: Site Infrastructure & Onboarding (Foundation)
+
+**Goal**: Stand up the MkDocs site skeleton and per-persona onboarding pages so the site is navigable and buildable.
+
+**Prerequisite**: None (greenfield)
+
+| Task | File(s) | Source | Priority |
+|------|---------|--------|----------|
+| Create MkDocs configuration | `mkdocs.yml` | research.md R5 | P0 |
+| Create landing page | `docs/index.md` | spec §1 | P0 |
+| Create getting-started index | `docs/getting-started/index.md` | spec §3.2–§7.2 intro | P0 |
+| Create ISSM getting-started | `docs/getting-started/issm.md` | spec §3.2 | P0 |
+| Create ISSO getting-started | `docs/getting-started/isso.md` | spec §4.2 | P0 |
+| Create SCA getting-started | `docs/getting-started/sca.md` | spec §5.2 | P0 |
+| Create AO getting-started | `docs/getting-started/ao.md` | spec §6.2 | P0 |
+| Create Engineer getting-started | `docs/getting-started/engineer.md` | spec §7.2 | P0 |
+| Redirect existing getting-started.md | `docs/getting-started.md` | research.md R6 | P0 |
+
+**Validation**: `mkdocs build --strict` passes; site serves locally with all getting-started pages navigable.
+
+**Estimated Tasks**: 9
+
+---
+
+### Phase 2: Persona Guides (Core Content)
+
+**Goal**: Create comprehensive per-persona guides with full RMF phase workflows, tool references, NL queries, and air-gapped callouts.
+
+**Prerequisite**: Phase 1 complete (site is buildable)
+
+| Task | File(s) | Source | Priority |
+|------|---------|--------|----------|
+| Create persona overview / RACI matrix | `docs/personas/index.md` | spec §2 | P1 |
+| Create ISSO comprehensive guide | `docs/personas/isso.md` | spec §4 | P1 |
+| Create Administrator guide | `docs/personas/administrator.md` | spec §8 | P1 |
+| Enhance ISSM guide with air-gapped notes + cross-links | `docs/guides/issm-guide.md` | spec §3, research.md R2 | P1 |
+| Enhance SCA guide with RBAC + evidence notes | `docs/guides/sca-guide.md` | spec §5, research.md R2 | P1 |
+| Enhance AO guide with portfolio view | `docs/guides/ao-quick-reference.md` | spec §6, research.md R2 | P1 |
+| Enhance Engineer guide with Kanban + IaC | `docs/guides/engineer-guide.md` | spec §7, research.md R2 | P1 |
+| Enhance Compliance Watch with air-gapped notes | `docs/guides/compliance-watch.md` | spec §13.4, research.md R2 | P1 |
+
+**Validation**: All persona pages render; each page conforms to `contracts/persona-guide.md` template. Cross-links resolve.
+
+**Estimated Tasks**: 8
+
+---
+
+### Phase 3: RMF Phase Pages (Workflow Reference)
+
+**Goal**: Create per-phase RMF workflow pages showing all persona responsibilities, gates, documents, and transitions.
+
+**Prerequisite**: Phase 2 complete (persona guides exist for cross-linking)
+
+| Task | File(s) | Source | Priority |
+|------|---------|--------|----------|
+| Create RMF overview | `docs/rmf-phases/index.md` | spec §10 | P1 |
+| Create Prepare page | `docs/rmf-phases/prepare.md` | spec §3.4 Phase 0 | P1 |
+| Create Categorize page | `docs/rmf-phases/categorize.md` | spec §3.4 Phase 1 | P1 |
+| Create Select page | `docs/rmf-phases/select.md` | spec §3.4 Phase 2 | P1 |
+| Create Implement page | `docs/rmf-phases/implement.md` | spec §3.4 Phase 3, §4.4, §7.4 | P1 |
+| Create Assess page | `docs/rmf-phases/assess.md` | spec §5.5, §4.4 | P1 |
+| Create Authorize page | `docs/rmf-phases/authorize.md` | spec §6.4 | P1 |
+| Create Monitor page | `docs/rmf-phases/monitor.md` | spec §3.4 Phase 6, §4.4 | P1 |
+
+**Validation**: All phase pages render; each conforms to `contracts/rmf-phase.md` template. Previous/Next links resolve. Gate conditions reference real tools.
+
+**Estimated Tasks**: 8
+
+---
+
+### Phase 4: Guides & Reference Pages (Depth Content)
+
+**Goal**: Create reference material — tool inventory, NL query catalog, document catalog, portfolio management, troubleshooting, and quick reference cards.
+
+**Prerequisite**: Phase 2 complete (persona guides exist for cross-linking from reference pages)
+
+| Task | File(s) | Source | Priority |
+|------|---------|--------|----------|
+| Create NL Query Reference | `docs/guides/nl-query-reference.md` | spec §12 | P1 |
+| Create Document Catalog | `docs/guides/document-catalog.md` | spec §11 | P1 |
+| Create Portfolio Management guide | `docs/guides/portfolio-management.md` | spec §9.4 | P1 |
+| Create Tool Inventory (114 tools) | `docs/reference/tool-inventory.md` | spec Appendix A | P1 |
+| Create Troubleshooting guide | `docs/reference/troubleshooting.md` | spec Appendix F | P1 |
+| Create Quick Reference Cards | `docs/reference/quick-reference-cards.md` | spec Appendix D | P2 |
+| Expand Glossary with new terms | `docs/reference/glossary.md` | spec Appendix C, research.md R2 | P2 |
+
+**Validation**: All reference pages render; tool names match codebase identifiers; troubleshooting covers 25+ scenarios. Pages conform to `contracts/reference.md`.
+
+**Estimated Tasks**: 7
+
+---
+
+### Phase 5: Scenarios, Polish & Validation (Final)
+
+**Goal**: Create end-to-end scenario, polish all cross-links, run full validation.
+
+**Prerequisite**: Phases 1–4 complete
+
+| Task | File(s) | Source | Priority |
+|------|---------|--------|----------|
+| Create full lifecycle scenario | `docs/scenarios/full-lifecycle.md` | spec Appendix B | P2 |
+| Validate all internal cross-links | All files | data-model.md Cross-Reference Map | P0 |
+| Run `mkdocs build --strict` and fix warnings | All files | quickstart.md | P0 |
+| Review all air-gapped callouts for consistency | Persona & RMF phase pages | spec clarification Q3 | P1 |
+| Verify tool name accuracy against codebase | Tool Inventory, persona guides | ComplianceMcpTools.cs | P1 |
+
+**Validation**: `mkdocs build --strict` produces zero warnings. All pages render correctly. Site is self-contained for `file://` browsing.
+
+**Estimated Tasks**: 5
+
+---
+
+## Phase Summary
+
+| Phase | Focus | Pages | Tasks | Priority |
+|-------|-------|-------|-------|----------|
+| 1 | Infrastructure & Onboarding | 9 | 9 | P0 |
+| 2 | Persona Guides | 8 | 8 | P1 |
+| 3 | RMF Phase Pages | 8 | 8 | P1 |
+| 4 | Guides & Reference | 7 | 7 | P1–P2 |
+| 5 | Scenarios & Validation | 1 + all | 5 | P0–P2 |
+| **Total** | | **33** | **37** | |
+
+## Constitution Re-Check (Post-Design)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Documentation as Source of Truth | **PASS** | All documentation lives in `docs/`, versioned in Git, single source of truth. |
+| III. Testing Standards | **PASS** | `mkdocs build --strict` validates all links and structure. Phase 5 includes explicit validation tasks. |
+| IV. Azure Government & Compliance First | **PASS** | Air-gapped callouts present in 4+ pages. `use_directory_urls: false` enables offline `file://` browsing. Self-contained `site/` bundle. |
+| VI. Code Quality & Maintainability | **PASS** | 4 page templates in `contracts/` enforce consistency. Cross-reference map ensures discoverability. |
+| VII. User Experience Consistency | **PASS** | Consistent navigation via MkDocs nav. Getting-started for each persona. Quick reference cards for at-a-glance lookup. |
+
+**Gate Result**: ✅ **PASS** — No violations after design phase. Proceed to task generation.

--- a/specs/016-user-documentation/quickstart.md
+++ b/specs/016-user-documentation/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Feature 016 — Documentation Site
+
+**Date**: 2026-02-28
+
+## Prerequisites
+
+- Python 3.9+
+- pip (Python package manager)
+
+## Install MkDocs
+
+```bash
+pip install mkdocs-material
+```
+
+This installs MkDocs, the Material theme, and all required extensions (admonition, pymdownx, etc.).
+
+## Serve Locally
+
+```bash
+# From repo root
+mkdocs serve
+```
+
+Opens at `http://127.0.0.1:8000`. Auto-reloads on file changes.
+
+## Build for Production
+
+```bash
+mkdocs build --strict
+```
+
+Generates static site in `site/` directory. The `--strict` flag fails on warnings (broken links, missing pages).
+
+## Build for Air-Gapped Delivery
+
+```bash
+mkdocs build --strict
+# The site/ directory is self-contained — no external CDN dependencies
+# Copy site/ to target environment and open index.html directly
+```
+
+Ensure `use_directory_urls: false` in `mkdocs.yml` so `file://` browsing works.
+
+## Validate Links
+
+```bash
+mkdocs build --strict 2>&1 | grep -i "warning\|error"
+```
+
+Any output indicates broken internal links or missing pages.
+
+## Content Authoring Workflow
+
+1. Create/edit Markdown files in `docs/`
+2. Run `mkdocs serve` to preview
+3. Add new pages to `nav:` section in `mkdocs.yml`
+4. Verify with `mkdocs build --strict`
+5. Commit and push
+
+## Page Template
+
+Every new page should follow this structure:
+
+```markdown
+# Page Title
+
+> One-line description of this page's purpose.
+
+---
+
+## Section Heading
+
+Content here. Use tables for structured data:
+
+| Column 1 | Column 2 |
+|----------|----------|
+| Data     | Data     |
+
+## Natural Language Queries
+
+> **"How do I...?"** → Tool: `tool_name` — Description of what happens.
+
+## See Also
+
+- [Related Page](../path/to/page.md)
+```
+
+## File Naming Conventions
+
+- Use lowercase with hyphens: `nl-query-reference.md`
+- Index files for sections: `getting-started/index.md`
+- Match existing conventions in `docs/guides/`

--- a/specs/016-user-documentation/research.md
+++ b/specs/016-user-documentation/research.md
@@ -1,0 +1,120 @@
+# Research: Feature 016 — Comprehensive User & Persona Documentation
+
+**Date**: 2026-02-28
+
+## Research Tasks
+
+### R1: Documentation Site Generator Selection
+
+**Decision**: MkDocs with Material theme
+
+**Rationale**:
+- MkDocs is Python-based, generates static HTML from Markdown — matches the existing `docs/` convention
+- Material for MkDocs provides: search, responsive navigation, dark/light mode, admonitions, tabs, code annotations
+- Static output works in air-gapped environments (serve from any web server, no runtime dependencies)
+- `mkdocs build --strict` provides validation (broken links, missing pages) as a quality gate
+- Alternative to DocFX (C#/.NET-native doc generator) was considered but rejected: DocFX is heavier, less flexible for pure Markdown sites, and has a smaller community for non-API docs
+
+**Alternatives Considered**:
+| Option | Rejected Because |
+|--------|-----------------|
+| DocFX | Better for API reference from XML docs; overkill for pure Markdown user guides |
+| Docusaurus | React-based; adds JS runtime dependency unnecessary for static docs |
+| Jekyll | Slower build times, Ruby dependency, less featureful search |
+| Hugo | Go-based; fast but less Markdown extension support than MkDocs Material |
+| Raw GitHub rendering | No search, no navigation structure, no offline bundle |
+
+### R2: Existing Documentation Inventory
+
+**Decision**: Preserve all existing files in-place; enhance with cross-links and air-gapped notes
+
+**Rationale**:
+- 15+ existing Markdown files across `docs/` already follow consistent conventions
+- Moving files would break any existing links/bookmarks
+- MkDocs `nav:` configuration can organize existing files into a coherent hierarchy without moving them
+- Existing guide format (H1 → blockquote tagline → `---`-separated sections → tables → fenced code) will be maintained for consistency
+
+**Inventory of Existing Docs**:
+
+| File | Lines | Content | Enhancement Needed |
+|------|-------|---------|-------------------|
+| `docs/getting-started.md` | 332 | Prerequisites, build, run modes | Redirect to new `getting-started/` section |
+| `docs/guides/issm-guide.md` | 726 | Full ISSM workflow (29 steps) | Add getting-started, air-gapped notes |
+| `docs/guides/sca-guide.md` | 189 | SCA assessment workflow | Add getting-started, RBAC constraints |
+| `docs/guides/ao-quick-reference.md` | 120+ | AO authorization decisions | Add getting-started, portfolio view |
+| `docs/guides/engineer-guide.md` | 222 | SSP authoring workflow | Add getting-started, Kanban remediation |
+| `docs/guides/compliance-watch.md` | 150+ | Monitoring, alerts, auto-remediation | Add air-gapped notes |
+| `docs/guides/remediation-kanban.md` | 200+ | Kanban board management | Add error scenarios |
+| `docs/guides/teams-bot-guide.md` | — | Teams bot setup | Preserve as-is |
+| `docs/guides/chat-app.md` | — | Chat app guide | Preserve as-is |
+| `docs/guides/knowledgebase.md` | — | Knowledge base guide | Preserve as-is |
+| `docs/reference/glossary.md` | — | Alphabetical glossary | Expand with new terms |
+| `docs/reference/rmf-process.md` | — | RMF process reference | Cross-link from rmf-phases/ |
+| `docs/reference/nist-controls.md` | — | NIST control reference | Preserve |
+| `docs/reference/nist-coverage.md` | — | Coverage report | Preserve |
+| `docs/reference/impact-levels.md` | — | IL reference | Preserve |
+| `docs/reference/stig-coverage.md` | — | STIG mapping | Preserve |
+| `docs/architecture/agent-tool-catalog.md` | — | Tool catalog | Source for tool-inventory.md |
+| `docs/architecture/overview.md` | — | Architecture overview | Preserve |
+| `docs/deployment.md` | — | Deployment guide | Preserve |
+
+### R3: New Pages Required
+
+**Decision**: 14 new pages needed to fulfill spec requirements
+
+| New Page | Source Spec Section | Priority |
+|----------|-------------------|----------|
+| `docs/index.md` | §1 Overview | P0 — Landing page |
+| `docs/getting-started/index.md` | §3.2, §4.2, §5.2, §6.2, §7.2 | P0 — Onboarding |
+| `docs/getting-started/issm.md` | §3.2 | P0 |
+| `docs/getting-started/isso.md` | §4.2 | P0 |
+| `docs/getting-started/sca.md` | §5.2 | P0 |
+| `docs/getting-started/ao.md` | §6.2 | P0 |
+| `docs/getting-started/engineer.md` | §7.2 | P0 |
+| `docs/personas/index.md` | §2 | P1 — Organization |
+| `docs/guides/portfolio-management.md` | §9.4 | P1 |
+| `docs/guides/document-catalog.md` | §11 | P1 |
+| `docs/guides/nl-query-reference.md` | §12 | P1 |
+| `docs/reference/tool-inventory.md` | §14 Appendix A | P1 |
+| `docs/reference/troubleshooting.md` | §14 Appendix F | P1 |
+| `docs/reference/quick-reference-cards.md` | §14 Appendix D | P2 |
+| `docs/scenarios/full-lifecycle.md` | §14 Appendix B | P2 |
+| `mkdocs.yml` | N/A (config) | P0 — Site configuration |
+
+### R4: Air-Gapped Documentation Delivery
+
+**Decision**: MkDocs `mkdocs build` produces a self-contained `site/` directory that can be served from any static web server or browsed locally via `file://` protocol
+
+**Rationale**:
+- No external CDN dependencies when using `--no-directory-urls` and bundling assets
+- Search index is a local JSON file — works offline
+- CSS and JS are bundled inline (Material theme support)
+- Can be distributed as a ZIP archive for air-gapped deployment
+
+### R5: MkDocs Configuration Best Practices
+
+**Decision**: Use Material theme with the following features
+
+**Configuration Choices**:
+| Feature | Setting | Rationale |
+|---------|---------|-----------|
+| Theme | `mkdocs-material` | Most popular MkDocs theme; search, nav, responsive |
+| Search | Built-in (lunr.js) | Client-side search, works offline |
+| Navigation | `nav:` with sections | Persona-based top-level, RMF phases second |
+| Tabs | `navigation.tabs` | Top-level sections as tabs |
+| TOC | `toc.integrate` | Integrate TOC into left navigation |
+| Content tabs | `content.tabs.link` | Linked tabs for multi-persona examples |
+| Admonitions | `admonition` extension | For air-gapped callouts (replaces blockquote convention) |
+| Code blocks | `pymdownx.highlight` | Syntax highlighting for NL query examples |
+| `use_directory_urls` | `false` | Enables offline browsing via `file://` |
+
+### R6: Content Migration Strategy
+
+**Decision**: In-place enhancement, not migration
+
+**Rationale**:
+- Existing `docs/guides/*.md` files are well-structured and actively used
+- MkDocs `nav:` can reference files in any subdirectory — no moves needed
+- New persona pages in `docs/personas/` will cross-link to existing guides via relative links
+- Getting-started pages will be new standalone files
+- Existing `docs/getting-started.md` will be updated to redirect to the new section

--- a/specs/016-user-documentation/spec.md
+++ b/specs/016-user-documentation/spec.md
@@ -1,0 +1,2305 @@
+# Feature 016: Comprehensive User & Persona Documentation
+
+**Created**: 2026-02-28
+**Status**: Feature Specification
+**Purpose**: Provide all-encompassing user documentation for ATO Copilot organized by persona, covering natural language interaction patterns, RMF phase workflows, document production, assessment guidance, and cross-persona collaboration.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Persona Definitions](#2-persona-definitions)
+3. [Persona 1: ISSM — Information System Security Manager](#3-persona-1-issm)
+4. [Persona 2: ISSO — Information System Security Officer](#4-persona-2-isso)
+5. [Persona 3: SCA — Security Control Assessor](#5-persona-3-sca)
+6. [Persona 4: AO — Authorizing Official](#6-persona-4-ao)
+7. [Persona 5: Platform Engineer / System Owner](#7-persona-5-platform-engineer)
+8. [Persona 6: Administrator](#8-persona-6-administrator)
+9. [Cross-Persona Collaboration Matrix](#9-cross-persona-collaboration-matrix)
+10. [RMF Phase Reference](#10-rmf-phase-reference)
+11. [Document Production Catalog](#11-document-production-catalog)
+12. [Natural Language Query Reference](#12-natural-language-query-reference)
+13. [Interface Guide](#13-interface-guide)
+14. [Appendices](#14-appendices)
+
+---
+
+## 1. Overview
+
+### 1.1 What Is ATO Copilot?
+
+ATO Copilot is an AI-powered assistant that guides DoD teams through every step of the NIST Risk Management Framework (RMF) — from system registration through continuous monitoring. It combines real Azure compliance scanning with RMF workflow automation, natural language interaction, and document generation.
+
+**ATO Copilot is NOT:**
+- A replacement for eMASS (it exports *to* eMASS)
+- A GRC platform (it is a productivity copilot)
+- A vulnerability scanner (it orchestrates Azure Policy + Defender for Cloud)
+
+**ATO Copilot IS:**
+- A copilot that knows the RMF process and guides users step by step
+- An assistant that has the full NIST 800-53 Rev 5 catalog embedded (1,000+ controls)
+- A scanner that queries real Azure infrastructure via Policy, Defender, and ARM APIs
+- A document generator that produces SSP, SAR, RAR, POA&M, and CRM from actual assessment data
+- A remediation tracker with Kanban boards linked to compliance findings
+- A continuous monitor that detects compliance drift and creates graduated alerts
+- A natural language interface where each persona sees information tailored to their role
+
+### 1.2 Supported Interfaces
+
+| Surface | Primary Users | How to Access |
+|---------|--------------|---------------|
+| **VS Code (GitHub Copilot Chat)** | Engineers, ISSOs | `@ato` participant with `/compliance`, `/knowledge`, `/config` slash commands |
+| **Microsoft Teams (M365 Bot)** | ISSMs, AOs, SCAs | Adaptive Cards for dashboards, assessments, approvals |
+| **MCP Server API** | All (via any MCP client) | REST + SSE + stdio transport — powers all surfaces above |
+| **CLI** | Engineers, ISSOs | Direct MCP tool invocations for scripting and automation |
+
+### 1.3 Applicable Standards
+
+| Standard | How ATO Copilot Uses It |
+|----------|------------------------|
+| DoDI 8510.01 | Defines the 7-step RMF lifecycle ATO Copilot implements |
+| NIST SP 800-37 Rev 2 | RMF framework including Step 0 (Prepare) |
+| NIST SP 800-53 Rev 5 | Full control catalog embedded (254K lines, sourced from OSCAL) |
+| NIST SP 800-60 Vol 1 & 2 | Information type catalog for FIPS 199 categorization |
+| FIPS 199 | Security categorization (C/I/A impact → Low/Moderate/High) |
+| CNSSI 1253 | DoD overlay controls mapped to Impact Levels (IL2–IL6) |
+| DISA STIGs | Technology-specific security configuration rules |
+| NIST SP 800-18 | SSP structure and required sections |
+| NIST SP 800-53A | Assessment procedures referenced by SAR generation |
+
+### 1.4 RBAC Roles
+
+ATO Copilot enforces role-based access control at every tool invocation. A user's role determines what they can do:
+
+| RBAC Role | Maps To | Access Level |
+|-----------|---------|-------------|
+| `Compliance.Administrator` | Administrator | Full infrastructure management, all tools |
+| `Compliance.SecurityLead` | ISSM | System registration, categorization, SSP, POA&M, ConMon, dashboards |
+| `Compliance.Analyst` | ISSO | Control narratives, evidence collection, remediation execution, monitoring |
+| `Compliance.Auditor` | SCA | Assessment, effectiveness determination, SAR/RAR generation (read-only enforcement — cannot modify system data) |
+| `Compliance.AuthorizingOfficial` | AO | Authorization decisions, risk acceptance, risk register (authorization-only permissions) |
+| `Compliance.PlatformEngineer` | Engineer | IaC scanning, STIG lookups, remediation tasks, evidence collection, narrative authoring |
+| `Compliance.Viewer` | Stakeholder | Read-only access to dashboards and reports |
+
+**Role Resolution**: CAC certificate → 4-tier chain: (1) explicit mapping by thumbprint, (2) Azure AD group membership, (3) Azure RBAC on subscription, (4) default to PlatformEngineer.
+
+---
+
+## Clarifications
+
+### Session 2026-02-28
+
+- Q: What is the primary documentation deliverable format? → A: Static documentation site (MkDocs or DocFX) generated from Markdown files in `docs/`.
+- Q: Should the documentation cover multi-system portfolio workflows? → A: Yes — include a dedicated "Portfolio Management" section covering multi-system workflows, bulk operations, and delegation.
+- Q: How should air-gapped/disconnected environment differences be documented? → A: Inline callouts within persona sections noting behavior differences per tool.
+- Q: Should the documentation include onboarding/getting-started guidance? → A: Yes — per-persona "Getting Started" subsection within each persona chapter (first-time setup, prerequisites, first 3 commands).
+- Q: Should error handling and troubleshooting be documented? → A: Yes — appendix organized by error category (RBAC, gates, connectivity, evidence, expiration) with resolution steps.
+
+---
+
+## 2. Persona Definitions
+
+### 2.1 RMF Role Assignments
+
+Each registered system has named personnel in specific RMF roles. These are tracked by ATO Copilot and linked to the RBAC system:
+
+| RMF Role | RBAC Mapping | Description |
+|----------|-------------|-------------|
+| **AuthorizingOfficial** | `Compliance.AuthorizingOfficial` | Senior official who accepts risk and grants ATO |
+| **ISSM** | `Compliance.SecurityLead` | Manages the security program for assigned systems |
+| **ISSO** | `Compliance.Analyst` | Implements and monitors security controls day-to-day |
+| **SCA** | `Compliance.Auditor` | Independent assessor of security control effectiveness |
+| **SystemOwner** | `Compliance.PlatformEngineer` | Program manager/engineer responsible for the system |
+
+### 2.2 Persona–RMF Phase Responsibility Matrix
+
+| RMF Phase | ISSM | ISSO | SCA | AO | Engineer |
+|-----------|------|------|-----|-----|----------|
+| **Prepare** | **Lead** | Support | — | Informed | Support |
+| **Categorize** | **Lead** | Support | — | Informed | Consulted |
+| **Select** | **Lead** | Support | Review | — | Consulted |
+| **Implement** | Oversight | **Lead** | — | — | **Lead** |
+| **Assess** | Support | Support | **Lead** | Informed | Support |
+| **Authorize** | Package prep | Support | SAR delivery | **Decide** | — |
+| **Monitor** | **Lead** | **Day-to-day** | Periodic assess | Escalation | Remediation |
+
+---
+
+## 3. Persona 1: ISSM — Information System Security Manager
+
+> *"The quarterback of the RMF process."*
+
+### 3.1 Role Summary
+
+The ISSM manages the security posture for one or more systems. They report to the AO, oversee ISSOs, own the authorization package, and coordinate the entire RMF lifecycle from registration through continuous monitoring.
+
+**RBAC Role**: `Compliance.SecurityLead`
+**Primary Interface**: Microsoft Teams, MCP API
+**Systems Managed**: One or more registered systems
+
+### 3.2 Getting Started (ISSM)
+
+**Prerequisites:**
+1. CAC enrolled with ATO Copilot (thumbprint mapped or Azure AD group membership as `Compliance.SecurityLead`)
+2. Azure subscription linked to ATO Copilot server
+3. Access to Microsoft Teams (primary) or MCP API client
+
+**First-Time Setup:**
+
+```
+Step 1: Verify your identity and role
+  → "What role am I logged in as?"
+  → Expected: Compliance.SecurityLead
+
+Step 2: Register your first system
+  → "Register a new system called 'My System' as a Major Application
+      in Azure Government"
+
+Step 3: View the system you just created
+  → "Show system details for {id}"
+```
+
+**What to do next:** Define the authorization boundary (§3.3 Phase 0), then assign RMF roles and advance through the lifecycle.
+
+### 3.3 Daily Activities
+- Track where each system is in the RMF lifecycle
+- Review compliance dashboards and trend reports
+- Coordinate remediation priorities across teams
+- Prepare authorization packages for the AO
+- Manage POA&M items and milestone deadlines
+- Respond to compliance alerts and significant changes
+- Brief leadership on security posture
+- Interface with eMASS for official record-keeping
+
+### 3.4 ISSM Workflow by RMF Phase
+
+#### Phase 0: Prepare
+
+**Goal**: Register the system, define its authorization boundary, assign roles, and establish the organizational baseline.
+
+**Natural Language Queries:**
+
+```
+Register a new system called 'ACME Portal' as a Major Application with
+mission-critical designation in Azure Government
+
+Define the authorization boundary for system {id} — add the production VMs,
+SQL database, and Key Vault
+
+Assign Jane Smith as ISSM and Bob Jones as ISSO for system {id}
+
+Show me all registered systems
+
+What roles are assigned to system {id}?
+
+Advance system {id} to the Categorize phase
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_register_system` | Creates system entity with initial RMF step = Prepare |
+| 2 | `compliance_define_boundary` | Adds Azure resource IDs to the authorization boundary |
+| 3 | `compliance_exclude_from_boundary` | Optionally excludes shared/inherited resources with rationale |
+| 4 | `compliance_assign_rmf_role` | Assigns AO, ISSM, ISSO, SCA, SystemOwner to the system |
+| 5 | `compliance_list_rmf_roles` | Verifies all required roles are assigned |
+| 6 | `compliance_advance_rmf_step` | Advances to Categorize (gate: ≥1 role + ≥1 boundary resource) |
+
+**Gate Conditions (Prepare → Categorize):**
+- At least one RMF role assigned to the system
+- At least one resource in the authorization boundary
+
+**Documents Produced**: None (informational artifacts only)
+
+---
+
+#### Phase 1: Categorize
+
+**Goal**: Perform FIPS 199 security categorization using SP 800-60 information types. Determine the C/I/A high-water mark and DoD Impact Level.
+
+**Natural Language Queries:**
+
+```
+Suggest information types for system {id} — it's a financial management
+and audit logging system
+
+Categorize system {id} with these information types:
+- Financial Management (C: Moderate, I: Moderate, A: Low)
+- Information Security (C: Moderate, I: High, A: Moderate)
+
+What is the current categorization for system {id}?
+
+What DoD Impact Level was derived for system {id}?
+
+Advance to the Select phase
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_suggest_info_types` | AI suggests SP 800-60 information types with confidence scores |
+| 2 | `compliance_categorize_system` | Applies information types, computes high-water mark, maps to DoD IL |
+| 3 | `compliance_get_categorization` | Reviews stored categorization and FIPS 199 notation |
+| 4 | `compliance_advance_rmf_step` | Advances to Select (gate: categorization exists + ≥1 info type) |
+
+**Key Outputs:**
+- FIPS 199 Notation: `SC System = {(confidentiality, MODERATE), (integrity, HIGH), (availability, MODERATE)}`
+- Overall Categorization: High (the maximum across C/I/A)
+- DoD Impact Level: IL5 (derived from categorization + NSS flag)
+- NIST Baseline: High (determined by overall categorization)
+
+**Documents Produced**: FIPS 199 Categorization Report (embedded in SSP)
+
+---
+
+#### Phase 2: Select
+
+**Goal**: Select the NIST 800-53 baseline, apply CNSSI 1253 overlay, tailor controls, declare inheritance, and generate the CRM.
+
+**Natural Language Queries:**
+
+```
+Select the control baseline for system {id} with CNSSI 1253 overlay
+
+How many controls are in the baseline for system {id}?
+
+Remove control PE-5 from the baseline — not applicable, system is 100%
+cloud-hosted with no physical media
+
+Set AC-1 as inherited from Azure Government FedRAMP High
+
+Set AC-2 as shared with Azure Government — customer configures access
+policies and reviews accounts quarterly
+
+Generate the Customer Responsibility Matrix for system {id}
+
+Show me the STIG mappings for AC-2
+
+Advance to the Implement phase
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_select_baseline` | Selects Low/Moderate/High baseline, optionally applies CNSSI 1253 overlay |
+| 2 | `compliance_tailor_baseline` | Adds/removes controls with documented rationale |
+| 3 | `compliance_set_inheritance` | Marks controls as Inherited/Shared/Customer with provider info |
+| 4 | `compliance_get_baseline` | Reviews baseline with tailoring and inheritance |
+| 5 | `compliance_generate_crm` | Generates Customer Responsibility Matrix grouped by family |
+| 6 | `compliance_show_stig_mapping` | Shows DISA STIG IDs mapped to NIST controls |
+| 7 | `compliance_advance_rmf_step` | Advances to Implement (gate: baseline exists) |
+
+**Baseline Control Counts:**
+- Low: ~152 controls (IL2)
+- Moderate: ~329 controls (IL4)
+- High: ~400 controls (IL5/IL6)
+
+**Inheritance Types:**
+| Type | Meaning | SSP Narrative |
+|------|---------|---------------|
+| **Inherited** | Fully satisfied by CSP (e.g., physical security) | Auto-populated standard statement |
+| **Shared** | Partially CSP, partially customer | Requires customer responsibility documentation |
+| **Customer** | Entirely the customer's responsibility | Requires full human-authored narrative |
+
+**Documents Produced**: Customer Responsibility Matrix (CRM)
+
+---
+
+#### Phase 3: Implement (ISSM Oversight)
+
+**Goal**: Oversee SSP authoring, track narrative completion, and generate the formal SSP document.
+
+**Natural Language Queries:**
+
+```
+What's the SSP completion status for system {id}?
+
+Show narrative progress for the AC family
+
+Generate the System Security Plan for system {id}
+
+Generate the SSP as PDF
+
+Generate SSP using our custom DISA template
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_narrative_progress` | Tracks per-family completion % (inherited auto-filled, customer pending) |
+| 2 | `compliance_generate_ssp` | Generates formal SSP with system info, categorization, baseline, all narratives |
+| 3 | `compliance_advance_rmf_step` | Advances to Assess (advisory gate — no hard block) |
+
+**Documents Produced**: System Security Plan (SSP) — Markdown, PDF, or DOCX
+
+---
+
+#### Phase 4: Assess (ISSM Support)
+
+**Goal**: Support the SCA during assessment by managing POA&M items and preparing the authorization package.
+
+**Natural Language Queries:**
+
+```
+Create a POA&M item for the missing MFA finding on IA-2(1) — assign to
+John Smith, due June 30
+
+List overdue POA&M items for system {id}
+
+Show all CAT I POA&M items
+
+Generate the Risk Assessment Report for system {id}
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_create_poam` | Creates formal POA&M with milestones, CAT severity, POC, resources |
+| 2 | `compliance_list_poam` | Lists POA&M items with status/severity/overdue filters |
+| 3 | `compliance_generate_rar` | Generates RAR with per-family risk breakdown and aggregate risk level |
+
+**Documents Produced**: Plan of Action & Milestones (POA&M), Risk Assessment Report (RAR)
+
+---
+
+#### Phase 5: Authorize (ISSM Package Preparation)
+
+**Goal**: Bundle the complete authorization package and deliver it to the AO for decision.
+
+**Natural Language Queries:**
+
+```
+Bundle the authorization package for system {id} including evidence
+
+What documents are ready for the authorization package?
+
+Show the risk register for system {id}
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_bundle_authorization_package` | Bundles SSP + SAR + RAR + POA&M + CRM + ATO Letter |
+| 2 | `compliance_show_risk_register` | Reviews all active/expired risk acceptances |
+
+**Authorization Package Contents:**
+
+| Document | Source | Required |
+|----------|--------|----------|
+| System Security Plan (SSP) | `compliance_generate_ssp` | Yes |
+| Security Assessment Report (SAR) | `compliance_generate_sar` | Yes |
+| Risk Assessment Report (RAR) | `compliance_generate_rar` | Yes |
+| Plan of Action & Milestones (POA&M) | `compliance_create_poam` / `compliance_list_poam` | Yes |
+| Customer Responsibility Matrix (CRM) | `compliance_generate_crm` | Yes |
+| ATO Letter | Generated from authorization decision | After AO decision |
+
+**Documents Produced**: Authorization Package (bundled ZIP)
+
+---
+
+#### Phase 6: Monitor
+
+**Goal**: Establish continuous monitoring, generate periodic reports, track ATO expiration, detect significant changes, manage reauthorization triggers, and maintain the portfolio dashboard.
+
+**Natural Language Queries:**
+
+```
+Create a ConMon plan for system {id} with monthly assessments and annual
+review on June 15
+
+Generate a monthly ConMon report for system {id}, period 2026-02
+
+Check ATO expiration for system {id}
+
+Report a significant change for system {id}: New Interconnection — added
+VPN tunnel to partner organization
+
+Check reauthorization triggers for system {id}
+
+Show the multi-system compliance dashboard
+
+Show all systems with expired ATOs
+
+Send a notification about the expiration alert for system {id}
+
+Export system {id} data to eMASS format
+
+Export OSCAL JSON for system {id}
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_create_conmon_plan` | Creates/updates ConMon plan with frequency, review date, distribution |
+| 2 | `compliance_generate_conmon_report` | Generates report with score delta, findings, POA&M status, Watch data |
+| 3 | `compliance_track_ato_expiration` | Checks expiration with graduated alerts (90d/60d/30d/expired) |
+| 4 | `compliance_report_significant_change` | Records change, flags for reauthorization if applicable |
+| 5 | `compliance_reauthorization_workflow` | Checks triggers (expiration, significant changes, score drift) |
+| 6 | `compliance_multi_system_dashboard` | Portfolio view: all systems with IL, RMF step, auth status, score |
+| 7 | `compliance_send_notification` | Delivers alerts via Teams/VS Code/alert pipeline |
+| 8 | `compliance_export_emass` | Exports to eMASS-compatible Excel format |
+| 9 | `compliance_export_oscal` | Exports in OSCAL v1.0.6 JSON format |
+
+**Expiration Alert Levels:**
+
+| Days Remaining | Alert Level | Severity | Action Required |
+|----------------|-------------|----------|-----------------|
+| ≤ 90 days | Info | Low | Begin reauthorization planning |
+| ≤ 60 days | Warning | Medium | Submit reauthorization package |
+| ≤ 30 days | Urgent | High | Escalate to AO immediately |
+| Expired | Expired | Critical | System operating without authorization |
+
+**Significant Change Types (Built-in):**
+1. New Interconnection
+2. Major Upgrade
+3. Data Type Change
+4. Architecture Change
+5. Security Policy Change
+6. Boundary Change
+7. Key Personnel Change
+8. Incident Response
+9. Compliance Drop
+10. Configuration Drift (auto-detected by Watch service)
+
+**Documents Produced**: ConMon Reports (monthly/quarterly/annual), Reauthorization Package
+
+> **🔒 Air-Gapped Note (Monitor Phase)**: In disconnected environments:
+> - `compliance_export_emass` generates the Excel file locally — manual transfer to eMASS via removable media is required.
+> - `compliance_send_notification` is limited to local channels (VS Code, audit log); external email/webhook notifications are unavailable.
+> - `compliance_export_oscal` works fully offline (file generation only).
+> - Watch event-driven monitoring requires network to Azure Policy/Defender — use scheduled-only mode with local policy cache.
+
+---
+
+### 3.5 ISSM Complete Workflow Summary
+
+```
+ 1. compliance_register_system            ← Register the system
+ 2. compliance_define_boundary            ← Define authorization boundary
+ 3. compliance_assign_rmf_role            ← Assign all required RMF roles
+ 4. compliance_advance_rmf_step           ← Prepare → Categorize
+ 5. compliance_suggest_info_types         ← Get AI-suggested info types
+ 6. compliance_categorize_system          ← FIPS 199 categorization
+ 7. compliance_advance_rmf_step           ← Categorize → Select
+ 8. compliance_select_baseline            ← Select NIST 800-53 baseline
+ 9. compliance_tailor_baseline            ← Add/remove controls
+10. compliance_set_inheritance            ← Declare inheritance
+11. compliance_generate_crm              ← Generate CRM
+12. compliance_advance_rmf_step           ← Select → Implement
+13. compliance_batch_populate_narratives  ← Auto-fill inherited narratives
+14. compliance_narrative_progress         ← Track SSP completion
+15. compliance_generate_ssp              ← Generate System Security Plan
+16. compliance_advance_rmf_step           ← Implement → Assess
+17. (SCA performs assessment — see §5)
+18. compliance_create_poam               ← Create POA&M items
+19. compliance_generate_rar              ← Generate RAR
+20. compliance_bundle_authorization_package ← Bundle for AO
+21. compliance_advance_rmf_step           ← Assess → Authorize
+22. (AO issues decision — see §6)
+23. compliance_advance_rmf_step           ← Authorize → Monitor
+24. compliance_create_conmon_plan         ← Establish ConMon plan
+25. compliance_generate_conmon_report     ← Periodic reports
+26. compliance_track_ato_expiration       ← Monitor expiration
+27. compliance_report_significant_change  ← Report changes
+28. compliance_multi_system_dashboard     ← Portfolio oversight
+29. compliance_export_emass              ← eMASS sync
+```
+
+---
+
+## 4. Persona 2: ISSO — Information System Security Officer
+
+> *"Day-to-day security operations — the hands on the keyboard."*
+
+### 4.1 Role Summary
+
+The ISSO implements and monitors security controls under ISSM oversight. They write SSP narratives, collect evidence, manage Watch monitoring, handle alerts, and coordinate remediation with engineers.
+
+**RBAC Role**: `Compliance.Analyst`
+**Primary Interface**: VS Code (`@ato`), Microsoft Teams
+**Reports to**: ISSM
+
+### 4.2 Getting Started (ISSO)
+
+**Prerequisites:**
+1. CAC enrolled with `Compliance.Analyst` role
+2. Assigned as ISSO to one or more systems by the ISSM (via `compliance_assign_rmf_role`)
+3. VS Code with GitHub Copilot Chat extension installed (primary interface)
+
+**First-Time Setup:**
+
+```
+Step 1: Verify your role and system assignments
+  → @ato "What systems am I assigned to?"
+  → Expected: List of systems where you are ISSO
+
+Step 2: Check the current RMF phase for your system
+  → @ato "Show system details for {id}"
+
+Step 3: Start your primary workflow
+  If Implement phase → "Show narrative progress for system {id}"
+  If Monitor phase  → "Show monitoring status for all subscriptions"
+```
+
+**What to do next:** If the system is in Implement phase, begin authoring narratives (§4.3 Phase 3). If in Monitor phase, enable Watch monitoring (§4.3 Phase 6).
+
+### 4.3 Daily Activities
+- Write and review control implementation narratives
+- Collect evidence from Azure infrastructure
+- Monitor compliance Watch alerts and triage new findings
+- Coordinate remediation tasks with engineers on Kanban boards
+- Respond to drift alerts and configuration changes
+- Run periodic compliance assessments
+- Ensure monitoring is enabled and properly configured
+
+### 4.4 ISSO Workflow by RMF Phase
+
+#### Phase 3: Implement (ISSO Lead)
+
+**Goal**: Author SSP control narratives, batch-populate inherited controls, and get AI-assisted suggestions for customer controls.
+
+**Natural Language Queries:**
+
+```
+Auto-populate the inherited control narratives for system {id}
+
+Suggest a narrative for AC-2 on system {id}
+
+Write the narrative for AC-2: "Account management is implemented using
+Azure Active Directory with conditional access policies..."
+
+What's the narrative completion for the SC family?
+
+Show all controls missing narratives for system {id}
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_batch_populate_narratives` | Auto-fills inherited/shared controls (~40-60% coverage) |
+| 2 | `compliance_suggest_narrative` | AI-generated draft for customer controls (confidence score included) |
+| 3 | `compliance_write_narrative` | Write/update narrative with status (Implemented/Partial/Planned/N-A) |
+| 4 | `compliance_narrative_progress` | Track per-family completion → target 100% |
+
+**AI Suggestion Confidence Levels:**
+| Score | Meaning | Action |
+|-------|---------|--------|
+| ≥ 0.85 | High confidence (inherited controls) | Review and accept |
+| 0.70–0.84 | Good confidence (shared controls) | Review and customize |
+| 0.50–0.69 | Moderate confidence (customer controls) | Significant review needed |
+| < 0.50 | Low confidence — flagged | Write manually |
+
+> **🔒 Air-Gapped Note**: In disconnected environments, `compliance_suggest_narrative` and `compliance_batch_populate_narratives` (AI-generated suggestions) are unavailable. Write all narratives manually using `compliance_write_narrative`. Inherited control narratives can still be auto-populated from the embedded control catalog (no network required).
+
+---
+
+#### Phase 4: Assess (ISSO Support)
+
+**Goal**: Collect evidence, support the SCA during assessment, and assist with finding remediation.
+
+**Natural Language Queries:**
+
+```
+Collect evidence for the AC family on subscription {sub-id}
+
+Run a compliance assessment on subscription {sub-id}
+
+Show me all critical findings from the last assessment
+
+Create a remediation board from the latest assessment
+
+Assign task REM-003 to engineer Bob Jones
+
+Fix alert ALT-12345 with dry run first
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_collect_evidence` | Collects Azure resource evidence with SHA-256 hashing |
+| 2 | `compliance_assess` | Runs NIST 800-53 compliance assessment (policy + Defender + ARM) |
+| 3 | `kanban_create_board` | Creates Kanban board from assessment findings |
+| 4 | `kanban_assign_task` | Assigns remediation tasks to engineers |
+| 5 | `watch_fix_alert` | Remediates findings with dry-run safety |
+
+---
+
+#### Phase 6: Monitor (ISSO Day-to-Day)
+
+**Goal**: Manage continuous monitoring, triage alerts, maintain baselines, and handle auto-remediation.
+
+**Natural Language Queries:**
+
+```
+Enable daily monitoring for subscription {sub-id}
+
+Show monitoring status for all subscriptions
+
+Show all critical alerts from the last 7 days
+
+Acknowledge alert ALT-12345
+
+What drifted this week?
+
+Show me the compliance trend for subscription {sub-id}
+
+Configure auto-remediation for Low severity drift alerts
+
+Show alert statistics for the last 30 days
+
+Set quiet hours from 22:00 to 06:00 on weekdays
+
+Configure escalation: if Critical alert is not acknowledged in 30 minutes,
+notify the ISSM
+```
+
+**Watch Monitoring Tools:**
+
+| Tool | Purpose |
+|------|---------|
+| `watch_enable_monitoring` | Enable scheduled/event-driven/combined monitoring |
+| `watch_disable_monitoring` | Disable monitoring for a subscription |
+| `watch_configure_monitoring` | Update frequency or mode |
+| `watch_monitoring_status` | View all monitoring configurations |
+| `watch_show_alerts` | List alerts with severity/status/family/time filters |
+| `watch_get_alert` | Full alert details with history and correlations |
+| `watch_acknowledge_alert` | Acknowledge (pauses SLA escalation) |
+| `watch_fix_alert` | Remediate with optional dry-run |
+| `watch_dismiss_alert` | Dismiss false positive (requires justification, officer only) |
+| `watch_create_rule` | Create custom alert rules |
+| `watch_list_rules` | List active alert rules |
+| `watch_suppress_alerts` | Suppress alert patterns with expiration |
+| `watch_configure_quiet_hours` | Set notification quiet hours |
+| `watch_configure_notifications` | Configure channels (Chat, Email, Webhook) |
+| `watch_configure_escalation` | Define escalation paths for SLA violations |
+
+**Alert Lifecycle States:**
+
+```
+New → Acknowledged → InProgress → Resolved
+  ↓        ↓
+Dismissed  Escalated (SLA violation)
+```
+
+| State | Description | SLA Timer |
+|-------|-------------|-----------|
+| **New** | Alert created, awaiting triage | Running |
+| **Acknowledged** | Team aware, triaging | Paused |
+| **InProgress** | Remediation underway | Paused |
+| **Resolved** | Finding fixed and verified | Stopped |
+| **Dismissed** | False positive (justification required) | Stopped |
+| **Escalated** | SLA violated, escalated per configured path | Escalation timer |
+
+**SLA Due Dates by Severity:**
+| Severity | Due Date | Escalation |
+|----------|----------|------------|
+| Critical | 24 hours | After 30 minutes unacknowledged |
+| High | 7 days | After 4 hours unacknowledged |
+| Medium | 30 days | After 24 hours unacknowledged |
+| Low | 90 days | After 7 days unacknowledged |
+
+---
+
+## 5. Persona 3: SCA — Security Control Assessor
+
+> *"Independent assessor — can observe and evaluate, never modify."*
+
+### 5.1 Role Summary
+
+The SCA independently evaluates whether controls are implemented and effective. They cannot implement or fix controls — only assess. They produce the SAR and RAR, and their effectiveness determinations feed the AO's authorization decision.
+
+**RBAC Role**: `Compliance.Auditor` (read-only enforcement — cannot modify system data)
+**Primary Interface**: Microsoft Teams, MCP API
+**Independence**: Must be organizationally independent from the implementation team
+
+### 5.2 Getting Started (SCA)
+
+**Prerequisites:**
+1. CAC enrolled with `Compliance.Auditor` role
+2. Assigned as SCA to one or more systems by the ISSM
+3. Organizationally independent from the implementation team (per DoDI 8510.01)
+4. Access to Microsoft Teams or MCP API client
+
+**First-Time Setup:**
+
+```
+Step 1: Verify your identity and read-only role
+  → "What role am I logged in as?"
+  → Expected: Compliance.Auditor
+
+Step 2: Review the system's SSP before assessment
+  → "Show narrative progress for system {id}"
+  → "Show the baseline for system {id}"
+
+Step 3: Begin your first assessment
+  → "Assess control AC-1 as Satisfied using the Examine method —
+      policy document reviewed and current"
+```
+
+**What to do next:** Systematically assess each control (§5.4), take snapshots, and generate SAR.
+
+> ⚠️ **Important**: As SCA you have read-only access. You cannot modify narratives, fix findings, or issue authorization decisions. If you attempt a write operation, ATO Copilot will return an RBAC denial with explanation.
+
+### 5.3 Assessment Methods
+
+| Method | When to Use | Examples |
+|--------|-------------|---------|
+| **Test** | Execute procedures, observe behavior, validate configurations | Run scans, test access controls, verify encryption |
+| **Interview** | Question personnel about policies, procedures, practices | Ask admin about account review process |
+| **Examine** | Review documentation, logs, configuration artifacts | Review SSP, audit logs, policy documents |
+
+> **🔒 Air-Gapped Note (SCA)**: All assessment tools (`compliance_assess_control`, `compliance_take_snapshot`, `compliance_verify_evidence`, `compliance_compare_snapshots`, `compliance_generate_sar`, `compliance_generate_rar`) work fully offline — they operate on locally stored assessment data. Evidence collection (`compliance_collect_evidence`) requires network access to Azure resources; in air-gapped environments, evidence must be imported from prior scans or manual artifact uploads.
+
+### 5.4 DoD CAT Severity Mapping
+
+| CAT Level | Severity | Impact | Examples |
+|-----------|----------|--------|----------|
+| **CAT I** | Critical/High | Direct loss of C/I/A — immediate exploitation risk | Missing encryption, no access control enforcement |
+| **CAT II** | Medium | Potential for system compromise | Weak password policies, incomplete logging |
+| **CAT III** | Low | Administrative or documentation gaps | Missing audit review procedures, incomplete labels |
+
+### 5.5 SCA Workflow — Phase 4: Assess
+
+**Goal**: Assess each control's effectiveness, collect and verify evidence, produce immutable snapshots, and generate the SAR.
+
+**Natural Language Queries:**
+
+```
+Assess control AC-2 as Satisfied using the Test method — account
+management procedures verified against STIG checklist
+
+Assess control AC-3 as Other Than Satisfied, CAT II — mandatory access
+control checks missing for privileged operations
+
+Take an assessment snapshot for system {id}
+
+Verify evidence {evidence-id} hasn't been tampered with
+
+Check evidence completeness for system {id} on the AC family
+
+Compare snapshot {snap-1} with snapshot {snap-2} to see remediation progress
+
+Generate the Security Assessment Report for system {id}
+
+Generate the Risk Assessment Report for system {id}
+
+Show controls with missing evidence
+
+What's the overall compliance score?
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_assess_control` | Record per-control determination (Satisfied / OtherThanSatisfied + CAT) |
+| 2 | `compliance_take_snapshot` | Create immutable SHA-256-hashed snapshot of assessment state |
+| 3 | `compliance_verify_evidence` | Recompute hash → verified or tampered |
+| 4 | `compliance_check_evidence_completeness` | Per-control evidence coverage report |
+| 5 | `compliance_compare_snapshots` | Before/after comparison showing score delta and changes |
+| 6 | `compliance_generate_sar` | Generate SAR with executive summary, CAT breakdown, per-family results |
+| 7 | `compliance_generate_rar` | Generate RAR with residual risk determination |
+
+**SAR Contents:**
+1. Executive Summary — system, assessor, overall score, finding counts
+2. CAT Severity Breakdown — CAT I/II/III counts with risk categorization
+3. Control Family Results — per-family pass/fail with CAT mapping
+4. Risk Summary — assessment-to-authorization risk posture
+5. Detailed Findings — per-control determination details
+
+**Typical SCA Assessment Cycle:**
+
+```
+ 1. compliance_assess_control       ← Assess each control (batch)
+ 2. compliance_take_snapshot        ← Snapshot current state
+ 3. compliance_verify_evidence      ← Spot-check evidence integrity
+ 4. compliance_check_evidence_completeness ← Verify coverage
+ 5. compliance_generate_sar         ← Generate SAR
+    ── (Remediation occurs) ──
+ 6. compliance_assess_control       ← Re-assess remediated controls
+ 7. compliance_take_snapshot        ← Snapshot after remediation
+ 8. compliance_compare_snapshots    ← Show improvement
+ 9. compliance_generate_sar         ← Updated SAR for AO decision
+10. compliance_generate_rar         ← Final RAR
+```
+
+**Documents Produced**: Security Assessment Report (SAR), Risk Assessment Report (RAR), Assessment Snapshots
+
+### 5.6 SCA RBAC Constraints
+
+| Tool | Access |
+|------|--------|
+| `compliance_assess_control` | **Allowed** — SCA's primary function |
+| `compliance_take_snapshot` | **Allowed** — creates immutable records |
+| `compliance_verify_evidence` | **Allowed** — evidence integrity verification |
+| `compliance_check_evidence_completeness` | **Allowed** — coverage reporting |
+| `compliance_compare_snapshots` | **Allowed** — trend analysis |
+| `compliance_generate_sar` | **Allowed** — SAR generation |
+| `compliance_generate_rar` | **Allowed** — RAR generation |
+| `compliance_write_narrative` | **DENIED** — SCA cannot modify SSP |
+| `compliance_remediate` | **DENIED** — SCA cannot fix findings |
+| `compliance_issue_authorization` | **DENIED** — only AO can authorize |
+| `watch_dismiss_alert` | **DENIED** — cannot dismiss alerts |
+
+---
+
+## 6. Persona 4: AO — Authorizing Official
+
+> *"Infrequent interaction, most consequential decisions."*
+
+### 6.1 Role Summary
+
+The AO is a senior leader (typically O-6/GS-15+) who accepts risk and signs the authorization decision. They interact with ATO Copilot infrequently but make the highest-stakes decisions: granting or denying authorization to operate.
+
+**RBAC Role**: `Compliance.AuthorizingOfficial` (dedicated role — separated from Administrator for separation of duties per DoDI 8510.01)
+**Primary Interface**: Microsoft Teams (Adaptive Cards)
+**Decision Authority**: Authorization decisions, risk acceptance
+
+### 6.2 Getting Started (AO)
+
+**Prerequisites:**
+1. CAC enrolled with `Compliance.AuthorizingOfficial` role (typically provisioned by Administrator)
+2. Designated as AO for one or more systems
+3. Access to Microsoft Teams (primary — Adaptive Cards for authorization decisions)
+
+**First-Time Setup:**
+
+```
+Step 1: Verify your role
+  → "What role am I logged in as?"
+  → Expected: Compliance.AuthorizingOfficial
+
+Step 2: View your portfolio
+  → "Show the multi-system compliance dashboard"
+
+Step 3: Review an authorization package
+  → "Show the authorization package summary for system {id}"
+```
+
+**What to do next:** When the ISSM delivers an authorization package, review the SAR/RAR, evaluate residual risk, and issue your decision (§6.4).
+
+### 6.3 Authorization Decision Types
+
+| Type | Description | Expiration | System State After |
+|------|-------------|------------|-------------------|
+| **ATO** | Authority to Operate — full authorization | Required (typically 3 years) | Monitor phase |
+| **ATOwC** | ATO with Conditions — authorization with stipulations | Required | Monitor phase (conditions tracked) |
+| **IATT** | Interim Authority to Test — limited testing only | Required (typically 6 months) | Monitor phase (limited scope) |
+| **DATO** | Denial of Authorization — system cannot operate | None | Read-only mode, advancement blocked |
+
+### 6.4 AO Workflow — Phase 5: Authorize
+
+**Goal**: Review the authorization package, evaluate residual risk, make the authorization decision, and accept risk on specific findings.
+
+**Natural Language Queries:**
+
+```
+Show the authorization package summary for system {id}
+
+What's the compliance score and finding breakdown for system {id}?
+
+Issue an ATO for system {id} expiring January 15, 2028 with Low residual
+risk — all CAT I findings remediated, 2 CAT III findings accepted
+
+Issue an ATO with conditions for system {id} — MFA enforcement must be
+completed within 90 days, quarterly POA&M reviews required
+
+Accept risk on finding {finding-id} for control CM-6 (CAT III) — configuration
+deviation documented and approved, compensating control: continuous
+monitoring alerts configured, expires December 31, 2026
+
+Deny authorization for system {id} — 3 unmitigated CAT I findings with no
+remediation plan
+
+Show the risk register for system {id}
+
+What risks have I accepted that are expiring soon?
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_bundle_authorization_package` | Review bundled package (SSP + SAR + RAR + POA&M + CRM) |
+| 2 | `compliance_show_risk_register` | Review existing risk acceptances |
+| 3 | `compliance_issue_authorization` | Issue ATO/ATOwC/IATT/DATO decision |
+| 4 | `compliance_accept_risk` | Accept risk on individual findings post-decision |
+
+**Key Authorization Behaviors:**
+- **Supersedes prior decisions**: Any existing active authorization is automatically deactivated
+- **Compliance score captured**: Score at decision time is recorded permanently
+- **RMF advancement**: System moves to Monitor phase on ATO/ATOwC/IATT
+- **Open findings recorded**: All open findings at decision time are captured in the record
+- **DATO effects**: System enters read-only mode, generates persistent alert, blocks RMF advancement
+
+**Risk Acceptance Lifecycle:**
+1. AO accepts risk with justification + compensating control + expiration date
+2. Risk acceptance is active → finding severity is documented but accepted
+3. Expiration date arrives → acceptance auto-expires, finding reverts to active
+4. Linked POA&M items revert from `RiskAccepted` to `Ongoing`
+5. Alert sent to both AO and ISSM
+
+**Documents Produced**: Authorization Decision Letter, Risk Acceptance Memorandum, Terms & Conditions
+
+### 6.5 AO in Monitor Phase
+
+The AO receives escalated alerts and expiration notifications:
+
+```
+Show all systems with ATOs expiring in the next 90 days
+
+Show the compliance dashboard — filter to my authorized systems
+
+What significant changes have been reported for system {id}?
+```
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_multi_system_dashboard` | Portfolio view of all authorized systems |
+| `compliance_track_ato_expiration` | Graduated expiration alerts |
+| `compliance_reauthorization_workflow` | Check triggers and initiate reauthorization |
+| `compliance_show_risk_register` | Review accepted risks approaching expiration |
+
+---
+
+## 7. Persona 5: Platform Engineer / System Owner
+
+> *"Fix the findings, implement the controls, prove it works."*
+
+### 7.1 Role Summary
+
+The engineer builds and operates the system being authorized. They implement controls, fix findings, write IaC, and collect evidence. They often have limited security background and need guidance in terms of their specific technology stack (Azure, Terraform, Kubernetes).
+
+**RBAC Role**: `Compliance.PlatformEngineer`
+**Primary Interface**: VS Code (`@ato` participant)
+**Reports to**: ISSO (operational), ISSM (oversight)
+
+### 7.2 Getting Started (Engineer)
+
+**Prerequisites:**
+1. CAC enrolled with `Compliance.PlatformEngineer` role (default if no explicit mapping)
+2. VS Code with GitHub Copilot Chat extension installed
+3. Azure subscription access for the system being authorized
+
+**First-Time Setup:**
+
+```
+Step 1: Verify your role
+  → @ato "What role am I logged in as?"
+  → Expected: Compliance.PlatformEngineer
+
+Step 2: Check your assigned tasks
+  → @ato "Show my assigned remediation tasks"
+
+Step 3: Learn about your first control
+  → @ato /knowledge "What does AC-2 mean for Azure?"
+```
+
+**What to do next:** If you have Kanban tasks, start fixing findings (§7.4 Phase 4). If in Implement phase, begin writing narratives (§7.4 Phase 3).
+
+### 7.3 Daily Activities
+- Write Infrastructure as Code (Bicep/Terraform/ARM) and deploy infrastructure
+- Implement security configurations per STIG requirements
+- Fix compliance findings assigned via Kanban board
+- Collect evidence proving fixes work
+- Write control implementation narratives (with AI assistance)
+- Run IaC compliance scans before deploying
+
+### 7.4 Engineer Workflow by RMF Phase
+
+#### Phase 3: Implement (Engineer Lead)
+
+**Goal**: Implement controls, write narratives, scan IaC for compliance, and apply STIG configurations.
+
+**Natural Language Queries:**
+
+```
+What does NIST control AC-2 mean for Azure?
+
+Show STIG findings for Azure SQL Database
+
+Scan my Bicep file for compliance issues
+
+What's the suggested fix for this STIG finding?
+
+Suggest a narrative for control SC-7 on system {id}
+
+Write the narrative for SC-7: "Network boundary protection is implemented
+using Azure Firewall with default-deny rules..."
+
+Auto-populate inherited control narratives for system {id}
+
+What controls still need narratives?
+```
+
+**Tool Sequence:**
+
+| Step | Tool | What Happens |
+|------|------|-------------|
+| 1 | `compliance_batch_populate_narratives` | Auto-fill inherited controls (~40-60% coverage) |
+| 2 | `compliance_suggest_narrative` | AI draft for customer controls with confidence score |
+| 3 | `compliance_write_narrative` | Write/update narrative (Implemented/Partial/Planned/N-A) |
+| 4 | `compliance_narrative_progress` | Track completion per-family |
+| 5 | `compliance_show_stig_mapping` | Look up STIG rules mapped to NIST controls |
+
+**VS Code Integration:**
+- **IaC Diagnostics**: Compliance findings appear as squiggly underlines (CAT I/II → Error, CAT III → Warning)
+- **Quick Fix**: Lightbulb Code Actions to apply suggested fixes from STIG findings
+- **Hover Info**: Shows NIST control + STIG rule + CAT severity on hover
+
+---
+
+#### Phase 4: Assess (Engineer Support — Remediation)
+
+**Goal**: Fix compliance findings, execute remediation scripts, validate fixes, and collect evidence.
+
+**Natural Language Queries:**
+
+```
+Show my assigned remediation tasks
+
+Show task REM-005 details
+
+Move REM-005 to In Progress
+
+Fix task REM-005 with dry run first
+
+Fix task REM-005
+
+Validate task REM-005 — check if the fix worked
+
+Collect evidence for task REM-005
+
+Move REM-005 to In Review
+
+Show all overdue tasks assigned to me
+```
+
+**Kanban Remediation Tools:**
+
+| Tool | Purpose |
+|------|---------|
+| `kanban_board_show` | View board overview with task counts per column |
+| `kanban_task_list` | List/filter tasks (severity, assignee, family, status) |
+| `kanban_get_task` | Full task detail with control ID, resources, script, history |
+| `kanban_move_task` | Move task between columns (status transitions) |
+| `kanban_remediate_task` | Execute remediation script for a task |
+| `kanban_task_validate` | Re-scan resources to verify remediation |
+| `kanban_collect_evidence` | Collect compliance evidence for a task |
+| `kanban_add_comment` | Add comments and @mentions |
+
+**Kanban Status Flow:**
+
+```
+Backlog → ToDo → InProgress → InReview → Done
+                     ↕
+                  Blocked
+```
+
+**Status Transition Rules:**
+| Transition | Rule |
+|-----------|------|
+| → Blocked | Requires blocker comment |
+| Blocked → | Requires resolution comment |
+| → Done | Requires validation pass (or officer override) |
+| → InProgress | Auto-assigns if unassigned |
+| → InReview | Triggers automatic validation scan |
+| Done → anything | Terminal — cannot reopen |
+
+---
+
+#### Phase 6: Monitor (Engineer — Fix Drift)
+
+**Goal**: Respond to Watch alerts by fixing drift findings.
+
+**Natural Language Queries:**
+
+```
+Show my alerts
+
+Fix alert ALT-12345 with dry run
+
+Fix alert ALT-12345
+
+Show compliance trend for my subscription
+```
+
+---
+
+## 8. Persona 6: Administrator
+
+> *"Copilot infrastructure management — not authorization decisions."*
+
+### 8.1 Role Summary
+
+The Administrator manages ATO Copilot server configuration, template management, and infrastructure settings. This role is explicitly separated from the AO role to enforce DoD separation of duties.
+
+**RBAC Role**: `Compliance.Administrator`
+**Primary Interface**: MCP API, VS Code
+
+### 8.2 Administrator Capabilities
+
+**Natural Language Queries:**
+
+```
+Upload our organization's SSP template (DOCX)
+
+List all uploaded document templates
+
+Update template {id} with new file content
+
+Delete template {id}
+
+Configure the Azure subscription connection
+
+Set up proxy configuration for air-gapped environment
+```
+
+**Template Management Tools:**
+
+| Tool | Purpose |
+|------|---------|
+| `compliance_upload_template` | Upload custom DOCX template for SSP/SAR/POA&M/RAR |
+| `compliance_list_templates` | List all uploaded templates, filter by document type |
+| `compliance_update_template` | Update template name or replace file content |
+| `compliance_delete_template` | Remove a template |
+
+**Template Merge Fields:**
+Templates use `{{field_name}}` placeholders that are automatically populated with system data:
+- `{{system_name}}`, `{{system_acronym}}`, `{{system_type}}`
+- `{{categorization}}`, `{{impact_level}}`, `{{fips_notation}}`
+- `{{control_implementations}}`, `{{baseline_summary}}`
+- `{{findings_summary}}`, `{{poam_items}}`, `{{risk_acceptances}}`
+
+---
+
+## 9. Cross-Persona Collaboration Matrix
+
+### 9.1 Who Hands Off to Whom
+
+| From → To | Trigger | What's Handed Off |
+|-----------|---------|-------------------|
+| **ISSM → ISSO** | System registered, baseline selected | System ID, control list for narrative authoring |
+| **ISSM → Engineer** | Controls need implementation | Kanban tasks, STIG requirements, narrative assignments |
+| **ISSO → Engineer** | Findings identified | Kanban remediation tasks with severity and SLA |
+| **Engineer → ISSO** | Remediation complete | Task moved to InReview, evidence collected |
+| **ISSO → SCA** | SSP ready for assessment | System ID, assessment scope, evidence package |
+| **SCA → ISSM** | Assessment complete | SAR, RAR, effectiveness determinations |
+| **ISSM → AO** | Package ready for decision | Bundled authorization package |
+| **AO → ISSM** | Decision issued | Authorization decision, risk acceptances, conditions |
+| **ISSO → ISSM** | Significant change detected | Change record, reauthorization flag |
+| **Watch Service → ISSO** | Drift/violation detected | Alert with severity, control ID, resource ID |
+| **ISSO → ISSM** | SLA escalation | Unacknowledged critical/high alerts |
+
+### 9.2 Shared Tools (Multiple Personas)
+
+| Tool | ISSM | ISSO | SCA | AO | Engineer |
+|------|------|------|-----|-----|----------|
+| `compliance_get_system` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `compliance_list_systems` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `compliance_get_categorization` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `compliance_get_baseline` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `compliance_narrative_progress` | ✅ | ✅ | ✅ | — | ✅ |
+| `compliance_show_risk_register` | ✅ | ✅ | ✅ (read) | ✅ | — |
+| `compliance_multi_system_dashboard` | ✅ | ✅ | ✅ | ✅ | — |
+| `compliance_show_stig_mapping` | ✅ | ✅ | ✅ | — | ✅ |
+| `compliance_check_evidence_completeness` | ✅ | ✅ | ✅ | — | — |
+| `compliance_compare_snapshots` | ✅ | ✅ | ✅ | — | — |
+
+### 9.3 Exclusive Tools (Single Persona)
+
+| Tool | Exclusive To | Reason |
+|------|-------------|--------|
+| `compliance_issue_authorization` | AO | Only AO can accept risk and authorize |
+| `compliance_accept_risk` | AO | Risk acceptance requires AO authority |
+| `compliance_assess_control` | SCA | Independence requirement — SCA only |
+| `compliance_generate_sar` | SCA | Assessment report — SCA product |
+| `watch_dismiss_alert` | ISSM (Officer) | Requires justification, compliance officer only |
+
+### 9.4 Portfolio Management (Multi-System Workflows)
+
+ISSMs and AOs often manage portfolios of dozens of systems simultaneously. This section covers workflows that span multiple systems.
+
+#### 9.4.1 Portfolio Dashboard
+
+The multi-system dashboard provides a single view of all registered systems with key metrics:
+
+**Natural Language Queries:**
+
+```
+Show the multi-system compliance dashboard
+
+Show all systems at the Assess phase
+
+Which systems have compliance scores below 80%?
+
+Show systems with expired or expiring ATOs
+
+Compare compliance trends across all IL5 systems
+
+Show portfolio risk summary
+```
+
+**Dashboard Data Points Per System:**
+
+| Field | Description |
+|-------|-------------|
+| System Name | Registered name |
+| Impact Level | IL2–IL6 |
+| Current RMF Phase | Prepare through Monitor |
+| Authorization Status | ATO/ATOwC/IATT/DATO/None |
+| Expiration Date | ATO expiration with color-coded urgency |
+| Compliance Score | Latest assessment percentage |
+| Open Findings | CAT I / CAT II / CAT III counts |
+| POA&M Status | Overdue / On Track / Completed counts |
+| ConMon Status | Last report date, next due date |
+
+#### 9.4.2 Bulk Operations
+
+**ISSM Bulk Workflows:**
+
+```
+Export all my systems to eMASS format
+
+Generate ConMon reports for all systems in the Monitor phase,
+period 2026-02
+
+Show overdue POA&M items across all systems
+
+Bulk assign all High severity Kanban tasks in system {id} to
+the security team
+
+Check ATO expiration for all systems
+```
+
+**Available Bulk Tools:**
+
+| Tool | Bulk Capability |
+|------|----------------|
+| `compliance_multi_system_dashboard` | All systems in one view |
+| `compliance_list_systems` | Filter/search across all systems |
+| `compliance_list_poam` | POA&M items across systems (when `systemId` omitted) |
+| `compliance_track_ato_expiration` | All systems' expiration status |
+| `kanban_bulk_update` | Bulk assign, move, or set due dates on tasks |
+| `kanban_export` | Export board as CSV or POA&M for portfolio reporting |
+| `compliance_export_emass` | Per-system export (loop for portfolio) |
+
+#### 9.4.3 Delegation Patterns
+
+When an ISSM manages many systems, delegation to ISSOs is critical:
+
+| Pattern | How It Works |
+|---------|-------------|
+| **System-level ISSO assignment** | Each system has a named ISSO via `compliance_assign_rmf_role` — that ISSO owns day-to-day operations |
+| **Alert routing** | Watch alerts route to the system's assigned ISSO first; escalation path goes to ISSM |
+| **Kanban task assignment** | ISSM creates boards; ISSOs assign tasks to engineers per system |
+| **ConMon responsibility** | ISSM sets the ConMon plan; ISSO executes monitoring and generates reports |
+| **Reporting rollup** | ISSM uses dashboard for portfolio view; drills into individual systems as needed |
+
+**Delegation Natural Language Queries:**
+
+```
+Who is the ISSO for system {id}?
+
+Show all systems where Bob Jones is the assigned ISSO
+
+Reassign ISSO role for system {id} from Bob Jones to Sarah Lee
+
+Show alert summary grouped by ISSO
+
+Which ISSOs have overdue tasks?
+```
+
+#### 9.4.4 AO Portfolio View
+
+The AO typically authorizes many systems and needs portfolio-level risk visibility:
+
+```
+Show all systems I have authorized
+
+What is my total portfolio risk exposure?
+
+Show risk acceptances expiring in the next 90 days across all systems
+
+Which of my authorized systems have CAT I findings?
+
+Show authorization decisions I have issued this year
+```
+
+---
+
+## 10. RMF Phase Reference
+
+### 10.1 Phase Transition Gate Conditions
+
+| Transition | Gate Requirements | Enforced? |
+|-----------|-------------------|-----------|
+| Prepare → Categorize | ≥1 RMF role assigned + ≥1 boundary resource | **Hard gate** |
+| Categorize → Select | SecurityCategorization exists + ≥1 InformationType | **Hard gate** |
+| Select → Implement | ControlBaseline exists | **Hard gate** |
+| Implement → Assess | Advisory (no hard block) | Advisory |
+| Assess → Authorize | Advisory (no hard block) | Advisory |
+| Authorize → Monitor | Advisory (no hard block) | Advisory |
+| Any backward movement | Requires `force: true` | **Hard gate** |
+
+### 10.2 RMF Phase → Tool Mapping
+
+| Phase | Primary Tools |
+|-------|--------------|
+| **Prepare** | `register_system`, `define_boundary`, `exclude_from_boundary`, `assign_rmf_role`, `list_rmf_roles`, `get_system`, `list_systems`, `advance_rmf_step` |
+| **Categorize** | `suggest_info_types`, `categorize_system`, `get_categorization`, `advance_rmf_step` |
+| **Select** | `select_baseline`, `tailor_baseline`, `set_inheritance`, `get_baseline`, `generate_crm`, `show_stig_mapping`, `advance_rmf_step` |
+| **Implement** | `write_narrative`, `suggest_narrative`, `batch_populate_narratives`, `narrative_progress`, `generate_ssp`, `advance_rmf_step` |
+| **Assess** | `assess_control`, `take_snapshot`, `compare_snapshots`, `verify_evidence`, `check_evidence_completeness`, `generate_sar`, `create_poam`, `list_poam`, `generate_rar`, `advance_rmf_step` |
+| **Authorize** | `issue_authorization`, `accept_risk`, `show_risk_register`, `bundle_authorization_package`, `advance_rmf_step` |
+| **Monitor** | `create_conmon_plan`, `generate_conmon_report`, `track_ato_expiration`, `report_significant_change`, `reauthorization_workflow`, `multi_system_dashboard`, `send_notification`, `export_emass`, `export_oscal` + all Watch tools |
+
+### 10.3 What Each Phase Produces
+
+| Phase | Artifacts Created | Format Options |
+|-------|-------------------|----------------|
+| Prepare | System Registration Record, Authorization Boundary, Role Assignments | JSON (MCP response) |
+| Categorize | FIPS 199 Categorization, Information Type Inventory | JSON, embedded in SSP |
+| Select | Control Baseline, Tailoring Record, Inheritance Map, CRM | JSON, Markdown, PDF, DOCX, Excel |
+| Implement | Control Implementation Narratives, SSP | Markdown, PDF, DOCX |
+| Assess | Effectiveness Determinations, Assessment Snapshots, SAR, RAR, POA&M | Markdown, PDF, DOCX, Excel |
+| Authorize | Authorization Decision, Risk Acceptances, Authorization Package | Markdown, PDF, DOCX, ZIP bundle |
+| Monitor | ConMon Plan, ConMon Reports, Significant Change Records, Alerts | Markdown, PDF, DOCX, eMASS Excel, OSCAL JSON |
+
+---
+
+## 11. Document Production Catalog
+
+### 11.1 Document Reference
+
+| Document | Full Name | Standard | Who Produces | When Produced | Output Formats |
+|----------|-----------|----------|-------------|---------------|----------------|
+| **SSP** | System Security Plan | NIST SP 800-18, DoDI 8510.01 | ISSO/ISSM | Implement phase | Markdown, PDF, DOCX |
+| **SAR** | Security Assessment Report | NIST SP 800-53A | SCA | Assess phase | Markdown, PDF, DOCX |
+| **RAR** | Risk Assessment Report | DoDI 8510.01 | SCA/ISSM | Assess phase | Markdown, PDF, DOCX |
+| **POA&M** | Plan of Action & Milestones | OMB A-130, DoDI 8510.01 | ISSM | Assess through Monitor | Markdown, PDF, Excel |
+| **CRM** | Customer Responsibility Matrix | FedRAMP, DoDI 8510.01 | ISSM | Select phase | Markdown, PDF, DOCX |
+| **ATO Letter** | Authorization Decision Letter | DoDI 8510.01 | AO (via tool) | Authorize phase | Markdown, PDF, DOCX |
+| **ConMon Report** | Continuous Monitoring Report | NIST SP 800-137 | ISSM | Monitor phase (periodic) | Markdown, PDF, DOCX |
+| **Authorization Package** | Bundled Package (SSP+SAR+RAR+POA&M+CRM+ATO) | DoDI 8510.01 | ISSM | Authorize phase | ZIP bundle |
+| **eMASS Export** | eMASS-Compatible Spreadsheet | DISA eMASS format | ISSM | Any phase | Excel (.xlsx) |
+| **OSCAL Export** | OSCAL v1.0.6 JSON | NIST OSCAL | ISSM | Any phase | JSON |
+
+### 11.2 SSP Sections
+
+The generated System Security Plan contains these sections:
+
+| Section | Content |
+|---------|---------|
+| 1. System Information | Name, type, mission criticality, hosting environment, RMF phase, boundary description |
+| 2. Security Categorization | FIPS 199 notation, C/I/A impacts, DoD IL, information types with provisional/adjustment details |
+| 3. Control Baseline | Baseline level, overlay applied, total controls, tailoring summary, inheritance coverage |
+| 4. Control Implementations | Per-family grouped controls with narrative text, status, inheritance type, STIG mappings |
+
+### 11.3 SAR Sections
+
+| Section | Content |
+|---------|---------|
+| 1. Executive Summary | System identification, assessor, overall score, total findings |
+| 2. CAT Severity Breakdown | CAT I/II/III counts with risk categorization |
+| 3. Control Family Results | Per-family pass/fail rates with CAT mapping |
+| 4. Risk Summary | Assessment-to-authorization risk posture |
+| 5. Detailed Findings | Per-control determination, method, evidence links, notes |
+
+### 11.4 RAR Sections
+
+| Section | Content |
+|---------|---------|
+| 1. Executive Summary | Aggregate risk level, recommendation |
+| 2. Per-Family Risk | Risk score by NIST control family |
+| 3. Threat/Vulnerability Analysis | Finding counts by severity category |
+| 4. Residual Risk | Accepted risks, compensating controls |
+
+### 11.5 POA&M Fields (DoD-Required)
+
+| Field | Description |
+|-------|-------------|
+| POA&M ID | Auto-generated identifier |
+| Weakness | Description of the finding |
+| Security Control | NIST 800-53 control ID |
+| CAT Severity | CAT I, CAT II, or CAT III |
+| Point of Contact | Responsible individual |
+| Resources Required | Budget, personnel, tools needed |
+| Scheduled Completion | Target remediation date |
+| Milestones | Target dates for intermediate steps |
+| Status | Ongoing, Completed, Delayed, Risk Accepted |
+
+### 11.6 Document Template System
+
+ATO Copilot supports two template modes:
+
+1. **ATO Copilot Format** (default) — Built-in compliant format covering all DoDI 8510.01 required sections. Not locked to a specific DISA template revision.
+
+2. **Custom Organizational Template** — Organizations upload DOCX templates with `{{merge_field}}` placeholders. The template engine validates merge fields on upload and injects data at generation time.
+
+**Example Workflow:**
+
+```
+1. Upload template:     compliance_upload_template(name="DISA SSP v3",
+                          document_type="ssp", file_base64="UEsDB...")
+
+2. Generate with template: compliance_generate_ssp(system_id="sys-001",
+                             format="docx", template="<template-id>")
+
+3. Generate default PDF:   compliance_generate_ssp(system_id="sys-001",
+                             format="pdf")
+```
+
+---
+
+## 12. Natural Language Query Reference
+
+### 12.1 System Registration & Setup
+
+```
+Register a new system called 'ACME Portal' as a Major Application,
+mission-critical, hosted in Azure Government
+
+List all registered systems
+
+Show system details for {id}
+
+What systems am I assigned to?
+
+Add the production VMs and database to system {id}'s boundary
+
+Exclude the shared logging service from system {id}'s boundary — it's
+under a separate ATO by shared services
+
+Assign Jane Smith as ISSM for system {id}
+
+Who is assigned to system {id}?
+```
+
+### 12.2 Categorization
+
+```
+What information types should I use for a financial management system?
+
+Categorize system {id} as Moderate confidentiality, High integrity,
+Moderate availability
+
+What's the DoD Impact Level for system {id}?
+
+What's the FIPS 199 notation for system {id}?
+
+Re-categorize system {id} — we added PII data types
+```
+
+### 12.3 Baseline & Controls
+
+```
+Select the NIST 800-53 baseline for system {id}
+
+How many controls are in the High baseline?
+
+Apply the CNSSI 1253 overlay for IL5
+
+Remove PE-5 from the baseline — not applicable for cloud-only systems
+
+Set AC-1 as inherited from Azure Government FedRAMP High
+
+Generate the Customer Responsibility Matrix
+
+What STIG rules map to AC-2?
+
+Show all controls in the AC family
+
+What controls require customer implementation?
+```
+
+### 12.4 SSP Authoring
+
+```
+Auto-populate inherited control narratives
+
+Suggest a narrative for AC-2 on system {id}
+
+Write the narrative for SC-7: "Network segmentation is..."
+
+What's the SSP completion percentage?
+
+Show narrative progress for the IA family
+
+Which controls still need narratives?
+
+Generate the SSP for system {id}
+
+Generate SSP as PDF using our DISA template
+```
+
+### 12.5 Assessment
+
+```
+Assess control AC-2 as Satisfied — tested and verified
+
+Assess AC-3 as Other Than Satisfied, CAT II — missing MAC enforcement
+
+Take a snapshot of the current assessment state
+
+Compare the before and after snapshots
+
+Is evidence complete for the AC family?
+
+Has evidence {id} been tampered with?
+
+Generate the Security Assessment Report
+
+What's the overall compliance score?
+
+How many CAT I findings are there?
+```
+
+### 12.6 Authorization
+
+```
+Bundle the authorization package for system {id}
+
+Issue an ATO for system {id} expiring January 2028 with Low residual risk
+
+Issue ATO with conditions — MFA required within 90 days
+
+Accept risk on finding {id} for CM-6 — compensating control: monitoring alerts
+
+Deny authorization — 3 unmitigated CAT I findings
+
+Show the risk register
+
+What accepted risks are expiring soon?
+```
+
+### 12.7 Continuous Monitoring
+
+```
+Create a ConMon plan with monthly assessments
+
+Generate the February 2026 ConMon report
+
+When does the ATO expire for system {id}?
+
+Report a significant change: new VPN interconnection
+
+Check reauthorization triggers
+
+Show the multi-system dashboard
+
+Which systems have expired ATOs?
+
+Export to eMASS format
+
+Export OSCAL JSON
+```
+
+### 12.8 Compliance Watch
+
+```
+Enable daily monitoring for subscription {sub-id}
+
+Show monitoring status
+
+Show all critical alerts
+
+Show alerts from the last 7 days for the AC family
+
+What drifted this week?
+
+Acknowledge alert ALT-12345
+
+Fix alert ALT-12345 with dry run
+
+Dismiss alert ALT-12345 — false positive, documented in ticket SNOW-123
+
+Show alert statistics for the last 30 days
+
+Show compliance trend for subscription {sub-id}
+
+Configure quiet hours from 22:00 to 06:00 weekdays
+
+Escalate Critical alerts to ISSM if not acknowledged in 30 minutes
+
+Create a suppression rule for PE controls expiring March 31
+```
+
+### 12.9 Kanban & Remediation
+
+```
+Create a remediation board from the latest assessment
+
+Show the board overview
+
+Show my assigned tasks
+
+Assign REM-003 to Bob Jones
+
+Move REM-005 to In Progress
+
+Fix REM-005 with dry run
+
+Validate REM-005
+
+Collect evidence for REM-005
+
+Move REM-005 to In Review
+
+Show all overdue tasks
+
+Export the board as POA&M format
+
+Bulk assign all High severity tasks to the security team
+```
+
+### 12.10 Knowledge & Education
+
+```
+What does NIST control AC-2 mean?
+
+Explain control SC-7 in terms of Azure implementation
+
+What are the FedRAMP Moderate requirements for encryption at rest?
+
+What STIG rules apply to Azure SQL Database?
+
+What is a CAT I finding?
+
+Explain the difference between ATO and ATOwC
+
+What triggers reauthorization?
+
+What is a Customer Responsibility Matrix?
+```
+
+### 12.11 PIM (Privileged Identity Management)
+
+```
+What PIM roles am I eligible for?
+
+Activate the Reader role for subscription {sub-id} — running quarterly
+compliance assessment
+
+List my active PIM roles
+
+Deactivate the Contributor role — remediation complete
+
+Show PIM activation history
+```
+
+---
+
+## 13. Interface Guide
+
+### 13.1 VS Code (GitHub Copilot Chat)
+
+**How to Access**: Type `@ato` in the GitHub Copilot Chat panel.
+
+**Slash Commands:**
+| Command | Purpose |
+|---------|---------|
+| `/compliance` | Compliance scanning, assessment, remediation |
+| `/knowledge` | NIST, STIG, RMF, FedRAMP knowledge queries |
+| `/config` | Server configuration and connection settings |
+
+**In-Editor Features:**
+- **IaC Diagnostics**: Compliance findings as squiggly underlines in Bicep/Terraform/ARM files
+- **Quick Fix (Lightbulb)**: Code actions to apply suggested STIG fixes
+- **Hover Info**: NIST control + STIG rule + CAT severity on hover over flagged code
+- **RMF Overview Panel**: Webview showing system status, timeline, and metrics
+
+**Example VS Code Session:**
+
+```
+User: @ato /compliance Scan my main.bicep for compliance issues
+→ Returns findings with CAT severity, STIG rule IDs, and inline suggestions
+
+User: @ato /knowledge What does SC-7 mean for Azure networking?
+→ Returns control explanation with Azure-specific implementation guidance
+
+User: @ato Fix finding SC-7-001 in main.bicep
+→ Applies suggested code fix as a VS Code Quick Fix
+```
+
+### 13.2 Microsoft Teams (M365 Bot)
+
+**How to Access**: Message the ATO Copilot bot in Teams or use it in a channel.
+
+**Adaptive Cards:**
+| Card | Purpose | Primary Persona |
+|------|---------|-----------------|
+| System Summary Card | Registered system overview (name, IL, phase, score) | ISSM |
+| Categorization Card | FIPS 199 categories with C/I/A levels | ISSM |
+| Authorization Card | ATO/ATOwC/IATT/DATO decision details | AO |
+| Dashboard Card | Multi-system portfolio view with color-coded status | ISSM, AO |
+
+**Example Teams Session:**
+
+```
+User: Show the compliance dashboard
+→ Returns Dashboard Adaptive Card with all systems, scores, and alerts
+
+User: What systems have ATOs expiring in 90 days?
+→ Returns filtered list with expiration dates and alert levels
+
+User: Issue ATO for ACME Portal expiring Jan 2028
+→ Returns Authorization Card with decision summary for confirmation
+```
+
+### 13.3 MCP API (Direct)
+
+All tools are accessible via the MCP server API using any MCP-compatible client:
+- **Transport**: REST, Server-Sent Events (SSE), stdio
+- **Authentication**: CAC certificate → role resolution
+- **Response Format**: JSON with `{ status, data, metadata }` envelope
+
+### 13.4 CI/CD (GitHub Actions)
+
+> **🔒 Air-Gapped Note (Interfaces)**: In disconnected environments:
+> - **VS Code**: Works fully — MCP server runs locally via stdio transport. AI-powered suggestions require proxy to LLM endpoint or are unavailable.
+> - **Teams**: Unavailable (requires M365 cloud connectivity).
+> - **MCP API**: Works fully locally with REST + stdio. SSE transport works within local network only.
+> - **CI/CD**: Works within local GitLab/Jenkins instances; GitHub Actions requires connectivity.
+
+**Compliance Gate Action:**
+```yaml
+- uses: ./.github/actions/ato-compliance-gate
+  with:
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    scan-type: iac
+    fail-on: cat-i,cat-ii
+    respect-risk-acceptances: true
+```
+
+Blocks PRs with CAT I/II findings. Respects active risk acceptances. Results appear as PR check annotations.
+
+---
+
+## 14. Appendices
+
+### Appendix A: Complete MCP Tool Inventory
+
+#### A.1 RMF Lifecycle Tools (Feature 015)
+
+| # | Tool Name | Phase | Description |
+|---|-----------|-------|-------------|
+| 1 | `compliance_register_system` | Prepare | Register system for RMF tracking |
+| 2 | `compliance_list_systems` | All | List registered systems |
+| 3 | `compliance_get_system` | All | Get full system details |
+| 4 | `compliance_advance_rmf_step` | All | Advance/regress RMF phase |
+| 5 | `compliance_define_boundary` | Prepare | Define authorization boundary |
+| 6 | `compliance_exclude_from_boundary` | Prepare | Exclude resource from boundary |
+| 7 | `compliance_assign_rmf_role` | Prepare | Assign RMF role to user |
+| 8 | `compliance_list_rmf_roles` | Prepare | List role assignments |
+| 9 | `compliance_categorize_system` | Categorize | FIPS 199 categorization |
+| 10 | `compliance_get_categorization` | Categorize | View categorization |
+| 11 | `compliance_suggest_info_types` | Categorize | AI-suggest SP 800-60 info types |
+| 12 | `compliance_select_baseline` | Select | Select NIST 800-53 baseline |
+| 13 | `compliance_tailor_baseline` | Select | Add/remove controls |
+| 14 | `compliance_set_inheritance` | Select | Set control inheritance |
+| 15 | `compliance_get_baseline` | Select | View baseline details |
+| 16 | `compliance_generate_crm` | Select | Generate CRM |
+| 17 | `compliance_write_narrative` | Implement | Write control narrative |
+| 18 | `compliance_suggest_narrative` | Implement | AI-suggest narrative |
+| 19 | `compliance_batch_populate_narratives` | Implement | Auto-fill inherited narratives |
+| 20 | `compliance_narrative_progress` | Implement | Track SSP completion |
+| 21 | `compliance_generate_ssp` | Implement | Generate SSP document |
+| 22 | `compliance_assess_control` | Assess | Record control effectiveness |
+| 23 | `compliance_take_snapshot` | Assess | Immutable assessment snapshot |
+| 24 | `compliance_compare_snapshots` | Assess | Compare snapshots |
+| 25 | `compliance_verify_evidence` | Assess | Evidence integrity check |
+| 26 | `compliance_check_evidence_completeness` | Assess | Evidence coverage report |
+| 27 | `compliance_generate_sar` | Assess | Generate SAR |
+| 28 | `compliance_issue_authorization` | Authorize | Issue ATO/ATOwC/IATT/DATO |
+| 29 | `compliance_accept_risk` | Authorize | Accept risk on finding |
+| 30 | `compliance_show_risk_register` | Authorize | View risk register |
+| 31 | `compliance_create_poam` | Assess | Create POA&M item |
+| 32 | `compliance_list_poam` | Assess | List POA&M items |
+| 33 | `compliance_generate_rar` | Assess | Generate RAR |
+| 34 | `compliance_bundle_authorization_package` | Authorize | Bundle SSP+SAR+RAR+POA&M+CRM |
+
+#### A.2 Continuous Monitoring Tools (Feature 015)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 35 | `compliance_create_conmon_plan` | Create/update ConMon plan |
+| 36 | `compliance_generate_conmon_report` | Generate periodic report |
+| 37 | `compliance_track_ato_expiration` | Check expiration status |
+| 38 | `compliance_report_significant_change` | Report significant change |
+| 39 | `compliance_reauthorization_workflow` | Check/initiate reauthorization |
+| 40 | `compliance_multi_system_dashboard` | Portfolio dashboard |
+| 41 | `compliance_send_notification` | Send notification via channels |
+
+#### A.3 Interoperability Tools (Feature 015)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 42 | `compliance_export_emass` | Export to eMASS Excel format |
+| 43 | `compliance_import_emass` | Import eMASS Excel with conflict resolution |
+| 44 | `compliance_export_oscal` | Export OSCAL v1.0.6 JSON |
+| 45 | `compliance_show_stig_mapping` | NIST-to-STIG cross-reference |
+
+#### A.4 Template Management Tools (Feature 015)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 46 | `compliance_upload_template` | Upload custom DOCX template |
+| 47 | `compliance_list_templates` | List templates by document type |
+| 48 | `compliance_update_template` | Update template content |
+| 49 | `compliance_delete_template` | Delete template |
+
+#### A.5 Core Compliance Tools (Features 001–014)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 50 | `compliance_assess` | Run NIST 800-53 assessment |
+| 51 | `compliance_get_control_family` | Get control family info |
+| 52 | `compliance_generate_document` | Generate compliance documents |
+| 53 | `compliance_collect_evidence` | Collect Azure evidence |
+| 54 | `compliance_remediate` | Remediate findings |
+| 55 | `compliance_validate_remediation` | Validate remediation |
+| 56 | `compliance_generate_plan` | Generate remediation plan |
+| 57 | `compliance_audit_log` | View audit trail |
+| 58 | `compliance_history` | View compliance history |
+| 59 | `compliance_status` | Current compliance posture |
+| 60 | `compliance_monitoring` | Monitoring setup |
+
+#### A.6 Compliance Watch Tools (Feature 005)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 61 | `watch_enable_monitoring` | Enable scheduled monitoring |
+| 62 | `watch_disable_monitoring` | Disable monitoring |
+| 63 | `watch_configure_monitoring` | Update frequency/mode |
+| 64 | `watch_monitoring_status` | View monitoring status |
+| 65 | `watch_show_alerts` | List alerts with filters |
+| 66 | `watch_get_alert` | Get alert details |
+| 67 | `watch_acknowledge_alert` | Acknowledge alert |
+| 68 | `watch_fix_alert` | Remediate alert finding |
+| 69 | `watch_dismiss_alert` | Dismiss alert (officer only) |
+| 70 | `watch_create_rule` | Create custom alert rule |
+| 71 | `watch_list_rules` | List alert rules |
+| 72 | `watch_suppress_alerts` | Suppress alert pattern |
+| 73 | `watch_list_suppressions` | List suppressions |
+| 74 | `watch_configure_quiet_hours` | Set notification quiet hours |
+| 75 | `watch_configure_notifications` | Configure channels |
+| 76 | `watch_configure_escalation` | Define escalation paths |
+| 77 | `watch_alert_history` | Natural language alert queries |
+| 78 | `watch_compliance_trend` | Compliance score over time |
+| 79 | `watch_alert_statistics` | Alert counts and metrics |
+| 80 | `watch_auto_remediation_create` | Create auto-remediation rule |
+| 81 | `watch_auto_remediation_list` | List auto-remediation rules |
+| 82 | `watch_auto_remediation_status` | View execution status |
+| 83 | `watch_capture_baseline` | Capture compliance baseline |
+
+#### A.7 Kanban Remediation Tools (Feature 002)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 84 | `kanban_create_board` | Create board from assessment |
+| 85 | `kanban_board_show` | Display board overview |
+| 86 | `kanban_get_task` | Get task details |
+| 87 | `kanban_create_task` | Create remediation task |
+| 88 | `kanban_assign_task` | Assign/reassign task |
+| 89 | `kanban_move_task` | Move task between columns |
+| 90 | `kanban_task_list` | List/filter tasks |
+| 91 | `kanban_task_history` | View task audit trail |
+| 92 | `kanban_task_validate` | Validate remediation |
+| 93 | `kanban_add_comment` | Add comment/@mention |
+| 94 | `kanban_task_comments` | List comments |
+| 95 | `kanban_edit_comment` | Edit comment (24hr window) |
+| 96 | `kanban_delete_comment` | Delete comment (1hr window) |
+| 97 | `kanban_remediate_task` | Execute remediation script |
+| 98 | `kanban_collect_evidence` | Collect evidence for task |
+| 99 | `kanban_bulk_update` | Bulk assign/move/set dates |
+| 100 | `kanban_export` | Export as CSV or POA&M |
+| 101 | `kanban_archive_board` | Archive completed board |
+
+#### A.8 PIM & Authentication Tools (Feature 003)
+
+| # | Tool Name | Description |
+|---|-----------|-------------|
+| 102 | `pim_list_eligible` | List PIM-eligible roles |
+| 103 | `pim_list_active` | List active PIM roles |
+| 104 | `pim_activate_role` | Activate PIM role |
+| 105 | `pim_deactivate_role` | Deactivate PIM role |
+| 106 | `pim_extend_role` | Extend role activation |
+| 107 | `pim_approve_request` | Approve activation request |
+| 108 | `pim_deny_request` | Deny activation request |
+| 109 | `pim_history` | View activation history |
+| 110 | `jit_request_access` | Request just-in-time access |
+| 111 | `jit_list_sessions` | List active JIT sessions |
+| 112 | `jit_revoke_access` | Revoke JIT session |
+| 113 | `cac_status` | Check CAC session status |
+| 114 | `cac_sign_out` | Sign out CAC session |
+
+---
+
+### Appendix B: End-to-End Scenario — Full RMF Lifecycle
+
+This scenario walks through the complete lifecycle of registering a system and taking it through ATO.
+
+**Scenario**: "ACME Portal" — a mission-critical Major Application hosted in Azure Government (IL5).
+
+#### Day 1: ISSM Registers the System
+
+```
+User (ISSM):
+  Register a new system called 'ACME Portal' as a Major Application
+  with mission-critical designation in Azure Government IL5
+
+ATO Copilot:
+  ✅ System registered: ACME Portal (ID: sys-acme-001)
+  Current RMF Phase: Prepare
+  Next steps:
+  1. Define the authorization boundary
+  2. Assign RMF roles
+  3. Advance to Categorize phase
+
+User (ISSM):
+  Define the authorization boundary — add 3 production VMs, the SQL
+  database, Key Vault, and the App Service
+
+  Assign Jane Smith as ISSM, Bob Jones as ISSO, Dr. Alice Chen as SCA,
+  and COL Davis as Authorizing Official
+
+  Advance to Categorize
+```
+
+#### Day 2: ISSM Categorizes the System
+
+```
+User (ISSM):
+  Suggest information types for ACME Portal — it handles financial
+  transactions and stores PII
+
+ATO Copilot:
+  Suggested types (confidence scores):
+  1. C.3.1.4 Financial Management (0.92)
+  2. C.2.4.1 General Information (0.87)
+  3. C.3.5.8 Information Security (0.85)
+
+User (ISSM):
+  Categorize with Financial Management (C:High, I:High, A:Moderate)
+  and Information Security (C:Moderate, I:High, A:Moderate)
+
+ATO Copilot:
+  ✅ Categorization complete:
+  FIPS 199: SC ACME Portal = {(C, HIGH), (I, HIGH), (A, MODERATE)}
+  Overall: HIGH | DoD IL: IL5 | Baseline: High (400 controls)
+```
+
+#### Days 3–5: ISSM Selects and Tailors Controls
+
+```
+User (ISSM):
+  Select the High baseline with CNSSI 1253 overlay
+
+  Set all physical security controls as inherited from Azure Government
+
+  Generate the CRM
+
+  Advance to Implement
+```
+
+#### Weeks 2–6: ISSO and Engineers Author SSP
+
+```
+User (ISSO):
+  Auto-populate inherited control narratives
+
+  Suggest narratives for all AC family customer controls
+
+User (Engineer):
+  Write the narrative for SC-7: "Network boundary protection is implemented
+  using Azure Firewall Premium with TLS inspection, default-deny egress
+  rules, and Azure DDoS Protection Standard..."
+
+User (ISSO):
+  What's the SSP completion percentage?
+
+ATO Copilot:
+  SSP Progress: 78% complete
+  ├─ AC: 18/20 ██████████████████░░ 90%
+  ├─ AU: 12/14 █████████████████░░░ 86%
+  ├─ SC: 15/22 ██████████████░░░░░░ 68%
+  └─ (14 more families...)
+  Missing: 88 narratives across 14 families
+```
+
+#### Weeks 7–8: SCA Assesses Controls
+
+```
+User (SCA):
+  Assess AC-2 as Satisfied — tested Azure AD account management against
+  STIG checklist, all 15 sub-requirements met
+
+  Assess AC-3 as Other Than Satisfied, CAT II — missing mandatory access
+  control for 3 storage accounts
+
+  Take an assessment snapshot
+
+  Generate the Security Assessment Report
+
+ATO Copilot:
+  SAR Generated:
+  Overall Score: 87.3%
+  Findings: 0 CAT I, 12 CAT II, 31 CAT III
+  Recommendation: Conditional authorization pending CAT II remediation
+```
+
+#### Week 9: ISSM Creates POA&M and Bundles Package
+
+```
+User (ISSM):
+  Create POA&M items for all 12 CAT II findings
+
+  Generate the RAR
+
+  Bundle the authorization package with evidence
+```
+
+#### Week 10: AO Issues Decision
+
+```
+User (AO):
+  Review the authorization package for ACME Portal
+
+  Issue ATO with conditions — CAT II findings must be remediated within
+  90 days, quarterly POA&M reviews required. Expiration: January 15, 2029.
+  Accept risk on 5 CAT III findings with compensating controls.
+
+ATO Copilot:
+  ✅ Authorization Issued: ATO with Conditions
+  System: ACME Portal | Expires: 2029-01-15
+  Risk Level: Medium | Score at Decision: 87.3%
+  Conditions: CAT II remediation within 90 days
+  Risk Acceptances: 5 findings accepted (expires 2027-01-15)
+  System moved to Monitor phase
+```
+
+#### Ongoing: Continuous Monitoring
+
+```
+User (ISSM):
+  Create a ConMon plan with monthly assessments, annual review June 15
+
+  Generate the February 2026 ConMon report
+
+  Show the multi-system dashboard
+
+ATO Copilot (automated):
+  ⚠️ Alert: ATO for ACME Portal expires in 90 days
+  Action: Begin reauthorization planning
+
+  🔴 Alert: Configuration drift detected — 7 resources drifted beyond
+  threshold. Significant change auto-reported.
+```
+
+---
+
+### Appendix C: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **ATO** | Authority to Operate — formal authorization for a system to operate in a DoD environment |
+| **ATOwC** | ATO with Conditions — authorization with specific remediation requirements |
+| **AO** | Authorizing Official — senior leader who accepts risk and grants authorization |
+| **CAC** | Common Access Card — DoD identity credential used for authentication |
+| **CAT I/II/III** | Category severity levels for findings per DoDI 8510.01 |
+| **CNSSI 1253** | Committee on National Security Systems Instruction — DoD overlay for NIST controls |
+| **ConMon** | Continuous Monitoring — ongoing assessment of system compliance posture |
+| **CRM** | Customer Responsibility Matrix — documents which controls are customer vs. CSP responsibility |
+| **DATO** | Denial of Authorization to Operate — system is not authorized to operate |
+| **eMASS** | Enterprise Mission Assurance Support Service — DoD GRC platform of record |
+| **FIPS 199** | Federal Information Processing Standards Publication 199 — security categorization |
+| **FedRAMP** | Federal Risk and Authorization Management Program — cloud authorization framework |
+| **IATT** | Interim Authority to Test — limited authorization for testing purposes |
+| **IL** | Impact Level — DoD classification (IL2 through IL6) |
+| **ISSM** | Information System Security Manager — manages security program for systems |
+| **ISSO** | Information System Security Officer — day-to-day security operations |
+| **MCP** | Model Context Protocol — the API protocol used by ATO Copilot |
+| **NIST 800-53** | National Institute of Standards and Technology Special Publication 800-53 — security controls catalog |
+| **OSCAL** | Open Security Controls Assessment Language — machine-readable compliance data format |
+| **PIM** | Privileged Identity Management — just-in-time role activation |
+| **POA&M** | Plan of Action and Milestones — tracks remediation of security findings |
+| **RAR** | Risk Assessment Report — documents residual risk for AO decision |
+| **RMF** | Risk Management Framework — DoD system authorization lifecycle (DoDI 8510.01) |
+| **SAR** | Security Assessment Report — documents assessment findings for AO review |
+| **SCA** | Security Control Assessor — independent assessor of control effectiveness |
+| **SP 800-60** | NIST Special Publication 800-60 — information type categorization |
+| **SSP** | System Security Plan — primary system authorization document |
+| **STIG** | Security Technical Implementation Guide — DISA technology-specific security rules |
+
+---
+
+### Appendix D: Quick Reference Cards
+
+#### ISSM Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                 ISSM Quick Reference                    │
+├─────────────────────────────────────────────────────────┤
+│ REGISTER:  "Register system {name} as {type} in {env}" │
+│ BOUNDARY:  "Add resources to system {id}'s boundary"    │
+│ ROLES:     "Assign {name} as {role} for system {id}"    │
+│ CATEGORIZE:"Categorize system {id} with {info types}"   │
+│ BASELINE:  "Select baseline for system {id}"            │
+│ TAILOR:    "Remove {control} — {rationale}"             │
+│ SSP:       "Generate SSP for system {id}"               │
+│ POAM:      "Create POA&M for finding {id}"              │
+│ PACKAGE:   "Bundle authorization package"               │
+│ DASHBOARD: "Show multi-system dashboard"                │
+│ CONMON:    "Generate monthly report for system {id}"    │
+│ EMASS:     "Export system {id} to eMASS"                │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### SCA Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  SCA Quick Reference                    │
+├─────────────────────────────────────────────────────────┤
+│ ASSESS:    "Assess {control} as {determination}"        │
+│ SNAPSHOT:  "Take assessment snapshot for system {id}"    │
+│ EVIDENCE:  "Verify evidence {id}"                       │
+│ COMPLETE:  "Check evidence completeness for {family}"   │
+│ COMPARE:   "Compare snapshots {a} and {b}"              │
+│ SAR:       "Generate SAR for system {id}"               │
+│ RAR:       "Generate RAR for system {id}"               │
+│                                                         │
+│ ⚠️ Read-only: Cannot modify system, fix findings,      │
+│    or issue authorization decisions                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### AO Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   AO Quick Reference                    │
+├─────────────────────────────────────────────────────────┤
+│ REVIEW:    "Show authorization package for system {id}" │
+│ AUTHORIZE: "Issue ATO for system {id} expiring {date}"  │
+│ CONDITIONS:"Issue ATOwC — {conditions}"                 │
+│ RISK:      "Accept risk on finding {id} — {rationale}"  │
+│ DENY:      "Deny authorization — {reason}"              │
+│ REGISTER:  "Show risk register for system {id}"         │
+│ DASHBOARD: "Show all my authorized systems"             │
+│ EXPIRATION:"What ATOs expire in the next 90 days?"      │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### Engineer Quick Reference
+
+```
+┌─────────────────────────────────────────────────────────┐
+│               Engineer Quick Reference                  │
+├─────────────────────────────────────────────────────────┤
+│ LEARN:     "What does {control} mean for Azure?"        │
+│ STIG:      "What STIG rules apply to {technology}?"     │
+│ SCAN:      "Scan my Bicep file for compliance"          │
+│ NARRATIVE: "Suggest narrative for {control}"             │
+│ WRITE:     "Write narrative for {control}: {text}"      │
+│ TASKS:     "Show my assigned tasks"                     │
+│ FIX:       "Fix task REM-{id} with dry run"             │
+│ VALIDATE:  "Validate task REM-{id}"                     │
+│ EVIDENCE:  "Collect evidence for task REM-{id}"         │
+│ PROGRESS:  "Show narrative progress for {family}"       │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Appendix E: Documentation Delivery
+
+**Primary Format**: Static documentation site generated from Markdown source files in `docs/` using MkDocs or DocFX.
+
+- **Source**: Markdown files organized per-persona and per-phase in `docs/guides/`
+- **Build**: CI/CD pipeline generates static site on merge to main
+- **Search**: Full-text search across all documentation pages
+- **Navigation**: Persona-based left nav with RMF phase sub-sections
+- **Versioning**: Documentation versioned alongside product releases
+- **Existing Guides**: Current `docs/guides/` files (issm-guide.md, sca-guide.md, ao-quick-reference.md, engineer-guide.md, compliance-watch.md, remediation-kanban.md) become pages in the site
+
+### Appendix F: Common Errors & Troubleshooting
+
+#### F.1 RBAC / Authorization Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Access denied: Compliance.Auditor cannot invoke compliance_write_narrative` | SCA attempting to modify SSP (write operation) | SCA role is read-only by design. Ask the assigned ISSO or Engineer to write the narrative. |
+| `Access denied: Compliance.PlatformEngineer cannot invoke compliance_issue_authorization` | Engineer attempting to issue an ATO decision | Only the AO (`Compliance.AuthorizingOfficial`) can issue authorization decisions. |
+| `Access denied: Compliance.Analyst cannot invoke watch_dismiss_alert` | ISSO attempting to dismiss an alert | Only officers (`Compliance.SecurityLead` or above) can dismiss alerts. Escalate to ISSM. |
+| `Role not recognized` | CAC certificate not mapped to any RBAC role | Contact Administrator to map your CAC thumbprint, or verify Azure AD group membership. Default fallback is `PlatformEngineer`. |
+
+#### F.2 RMF Gate Validation Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Cannot advance: Prepare → Categorize requires at least 1 RMF role and 1 boundary resource` | Tried to advance before assigning roles or defining boundary | Use `compliance_assign_rmf_role` and `compliance_define_boundary` first. |
+| `Cannot advance: Categorize → Select requires SecurityCategorization` | Tried to advance before categorizing | Use `compliance_categorize_system` with at least one information type. |
+| `Cannot advance: Select → Implement requires ControlBaseline` | Tried to advance before selecting baseline | Use `compliance_select_baseline` to select Low/Moderate/High baseline. |
+| `Cannot regress RMF step without force: true` | Tried to move backward in the RMF lifecycle | Add `force: true` parameter to `compliance_advance_rmf_step` (ISSM only). This is intentionally guarded. |
+| `System in DATO status: advancement blocked` | AO denied authorization; system is in read-only mode | The AO must issue a new authorization decision (ATO/ATOwC/IATT) before the system can advance. |
+
+#### F.3 Evidence & Integrity Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Evidence verification failed: hash mismatch` | Evidence artifact was modified after collection | Re-collect evidence using `compliance_collect_evidence`. If intentional modification, document the change and re-collect. |
+| `Evidence completeness: 12 controls missing evidence` | Not all controls in scope have associated evidence | Use `compliance_check_evidence_completeness` to identify gaps, then collect evidence for each missing control. |
+| `Snapshot creation failed: no assessment data` | Tried to take a snapshot before any controls were assessed | Assess at least one control using `compliance_assess_control` first. |
+
+#### F.4 Authorization & Risk Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Risk acceptance expired` | An accepted risk passed its expiration date | The AO must either re-accept the risk with a new expiration date or the finding reverts to active. Linked POA&M items revert to `Ongoing`. |
+| `Authorization superseded` | A new authorization decision deactivated the prior one | Expected behavior — only one active authorization per system. Review the new decision. |
+| `Cannot bundle: SAR not generated` | Tried to bundle authorization package before SCA generated the SAR | SCA must complete assessment and run `compliance_generate_sar` first. |
+| `Cannot bundle: SSP not generated` | SSP has not been generated yet | Run `compliance_generate_ssp` to produce the SSP before bundling. |
+
+#### F.5 Azure Connectivity Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Azure Policy query failed: connection timeout` | Cannot reach Azure Resource Manager APIs | Check network connectivity. In air-gapped environments, use scheduled monitoring with local policy cache. |
+| `Defender for Cloud unavailable` | Azure Defender not enabled or unreachable | Verify Defender for Cloud is enabled on the subscription. In disconnected mode, assessment runs against cached policy data only. |
+| `Subscription not found: {sub-id}` | Subscription ID is incorrect or ATO Copilot lacks access | Verify the subscription ID and ensure the ATO Copilot service principal has Reader access. |
+
+#### F.6 Monitoring & Alert Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Monitoring already enabled for subscription {sub-id}` | Attempted to enable monitoring that is already active | Use `watch_configure_monitoring` to update frequency or mode instead. |
+| `Alert not found: ALT-{id}` | Alert ID is incorrect or alert has been archived | Use `watch_show_alerts` to list current alerts. Archived alerts are available via `watch_alert_history`. |
+| `Cannot dismiss: justification required` | Tried to dismiss alert without providing a reason | Include a justification string when calling `watch_dismiss_alert`. |
+| `SLA escalation triggered` | Alert remained unacknowledged beyond SLA threshold | Acknowledge the alert immediately. Review escalation configuration with `watch_configure_escalation`. |
+| `Quiet hours active: notification suppressed` | Notification not delivered due to quiet hours configuration | Alert is still recorded — check `watch_show_alerts` after quiet hours end. Adjust with `watch_configure_quiet_hours`. |
+
+#### F.7 Kanban & Remediation Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Cannot move to Done: validation failed` | Task remediation did not pass re-scan validation | Review the validation results, fix remaining issues, and re-validate with `kanban_task_validate`. An officer can override with `force: true`. |
+| `Cannot move from Blocked: resolution comment required` | Tried to unblock a task without explaining the resolution | Add a comment explaining how the blocker was resolved before moving the task. |
+| `Cannot reopen: Done is terminal` | Tried to move a completed task back to an earlier column | Create a new task if additional work is needed on the same finding. |
+| `Dry run completed: no changes applied` | Used `dryRun: true` on remediation | Expected behavior — review the dry run output, then re-run without `dryRun` to apply changes. |
+
+---
+
+*This specification covers all user interactions with ATO Copilot across all personas and all RMF phases. It serves as both a planning document for feature development and a foundation for end-user documentation.*

--- a/specs/016-user-documentation/tasks.md
+++ b/specs/016-user-documentation/tasks.md
@@ -1,0 +1,292 @@
+# Tasks: Comprehensive User & Persona Documentation
+
+**Input**: Design documents from `/specs/016-user-documentation/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not requested — this is a documentation-only feature. Validation is performed via `mkdocs build --strict`.
+
+**Organization**: Tasks are grouped by user story to enable independent authoring and validation of each content area.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Documentation pages**: `docs/` at repository root
+- **Site configuration**: `mkdocs.yml` at repository root
+- **Spec reference**: `specs/016-user-documentation/spec.md` sections noted as `§N`
+
+---
+
+## Phase 1: Setup (Site Infrastructure)
+
+**Purpose**: Initialize MkDocs configuration and establish the site skeleton so `mkdocs build` passes.
+
+- [X] T001 Create MkDocs configuration with Material theme, navigation structure, and all extensions in mkdocs.yml
+- [X] T002 [P] Add site/ to .gitignore to exclude generated static site output
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create the landing page and onboarding hub that ALL other pages link to. These MUST exist before persona/phase pages can cross-link correctly.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Create documentation site landing page with persona quick links, overview, and supported interfaces in docs/index.md
+- [X] T004 [P] Create getting-started hub page with persona selector and prerequisites overview in docs/getting-started/index.md
+- [X] T005 [P] Update existing getting-started.md to redirect to the new getting-started/index.md section in docs/getting-started.md
+
+**Checkpoint**: `mkdocs build --strict` passes with landing page and getting-started hub navigable.
+
+---
+
+## Phase 3: User Story 1 — Per-Persona Onboarding (Priority: P1) 🎯 MVP
+
+**Goal**: Each persona can find a dedicated getting-started page with prerequisites, first-time setup, and first 3 commands.
+
+**Independent Test**: Navigate to Getting Started > {Persona} and verify prerequisites, setup steps, and 3 NL query examples render correctly. Each page conforms to `contracts/getting-started.md` template.
+
+### Implementation for User Story 1
+
+- [X] T006 [P] [US1] Create ISSM getting-started page with prerequisites, first-time setup, and first 3 commands in docs/getting-started/issm.md
+- [X] T007 [P] [US1] Create ISSO getting-started page with prerequisites, first-time setup, and first 3 commands in docs/getting-started/isso.md
+- [X] T008 [P] [US1] Create SCA getting-started page with prerequisites, first-time setup, and first 3 commands in docs/getting-started/sca.md
+- [X] T009 [P] [US1] Create AO getting-started page with prerequisites, first-time setup, and first 3 commands in docs/getting-started/ao.md
+- [X] T010 [P] [US1] Create Engineer getting-started page with prerequisites, first-time setup, and first 3 commands in docs/getting-started/engineer.md
+
+**Checkpoint**: All 5 getting-started pages render and link back to the hub. `mkdocs build --strict` passes.
+
+---
+
+## Phase 4: User Story 2 — Comprehensive Persona Guides (Priority: P1)
+
+**Goal**: Each persona has a full-length guide covering role overview, permissions, RMF phase workflows, NL queries, air-gapped notes, and cross-persona handoffs.
+
+**Independent Test**: Navigate to Personas > {Persona Guide} and verify all sections from `contracts/persona-guide.md` are present. Tool names match codebase identifiers. Air-gapped callouts present where required.
+
+### Implementation for User Story 2
+
+- [X] T011 [P] [US2] Create persona overview page with RACI matrix and role definitions in docs/personas/index.md
+- [X] T012 [P] [US2] Create ISSO comprehensive guide with Implement/Assess/Monitor workflows, Watch tools, and air-gapped notes in docs/personas/isso.md
+- [X] T013 [P] [US2] Create Administrator guide with template management, configuration, and separation of duties in docs/personas/administrator.md
+- [X] T014 [P] [US2] Enhance ISSM guide with getting-started cross-link, air-gapped Monitor notes, and cross-references to rmf-phases/ in docs/guides/issm-guide.md
+- [X] T015 [P] [US2] Enhance SCA guide with RBAC constraints table, evidence integrity notes, and air-gapped Assess callout in docs/guides/sca-guide.md
+- [X] T016 [P] [US2] Enhance AO guide with portfolio view section, risk expiration queries, and getting-started cross-link in docs/guides/ao-quick-reference.md
+- [X] T017 [P] [US2] Enhance Engineer guide with Kanban remediation workflow, VS Code IaC diagnostics, and getting-started cross-link in docs/guides/engineer-guide.md
+- [X] T018 [P] [US2] Enhance Compliance Watch guide with air-gapped monitoring notes and scheduled-only mode callout in docs/guides/compliance-watch.md
+
+**Checkpoint**: All persona guides render. Cross-links to getting-started/ resolve. Air-gapped callouts present for ISSO (Implement), ISSM (Monitor), SCA (Assess).
+
+---
+
+## Phase 5: User Story 3 — RMF Phase Reference Pages (Priority: P1)
+
+**Goal**: Each RMF phase has a dedicated page showing all persona responsibilities, gate conditions, documents produced, and transition triggers.
+
+**Independent Test**: Navigate to RMF Phases > {Phase} and verify all personas with responsibilities in that phase have a subsection. Gate conditions reference real tools. Previous/Next phase links resolve. Each page conforms to `contracts/rmf-phase.md` template.
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Create RMF lifecycle overview page with phase diagram, gate summary table, and tool mapping in docs/rmf-phases/index.md
+- [X] T020 [P] [US3] Create Prepare phase page with ISSM lead tasks, gate conditions, and boundary/role workflows in docs/rmf-phases/prepare.md
+- [X] T021 [P] [US3] Create Categorize phase page with FIPS 199 workflow, info type suggestions, and IL derivation in docs/rmf-phases/categorize.md
+- [X] T022 [P] [US3] Create Select phase page with baseline selection, tailoring, inheritance, CRM generation in docs/rmf-phases/select.md
+- [X] T023 [P] [US3] Create Implement phase page with ISSO/Engineer narrative authoring, AI suggestions, and SSP generation in docs/rmf-phases/implement.md
+- [X] T024 [P] [US3] Create Assess phase page with SCA assessment workflow, evidence verification, snapshot comparison, SAR/RAR generation in docs/rmf-phases/assess.md
+- [X] T025 [P] [US3] Create Authorize phase page with AO decision types, risk acceptance, package bundling in docs/rmf-phases/authorize.md
+- [X] T026 [P] [US3] Create Monitor phase page with ConMon plans, Watch integration, expiration alerts, significant changes, eMASS/OSCAL export in docs/rmf-phases/monitor.md
+
+**Checkpoint**: All 7 phase pages + overview render. Previous/Next links form a connected chain. Gate conditions match spec §10.1.
+
+---
+
+## Phase 6: User Story 4 — Cross-Cutting Guides (Priority: P1)
+
+**Goal**: Users can look up NL query examples by category, find the complete document production catalog, and manage multi-system portfolios.
+
+**Independent Test**: Navigate to Guides > {Guide} and verify content is comprehensive. NL query reference covers all 11 categories from spec §12. Document catalog covers all 10 document types from spec §11. Portfolio management covers dashboard, bulk ops, and delegation from spec §9.4.
+
+### Implementation for User Story 4
+
+- [X] T027 [P] [US4] Create NL query reference with all 11 categories (registration, categorization, baseline, SSP, assessment, authorization, monitoring, Watch, Kanban, knowledge, PIM) in docs/guides/nl-query-reference.md
+- [X] T028 [P] [US4] Create document production catalog with all 10 document types, SSP/SAR/RAR/POA&M section breakdowns, and template system in docs/guides/document-catalog.md
+- [X] T029 [P] [US4] Create portfolio management guide with dashboard, bulk operations, delegation patterns, and AO portfolio view in docs/guides/portfolio-management.md
+
+**Checkpoint**: All 3 guide pages render. NL queries use realistic examples. Document catalog covers every artifact from spec §11.
+
+---
+
+## Phase 7: User Story 5 — Reference Material (Priority: P2)
+
+**Goal**: Users can look up any of the 114 MCP tools, troubleshoot 25+ common errors, use quick reference cards, and find glossary definitions.
+
+**Independent Test**: Navigate to Reference > {Page} and verify completeness. Tool inventory has all 114 tools grouped by 8 categories. Troubleshooting has 7 error categories with 25+ scenarios. Quick reference cards cover all 5 personas + admin. Glossary includes all Appendix C terms.
+
+### Implementation for User Story 5
+
+- [X] T030 [P] [US5] Create complete tool inventory with all 114 MCP tools grouped by 8 categories (RMF Lifecycle, ConMon, Interop, Templates, Core, Watch, Kanban, PIM) with RBAC roles and phase applicability in docs/reference/tool-inventory.md
+- [X] T031 [P] [US5] Create troubleshooting guide with 7 error categories (RBAC, gates, evidence, authorization, connectivity, monitoring, Kanban) covering 25+ error scenarios in docs/reference/troubleshooting.md
+- [X] T032 [P] [US5] Create quick reference cards for ISSM, SCA, AO, Engineer, and ISSO with top NL queries, key tools, and phase responsibilities in docs/reference/quick-reference-cards.md
+- [X] T033 [P] [US5] Expand glossary with ~10 new terms from spec Appendix C (ATOwC, CNSSI 1253, ConMon, CRM, DATO, IATT, IL, MCP, OSCAL, PIM) in docs/reference/glossary.md
+
+**Checkpoint**: All 4 reference pages render. Tool names match codebase identifiers exactly. Troubleshooting cross-links to persona guides.
+
+---
+
+## Phase 8: User Story 6 — End-to-End Scenario (Priority: P2)
+
+**Goal**: Users can follow a complete RMF lifecycle scenario from system registration through continuous monitoring, seeing all personas interact.
+
+**Independent Test**: Navigate to Scenarios > Full RMF Lifecycle and verify the scenario covers all 7 phases, involves all 5 operational personas, shows realistic NL queries and tool responses, and matches the ACME Portal scenario from spec Appendix B.
+
+### Implementation for User Story 6
+
+- [X] T034 [US6] Create full RMF lifecycle scenario (ACME Portal) covering Day 1 registration through ongoing ConMon with all persona interactions in docs/scenarios/full-lifecycle.md
+
+**Checkpoint**: Scenario page renders with all phases and persona handoffs. Cross-links to getting-started and persona guides resolve.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate all cross-links, build integrity, air-gapped consistency, and tool name accuracy.
+
+- [X] T035 Validate all internal cross-links against data-model.md Cross-Reference Map across all documentation pages
+- [X] T036 Run mkdocs build --strict and fix all warnings and errors across all documentation files
+- [X] T037 Review all air-gapped callouts (🔒) for consistency across persona guides and RMF phase pages
+- [X] T038 Verify all MCP tool name references match codebase identifiers in ComplianceMcpTools.cs across tool-inventory.md and persona guides
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (mkdocs.yml must exist) — BLOCKS all user stories
+- **US1 Getting Started (Phase 3)**: Depends on Foundational (getting-started hub must exist)
+- **US2 Persona Guides (Phase 4)**: Depends on Foundational (index.md must exist for cross-linking)
+- **US3 RMF Phase Pages (Phase 5)**: Depends on US2 (persona guides must exist for cross-linking)
+- **US4 Cross-Cutting Guides (Phase 6)**: Depends on US2 (persona guides referenced by NL queries and document catalog)
+- **US5 Reference Material (Phase 7)**: Depends on Foundational only (can start after Phase 2)
+- **US6 Scenario (Phase 8)**: Depends on US1 + US2 (references getting-started and persona guides)
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Getting Started)**: After Foundational → Independent of other stories
+- **US2 (Persona Guides)**: After Foundational → Independent of other stories
+- **US3 (RMF Phases)**: After US2 → Cross-links to persona guides
+- **US4 (Cross-Cutting Guides)**: After US2 → References persona-specific tool usage
+- **US5 (Reference Material)**: After Foundational → Independent of other stories
+- **US6 (Scenario)**: After US1 + US2 → References both getting-started and persona guides
+
+### Within Each User Story
+
+- All pages marked [P] within a story can be authored in parallel (different files)
+- Overview/index pages should be created before detail pages (for cross-linking)
+- Enhancement tasks (existing files) are independent of new page creation
+
+### Parallel Opportunities
+
+- T001 and T002 (Setup) can run in parallel
+- T003, T004, T005 (Foundational) — T004 and T005 are parallel; T003 is independent
+- All US1 tasks (T006–T010) can run in parallel — different files, same template
+- All US2 tasks (T011–T018) can run in parallel — different files, no dependencies
+- All US3 tasks (T020–T026) can run in parallel after T019 (overview is the hub)
+- All US4 tasks (T027–T029) can run in parallel — different files
+- All US5 tasks (T030–T033) can run in parallel — different files
+- US1, US2, and US5 can all run in parallel after Foundational completes
+- US3 and US4 can run in parallel once US2 is complete
+
+---
+
+## Parallel Example: User Story 1 (Getting Started)
+
+```bash
+# All 5 getting-started pages can be authored simultaneously:
+Task T006: "Create ISSM getting-started in docs/getting-started/issm.md"
+Task T007: "Create ISSO getting-started in docs/getting-started/isso.md"
+Task T008: "Create SCA getting-started in docs/getting-started/sca.md"
+Task T009: "Create AO getting-started in docs/getting-started/ao.md"
+Task T010: "Create Engineer getting-started in docs/getting-started/engineer.md"
+```
+
+## Parallel Example: User Story 2 (Persona Guides)
+
+```bash
+# All 8 persona guide tasks can run simultaneously:
+Task T011: "Create persona overview in docs/personas/index.md"
+Task T012: "Create ISSO guide in docs/personas/isso.md"
+Task T013: "Create Administrator guide in docs/personas/administrator.md"
+Task T014: "Enhance ISSM guide in docs/guides/issm-guide.md"
+Task T015: "Enhance SCA guide in docs/guides/sca-guide.md"
+Task T016: "Enhance AO guide in docs/guides/ao-quick-reference.md"
+Task T017: "Enhance Engineer guide in docs/guides/engineer-guide.md"
+Task T018: "Enhance Compliance Watch in docs/guides/compliance-watch.md"
+```
+
+## Parallel Example: After Foundational Completes
+
+```bash
+# Three user stories can start simultaneously after Phase 2:
+Stream A: US1 (T006–T010) — Getting Started pages
+Stream B: US2 (T011–T018) — Persona Guides
+Stream C: US5 (T030–T033) — Reference Material
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (mkdocs.yml)
+2. Complete Phase 2: Foundational (index.md, getting-started hub, redirect)
+3. Complete Phase 3: US1 — Getting Started pages
+4. **STOP and VALIDATE**: `mkdocs build --strict` passes, all 5 persona getting-started pages navigable
+5. Deploy/demo if ready — users can onboard immediately
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Site skeleton live
+2. Add US1 (Getting Started) → Users can onboard → **MVP!**
+3. Add US2 (Persona Guides) → Full persona documentation → Deploy/Demo
+4. Add US3 (RMF Phases) → Phase-by-phase reference → Deploy/Demo
+5. Add US4 (Cross-Cutting Guides) → NL queries, documents, portfolio → Deploy/Demo
+6. Add US5 (Reference Material) → Tool inventory, troubleshooting, quick ref → Deploy/Demo
+7. Add US6 (Scenario) → End-to-end walkthrough → Deploy/Demo
+8. Polish → All cross-links validated, build clean → **Final Release**
+
+### Parallel Team Strategy
+
+With multiple authors:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Author A: US1 (Getting Started) — 5 pages
+   - Author B: US2 (Persona Guides) — 8 pages
+   - Author C: US5 (Reference Material) — 4 pages
+3. After US2 completes:
+   - Author A: US3 (RMF Phases) — 8 pages
+   - Author B: US4 (Cross-Cutting Guides) — 3 pages
+   - Author C: US6 (Scenario) — 1 page
+4. All complete → Polish phase together
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies between them
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and verifiable via `mkdocs build --strict`
+- No tests are generated — validation is `mkdocs build --strict` + manual review
+- All page content should follow the corresponding template in `contracts/`
+- Tool names MUST match the exact MCP tool identifiers from `ComplianceMcpTools.cs`
+- Air-gapped callouts (🔒) are required for: ISSO Implement, ISSM Monitor, SCA Assess, Interface Guide
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently


### PR DESCRIPTION
This pull request introduces a comprehensive onboarding experience for ATO Copilot users, organized by persona. It adds new Markdown documentation for each role, restructures navigation links for clarity, and updates agent instructions to reflect the new documentation system. The most important changes are grouped below:

**User Documentation System**

* Added support for static Markdown documentation using MkDocs, including the mkdocs-material theme and mkdocs-search plugin, as well as a new documentation directory (`docs/`). This enables Python-based static site generation for user guides. [[1]](diffhunk://#diff-2555cee0e70bf9acdac3a0083265e4a8b2b6cd1f6a1a05dffae554cb46a21fbfR34-R35) [[2]](diffhunk://#diff-2555cee0e70bf9acdac3a0083265e4a8b2b6cd1f6a1a05dffae554cb46a21fbfR55-L55)
* Created a central "Getting Started" hub (`docs/getting-started/index.md`) that explains RBAC mapping, supported interfaces, and links to persona-specific onboarding guides.

**Persona-Specific Onboarding Guides**

* Added detailed "Getting Started" guides for each persona: ISSM (`issm.md`), ISSO (`isso.md`), SCA (`sca.md`), AO (`ao.md`), and Engineer (`engineer.md`). Each guide covers prerequisites, first-time setup, the user's first three commands, common issues, and next steps. [[1]](diffhunk://#diff-d80aa14eaf4312de5a070283c3b0cacc254a16c73095eaaff40ef6e665892cb0R1-R74) [[2]](diffhunk://#diff-2cb446fe6e9856dfb2655198f5a130ea7e735940c4ca9458197f29fd508348d1R1-R77) [[3]](diffhunk://#diff-5b963dc4f890203a15be5cfe9fae95dfbed329f50c347ab55785c0e1d75f9e94R1-R84) [[4]](diffhunk://#diff-dd78a3f025f6dc1ab2c0744f7a020ef97ef8e62263536be94de479f5c4196db4R1-R82) [[5]](diffhunk://#diff-69faa0f13b980be4bceaa871cbffa6d03f797e7f0cc97f8aff0f228870571d73R1-R87)

**Navigation and Link Updates**

* Updated navigation links in `docs/getting-started.md` to point to new locations for architecture, development, compliance watch, and remediation kanban documentation, reflecting the reorganized documentation structure.
* Added contextual tips and references in guides, such as a prompt to start with the AO Getting Started guide in the AO quick reference. [[1]](diffhunk://#diff-a4cc0df880b963fb93e5de843dc3e33bb3c57c708945e1ea1eda05dd5082d892R7-R9) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R5-R7)

These changes provide a clear, role-based onboarding experience, streamline documentation access, and improve maintainability of user guides.