### PR TITLE
017 scap stig import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to ATO Copilot are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2026-03-15
+
+### Added
+
+#### Feature 017: SCAP/STIG Viewer Import & Export
+
+- **CKL Checklist Import** (`compliance_import_ckl`) — Import DISA STIG Viewer `.ckl` checklist files with automatic STIG rule resolution, CCI-to-NIST mapping, finding creation, and control effectiveness determination. Supports `Skip`/`Overwrite`/`Merge` conflict resolution strategies and dry-run preview mode.
+- **XCCDF Results Import** (`compliance_import_xccdf`) — Import SCAP Compliance Checker XCCDF result files (1.1 and 1.2 namespaces) with automated rule ID resolution, benchmark score capture, and error/unknown/notchecked result handling.
+- **CKL Checklist Export** (`compliance_export_ckl`) — Export assessment data as DISA STIG Viewer-compatible CHECKLIST XML for eMASS upload or offline review. Generates ASSET, STIG_INFO, and VULN elements with finding status mapping.
+- **Import History** (`compliance_list_imports`) — Paginated import history with filtering by benchmark, import type, date range, and dry-run inclusion.
+- **Import Summary** (`compliance_get_import_summary`) — Detailed per-finding breakdown of any import operation including unmatched rules, conflict resolution actions, and NIST control mappings.
+- **CKL Parser** — Parses DISA STIG Viewer CHECKLIST XML with SI_DATA/VULN_DATA extraction, host metadata, and STIG info parsing. Includes `CklParseException` for structured error reporting.
+- **XCCDF Parser** — Parses SCAP Compliance Checker XCCDF results with XCCDF 1.1/1.2 namespace detection, Benchmark-wrapped TestResult handling, score extraction, and rule ID prefix stripping.
+- **CKL Generator** — Generates DISA STIG Viewer-compatible CHECKLIST XML from assessment data with proper STATUS, FINDING_DETAILS, COMMENTS, and SEVERITY_OVERRIDE elements.
+- **Import Data Model** — `ScanImportRecord` and `ScanImportFinding` entities with SHA-256 duplicate detection, `ImportFindingAction` enum (Created/Updated/Skipped/Unmatched/NotApplicable/NotReviewed/Error), and `ScanImportStatus` lifecycle tracking.
+- **STIG Resolution** — Control lookup by VulnId and RuleId with CCI cross-reference to NIST 800-53 controls. Benchmark-based bulk control retrieval for export.
+- **Effectiveness Aggregation** — Auto-determines per-control effectiveness (Satisfied/OtherThanSatisfied) based on aggregate STIG finding status across all imports.
+- **Evidence Capture** — SHA-256 hashed import evidence with benchmark metadata, finding counts, and XCCDF score data.
+- **Performance** — CKL import with 500 VULNs completes in < 10 seconds; XCCDF import with 500 rule-results in < 5 seconds.
+- **170+ Unit Tests** — Comprehensive test coverage for parsers, service logic, MCP tools, models, CKL generation, and integration scenarios.
+
+### Documentation
+
+- **Agent Tool Catalog** — 5 new tool entries with parameter tables, response schemas, RBAC roles, and RMF step mapping.
+- **ISSM Guide** — STIG import workflow section with dry-run, conflict resolution, and eMASS export workflow.
+- **SCA Guide** — SCAP import for assessment section with imported data usage and SAR integration.
+- **Engineer Guide** — CKL import/export from VS Code via `@ato` chat participant.
+- **STIG Coverage Reference** — Import processing pipeline, status mapping tables, conflict resolution, and duplicate detection.
+
+---
+
 ## [1.17.0] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ AI-powered compliance copilot that guides DoD teams through every step of the NI
 
 Built on the Model Context Protocol (MCP) with Azure OpenAI function calling, 130 compliance tools, and multi-channel delivery (VS Code, web chat, stdio).
 
+ATO Copilot is the first tool that:
+
+- Covers all 7 steps in a single conversational interface
+- Uses AI to automate the hardest part (control narrative writing)
+- Integrates with Azure for automated compliance evidence
+- Exports to eMASS so it fits into the existing DoD workflow instead of replacing it
+
 ATO Copilot is where you DO the work, eMASS is where you SUBMIT the work.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ AI-powered compliance copilot that guides DoD teams through every step of the NI
 
 Built on the Model Context Protocol (MCP) with Azure OpenAI function calling, 130 compliance tools, and multi-channel delivery (VS Code, web chat, stdio).
 
+ATO Copilot is where you DO the work, eMASS is where you SUBMIT the work.
+
 ## Features
 
 ### RMF Lifecycle Automation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ATO Copilot is the first tool that:
 - Integrates with Azure for automated compliance evidence
 - Exports to eMASS so it fits into the existing DoD workflow instead of replacing it
 
-ATO Copilot is where you DO the work, eMASS is where you SUBMIT the work.
+ATO Copilot is where you DO the work, eMASS is where you SUBMIT the work. 
 
 ## Features
 

--- a/docs/architecture/agent-tool-catalog.md
+++ b/docs/architecture/agent-tool-catalog.md
@@ -1722,3 +1722,228 @@ The existing document generation tool now supports three output formats:
 - **RMF Step**: Authorize (Step 5), Monitor (Step 6)
 - **PDF Engine**: QuestPDF (Community Edition, MIT license)
 - **Progress**: Reports streaming progress (0.0–1.0) during PDF generation
+
+---
+
+## SCAP/STIG Viewer Import & Export Tools (Feature 017)
+
+### `compliance_import_ckl`
+
+Import a DISA STIG Viewer CKL checklist file for a registered system. Creates
+compliance findings, control effectiveness records, and evidence artifacts.
+Accepts base64-encoded file content (max 5 MB after decoding).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | Registered system ID |
+| `file_content` | string | Yes | Base64-encoded CKL file content (max 5 MB) |
+| `file_name` | string | Yes | Original file name (e.g., `windows_server_2022.ckl`) |
+| `conflict_resolution` | string | No | How to handle duplicates: `Skip` (default), `Overwrite`, `Merge` |
+| `dry_run` | boolean | No | Preview results without persisting (default: `false`) |
+| `assessment_id` | string | No | Optional assessment ID; auto-resolves or creates one if omitted |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "import_record_id": "...",
+    "import_status": "Completed",
+    "dry_run": false,
+    "benchmark": "Windows_Server_2022_STIG",
+    "benchmark_title": "Windows Server 2022 STIG",
+    "total_entries": 287,
+    "summary": {
+      "open": 12,
+      "pass": 260,
+      "not_applicable": 10,
+      "not_reviewed": 5,
+      "skipped": 0,
+      "unmatched": 3
+    },
+    "changes": {
+      "findings_created": 12,
+      "findings_updated": 0,
+      "effectiveness_created": 8,
+      "effectiveness_updated": 0,
+      "nist_controls_affected": 8
+    },
+    "warnings": ["3 STIG rule(s) not found in curated library: V-99997, V-99998, V-99999"]
+  }
+}
+```
+
+- **RBAC**: ISSM, SCA
+- **RMF Step**: Assess (Step 4)
+- **Duplicate Detection**: SHA-256 file hash prevents re-importing identical files
+- **Conflict Resolution**: `Skip` ignores existing findings, `Overwrite` replaces, `Merge` keeps higher severity
+
+---
+
+### `compliance_import_xccdf`
+
+Import a SCAP Compliance Checker XCCDF results file for a registered system.
+Creates compliance findings and control effectiveness records from automated
+scan results. Supports XCCDF 1.1 and 1.2 namespace formats.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | Registered system ID |
+| `file_content` | string | Yes | Base64-encoded XCCDF file content (max 5 MB) |
+| `file_name` | string | Yes | Original file name (e.g., `scan_results.xccdf`) |
+| `conflict_resolution` | string | No | How to handle duplicates: `Skip` (default), `Overwrite`, `Merge` |
+| `dry_run` | boolean | No | Preview without persisting (default: `false`) |
+| `assessment_id` | string | No | Optional assessment ID |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "import_record_id": "...",
+    "import_status": "CompletedWithWarnings",
+    "dry_run": false,
+    "benchmark": "Windows_Server_2022_STIG",
+    "total_entries": 300,
+    "summary": {
+      "open": 15,
+      "pass": 270,
+      "not_applicable": 8,
+      "error": 2,
+      "skipped": 0,
+      "unmatched": 5
+    },
+    "changes": {
+      "findings_created": 15,
+      "findings_updated": 0,
+      "effectiveness_created": 10,
+      "effectiveness_updated": 0,
+      "nist_controls_affected": 10
+    }
+  }
+}
+```
+
+- **RBAC**: ISSM, SCA
+- **RMF Step**: Assess (Step 4)
+- **Collection Method**: Automated (vs. Manual for CKL)
+- **Score Capture**: XCCDF benchmark score recorded in import record
+
+---
+
+### `compliance_export_ckl`
+
+Export a CKL checklist file for a system and STIG benchmark. Returns
+base64-encoded XML content compatible with DISA STIG Viewer and eMASS upload.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | Registered system ID |
+| `benchmark_id` | string | Yes | STIG benchmark ID (e.g., `Windows_Server_2022_STIG`) |
+| `assessment_id` | string | No | Optional assessment ID (uses latest if omitted) |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "file_content": "<base64-encoded CKL XML>",
+    "file_name": "Windows_Server_2022_STIG_sys-001.ckl",
+    "content_type": "application/xml",
+    "benchmark_id": "Windows_Server_2022_STIG",
+    "system_id": "sys-001"
+  }
+}
+```
+
+- **RBAC**: ISSM, SCA, Engineer
+- **RMF Step**: Assess (Step 4), Monitor (Step 6)
+- **Output Format**: DISA STIG Viewer CHECKLIST XML schema
+- **Finding Status Mapping**: Open → `Open`, Remediated → `NotAFinding`, Accepted → `Not_Applicable`, null → `Not_Reviewed`
+
+---
+
+### `compliance_list_imports`
+
+List import history for a registered system. Shows CKL and XCCDF imports with
+summary statistics. Supports pagination and filtering.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | Registered system ID |
+| `page` | integer | No | Page number, 1-based (default: 1) |
+| `page_size` | integer | No | Items per page (default: 20, max: 100) |
+| `benchmark_id` | string | No | Filter by benchmark ID |
+| `include_dry_runs` | boolean | No | Include dry-run records (default: `false`) |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "total_count": 5,
+    "page": 1,
+    "page_size": 20,
+    "imports": [
+      {
+        "id": "...",
+        "file_name": "windows_2022.ckl",
+        "import_type": "Ckl",
+        "benchmark_id": "Windows_Server_2022_STIG",
+        "status": "Completed",
+        "imported_at": "2026-03-15T10:30:00Z",
+        "total_entries": 287,
+        "open_count": 12,
+        "pass_count": 260,
+        "findings_created": 12
+      }
+    ]
+  }
+}
+```
+
+- **RBAC**: All compliance roles
+- **RMF Step**: Assess (Step 4), Monitor (Step 6)
+
+---
+
+### `compliance_get_import_summary`
+
+Get detailed summary of a specific import operation, including per-finding
+breakdown, unmatched rules, and import configuration.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `import_id` | string | Yes | Import record ID |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "id": "...",
+    "file_name": "windows_2022.ckl",
+    "file_hash": "abc123...",
+    "import_type": "Ckl",
+    "import_status": "CompletedWithWarnings",
+    "benchmark_id": "Windows_Server_2022_STIG",
+    "imported_at": "2026-03-15T10:30:00Z",
+    "conflict_resolution": "Skip",
+    "counts": {
+      "total": 287,
+      "open": 12,
+      "pass": 260,
+      "findings_created": 12,
+      "nist_controls_affected": 8
+    },
+    "findings": [
+      {
+        "vuln_id": "V-12345",
+        "rule_id": "SV-12345r1_rule",
+        "raw_status": "Open",
+        "mapped_severity": "CatII",
+        "action": "Created",
+        "resolved_stig_id": "V-12345"
+      }
+    ]
+  }
+}
+```
+
+- **RBAC**: All compliance roles
+- **RMF Step**: Assess (Step 4), Monitor (Step 6)

--- a/docs/guides/engineer-guide.md
+++ b/docs/guides/engineer-guide.md
@@ -298,6 +298,57 @@ ATO Copilot integrates compliance checking directly into your VS Code editing ex
 
 ---
 
+## CKL Import & Export from VS Code
+
+> Feature 017: SCAP/STIG Viewer Import
+
+Engineers can import CKL checklist files and XCCDF scan results directly through the `@ato` Chat Participant in VS Code, and export CKL files for DISA STIG Viewer review.
+
+### Importing a CKL File
+
+Use the chat participant to import a CKL checklist:
+
+```
+@ato Import this CKL file for my Windows Server system
+```
+
+The AI will invoke `compliance_import_ckl` with the file content and map STIG findings to NIST controls in your baseline.
+
+### Importing XCCDF Scan Results
+
+```
+@ato Import SCAP scan results for system Eagle Eye
+```
+
+The AI resolves the system name to a UUID and invokes `compliance_import_xccdf`.
+
+### Exporting a CKL Checklist
+
+```
+@ato Export a CKL checklist for the Windows Server 2022 STIG on Eagle Eye
+```
+
+The exported CKL file can be opened in DISA STIG Viewer or uploaded to eMASS.
+
+### Reviewing Import History
+
+```
+@ato Show import history for Eagle Eye
+@ato Show details of import <import-id>
+```
+
+### Available Import Tools
+
+| Tool | Description |
+|------|-------------|
+| `compliance_import_ckl` | Import DISA STIG Viewer CKL checklist |
+| `compliance_import_xccdf` | Import SCAP Compliance Checker XCCDF results |
+| `compliance_export_ckl` | Export CKL for STIG Viewer / eMASS upload |
+| `compliance_list_imports` | List import history for a system |
+| `compliance_get_import_summary` | Detailed per-finding import breakdown |
+
+---
+
 ## See Also
 
 - [Engineer Getting Started](../getting-started/engineer.md) — First-time setup and first 3 commands

--- a/docs/guides/issm-guide.md
+++ b/docs/guides/issm-guide.md
@@ -742,6 +742,91 @@ custom template for DOCX generation.
 
 ---
 
+## SCAP/STIG Viewer Import Workflow
+
+> Feature 017: SCAP/STIG Viewer Import
+
+ATO Copilot supports importing DISA STIG Viewer CKL checklists and SCAP Compliance Checker XCCDF results directly into the compliance database. Imported data auto-creates compliance findings, assessment evidence, and control effectiveness records.
+
+### Import CKL Checklists
+
+Use `compliance_import_ckl` to import manual STIG checklist results from DISA STIG Viewer:
+
+```
+Tool: compliance_import_ckl
+Parameters:
+  system_id: "<system-guid>"
+  file_content: "<base64-encoded .ckl file>"
+  file_name: "windows_server_2022.ckl"
+  conflict_resolution: "Skip"
+  dry_run: "true"
+```
+
+!!! tip "Dry Run First"
+    Always run with `dry_run: true` first to preview changes. Review the summary, then re-run with `dry_run: false` to persist.
+
+### Import XCCDF Scan Results
+
+Use `compliance_import_xccdf` to import automated SCAP scan results:
+
+```
+Tool: compliance_import_xccdf
+Parameters:
+  system_id: "<system-guid>"
+  file_content: "<base64-encoded .xccdf file>"
+  file_name: "scan_results.xccdf"
+  conflict_resolution: "Overwrite"
+```
+
+### Export CKL for eMASS Upload
+
+Export current assessment state as a CKL checklist for upload to eMASS or review in DISA STIG Viewer:
+
+```
+Tool: compliance_export_ckl
+Parameters:
+  system_id: "<system-guid>"
+  benchmark_id: "Windows_Server_2022_STIG"
+```
+
+### Conflict Resolution Strategies
+
+| Strategy | Behavior |
+|----------|----------|
+| `Skip` | Keep existing findings unchanged (default) |
+| `Overwrite` | Replace existing findings with new import data |
+| `Merge` | Keep whichever finding has the higher severity |
+
+### Review Import History
+
+```
+Tool: compliance_list_imports
+Parameters:
+  system_id: "<system-guid>"
+  benchmark_id: "Windows_Server_2022_STIG"  (optional filter)
+```
+
+For detailed per-finding breakdown of a specific import:
+
+```
+Tool: compliance_get_import_summary
+Parameters:
+  import_id: "<import-record-id>"
+```
+
+### Typical ISSM STIG Import Workflow
+
+```
+1. Receive CKL/XCCDF files from assessors or scanning team
+2. compliance_import_ckl (dry_run: true)  ← Preview findings
+3. compliance_import_ckl (dry_run: false) ← Persist findings
+4. compliance_list_imports               ← Verify import record
+5. compliance_get_import_summary         ← Review per-finding details
+6. compliance_export_ckl                 ← Export for eMASS upload
+```
+
+---
+
 ## See Also
 
 - [ISSM Getting Started](../getting-started/issm.md) — First-time setup and first 3 commands

--- a/docs/guides/sca-guide.md
+++ b/docs/guides/sca-guide.md
@@ -232,6 +232,59 @@ All evidence collected by ATO Copilot is integrity-protected:
 
 ---
 
+## SCAP/STIG Import for Assessment
+
+> Feature 017: SCAP/STIG Viewer Import
+
+As an SCA, you can leverage imported CKL and XCCDF data to inform your control assessments. Imported scan results automatically create compliance findings with STIG-to-NIST mappings, providing evidence for your assessment determinations.
+
+### Using Imported Scan Data
+
+After the ISSM imports CKL/XCCDF files, findings are automatically created with:
+- **CAT severity** mapped from STIG rules
+- **NIST control mapping** via CCI cross-references
+- **Control effectiveness** auto-determined based on aggregate finding status
+
+### Reviewing Import Results
+
+```
+Tool: compliance_list_imports
+Parameters:
+  system_id: "<system-guid>"
+```
+
+For per-finding detail:
+
+```
+Tool: compliance_get_import_summary
+Parameters:
+  import_id: "<import-record-id>"
+```
+
+### Assessment Workflow with STIG Imports
+
+```
+1. Review imported findings via compliance_list_imports
+2. compliance_assess_control  ← Use imported STIG data as evidence
+3. compliance_take_snapshot   ← Capture state including imported findings
+4. compliance_generate_sar    ← SAR includes STIG-based severity data
+```
+
+### Exporting Assessment State
+
+Export the current assessment state as a CKL checklist for external review:
+
+```
+Tool: compliance_export_ckl
+Parameters:
+  system_id: "<system-guid>"
+  benchmark_id: "Windows_Server_2022_STIG"
+```
+
+The exported CKL file is compatible with DISA STIG Viewer and eMASS.
+
+---
+
 ## See Also
 
 - [SCA Getting Started](../getting-started/sca.md) — First-time setup and first 3 commands

--- a/docs/reference/stig-coverage.md
+++ b/docs/reference/stig-coverage.md
@@ -143,3 +143,79 @@ The GitHub Actions compliance gate (`ato-compliance-gate`) uses CAT severity to 
 | CAT III | Warning annotation only |
 
 Risk acceptances for specific findings bypass the gate block for accepted controls.
+
+---
+
+## STIG Import & Export
+
+> Feature 017: SCAP/STIG Viewer Import
+
+ATO Copilot can import and export STIG assessment data in industry-standard formats:
+
+### Supported Import Formats
+
+| Format | Source | Tool | Collection Method |
+|--------|--------|------|-------------------|
+| **CKL** | DISA STIG Viewer | `compliance_import_ckl` | Manual |
+| **XCCDF** | SCAP Compliance Checker | `compliance_import_xccdf` | Automated |
+
+### Import Processing Pipeline
+
+```
+CKL/XCCDF File
+  ↓ Parse & validate
+STIG Rule Resolution
+  ↓ Match VulnId/RuleId → StigControl
+CCI/NIST Mapping
+  ↓ Cross-reference StigControl → CCI → NIST 800-53
+Finding Creation
+  ↓ ComplianceFinding with CAT severity
+Effectiveness Update
+  ↓ Aggregate per-control effectiveness
+Evidence Capture
+  ↓ SHA-256 hashed import evidence
+```
+
+### Status Mapping
+
+#### CKL Status → Finding Status
+
+| CKL Status | Finding Status |
+|------------|----------------|
+| Open | Open |
+| NotAFinding | Remediated |
+| Not_Applicable | Accepted |
+| Not_Reviewed | Open |
+
+#### XCCDF Result → Finding Status
+
+| XCCDF Result | Finding Status |
+|--------------|----------------|
+| fail | Open |
+| pass | Remediated |
+| notapplicable | Accepted |
+| error | Open |
+| unknown | Open |
+| notchecked | Open |
+
+### Export Format
+
+| Format | Target | Tool |
+|--------|--------|------|
+| **CKL** | DISA STIG Viewer / eMASS | `compliance_export_ckl` |
+
+Exported CKL files follow the DISA STIG Viewer CHECKLIST XML schema with ASSET, STIG_INFO, and VULN elements.
+
+### Conflict Resolution
+
+When re-importing files that contain findings already present in the database:
+
+| Strategy | Behavior |
+|----------|----------|
+| **Skip** | Keep existing finding unchanged (default) |
+| **Overwrite** | Replace existing finding with imported data |
+| **Merge** | Keep whichever finding has the higher severity |
+
+### Duplicate Detection
+
+Imports use SHA-256 file hashing to detect and warn about duplicate file imports.

--- a/specs/017-scap-stig-import/checklists/comprehensive.md
+++ b/specs/017-scap-stig-import/checklists/comprehensive.md
@@ -1,0 +1,150 @@
+# Comprehensive Requirements Quality Checklist: 017 — SCAP/STIG Viewer Import
+
+**Purpose**: Validate completeness, clarity, consistency, and measurability of requirements for Feature 017.  
+**Created**: 2026-03-01  
+**Feature**: [spec.md](../spec.md) | [plan.md](../plan.md) | [data-model.md](../data-model.md) | [contracts/mcp-tools.md](../contracts/mcp-tools.md)  
+**Depth**: Deep (30+ items)  
+**Audience**: Author self-review before implementation  
+**Focus**: CKL/XCCDF parsing, STIG resolution, finding creation, import management
+
+---
+
+## Requirement Completeness — Parsing
+
+- [x] CHK001 — Are all CKL XML elements documented that the parser must handle? [Completeness, Spec §3.1]
+  > **PASS**: Spec §3.1 documents CHECKLIST structure: ASSET (7 fields), STIGS/iSTIG/STIG_INFO (SI_DATA pairs), VULN (STIG_DATA pairs + STATUS/FINDING_DETAILS/COMMENTS/SEVERITY_OVERRIDE/SEVERITY_JUSTIFICATION). Research R1 adds edge cases (multiple iSTIG, missing CCI_REF, HTML in details).
+
+- [x] CHK002 — Are all CKL STATUS values mapped with clear behavior? [Completeness, Spec §3.1]
+  > **PASS**: Four STATUS values fully mapped: Open→FindingStatus.Open, NotAFinding→FindingStatus.Remediated, Not_Applicable→no finding created, Not_Reviewed→FindingStatus.Open with note "Not yet reviewed" (clarified 2026-03-03). Each maps to ControlEffectiveness determination.
+
+- [x] CHK003 — Are all XCCDF result values documented with mapping? [Completeness, Spec §3.2]
+  > **PASS**: Nine result values mapped: pass, fail, error, unknown, notapplicable, notchecked, notselected, informational, fixed. Error/unknown flagged for manual review.
+
+- [x] CHK004 — Is the XCCDF namespace handling strategy defined for version compatibility? [Completeness, Research R2]
+  > **PASS**: Research R2 defines: try XCCDF 1.2 namespace first, fall back to 1.1, then namespace-agnostic local-name matching. ARF wrapper detection also specified.
+
+- [x] CHK005 — Are malformed XML handling requirements specified? [Completeness, Spec §1.1]
+  > **PASS**: Spec §1.1 requires "Handle malformed/truncated XML gracefully with detailed error reporting." Research R1 specifies XmlException catching. Test data includes malformed samples (T010, T037).
+
+## Requirement Completeness — Resolution Pipeline
+
+- [x] CHK006 — Is the STIG resolution fallback chain fully specified? [Completeness, Spec §6]
+  > **PASS**: Spec §6 defines: Primary=VulnId, Fallback 1=RuleId, Fallback 2=StigVersion. Unmatched entries logged with VulnId/RuleId/Title. T014 implements this chain.
+
+- [x] CHK007 — Is the CCI→NIST mapping resolution documented with failure handling? [Completeness, Spec §6]
+  > **PASS**: Spec §6 step 3 defines: CCI→cci-nist-mapping.json→NIST IDs. Validate against ControlBaseline.ControlIds. Log controls not in baseline. Research R3 confirms missing CCI refs logged as warnings.
+
+- [x] CHK008 — Is the aggregation rule for ControlEffectiveness clearly defined when multiple STIG rules map to the same NIST control? [Clarity, Research R3]
+  > **PASS**: Research R3 defines: "worst result" — any Open finding → OtherThanSatisfied for the NIST control. All rules pass → Satisfied. Clarified 2026-03-03: re-evaluates ALL current findings for the control after each import (aggregate state, not per-import).
+
+- [x] CHK009 — Is the behavior defined when a CKL entry has zero CCI references? [Edge Case, Research R1]
+  > **PASS**: Research R1 identifies this edge case for older STIGs. Fallback: use curated `StigControl.NistControls` field. If StigControl not found either → unmatched, logged.
+
+## Requirement Completeness — Import Management
+
+- [x] CHK010 — Is the assessment context behavior specified when no assessment_id is provided? [Completeness, Spec §7.4]
+  > **PASS**: Spec §7.4 defines three cases: (1) assessment_id provided → validate active, (2) no active assessment → create one with source="STIG/SCAP Import", (3) active assessment exists → use it with warning.
+
+- [x] CHK011 — Is dry-run behavior specified in enough detail? [Completeness, Spec §1.8]
+  > **PASS**: Spec §1.8 requires "Preview import results without persisting changes." Data-model sets `IsDryRun=true`. T027 requires no DB writes. T029 validates dry-run accuracy matches actual.
+
+- [x] CHK012 — Is import history sufficient for audit requirements? [Completeness, Data Model]
+  > **PASS**: ScanImportRecord captures: file hash, file size, benchmark, target, all counts, conflict resolution used, dry-run flag, importer identity, timestamp, warnings. ScanImportFinding provides per-rule audit trail.
+
+## Requirement Clarity — Ambiguous Terms
+
+- [x] CHK013 — Is "merge" conflict resolution defined with specific field-level behavior? [Clarity, Research R5]
+  > **PASS**: Research R5 defines per-field merge rules: Status takes imported (more current), Severity takes higher (conservative), FindingDetails appends with timestamp separator, Comments appends, CatSeverity uses override if present, Timestamps update DiscoveredAt.
+
+- [x] CHK014 — Is "unmatched rule" clearly defined? [Clarity, Spec §4.5]
+  > **PASS**: A STIG rule is "unmatched" when neither VulnId, RuleId, nor StigVersion matches any record in the curated `stig-controls.json` library. Tracked in `ScanImportFinding.ImportAction = Unmatched`.
+
+- [x] CHK015 — Is the 5MB file size limit justified and clearly documented? [Clarity, Spec §7.3]
+  > **PASS**: Spec §7.3 provides size analysis showing typical CKL/XCCDF files are well under 5MB. Research R4 confirms >99% coverage. Error message provides actionable guidance ("Consider splitting by benchmark").
+
+## Requirement Consistency
+
+- [x] CHK016 — Is `ScanSourceType` consistently used? Existing findings use `Resource|Policy|Defender|Combined` — does "CKL Import" fit any of these? [Consistency, Spec §1.4]
+  > **PASS**: Spec §1.4 sets `ScanSource = ScanSourceType.Combined`. The `Source` string field (not enum) gets the descriptive value `"CKL Import"` / `"SCAP Import"`. This matches the existing pattern where `Source` is a descriptive string.
+
+- [x] CHK017 — Are new `EvidenceType` values consistent with existing types? [Consistency, Data Model]
+  > **PASS**: `EvidenceType` is a string field, not an enum. Existing values: "ConfigurationExport", "PolicySnapshot", etc. New values "StigChecklist" and "ScapResult" follow the same naming convention.
+
+- [x] CHK018 — Is the `ComplianceFinding.ImportRecordId` FK nullable and backward-compatible? [Consistency, Data Model]
+  > **PASS**: `ImportRecordId` is nullable (string?). Existing findings have null ImportRecordId. OnDelete=SetNull. No breaking changes to existing data.
+
+- [x] CHK019 — Are RBAC roles consistent between import tools and existing assessment tools? [Consistency, Contracts RBAC Summary]
+  > **PASS**: Import tools use SecurityLead/Analyst/Administrator — same roles that can write assessment data. Auditor gets read-only (list/summary) matching existing assessment tool pattern.
+
+## Acceptance Criteria Quality
+
+- [x] CHK020 — Are performance requirements testable? [Measurability, Spec §10]
+  > **PASS**: "CKL import < 10s for 500 VULNs" and "XCCDF import < 5s for 500 rule-results" are specific, measurable, and testable with sample files.
+
+- [x] CHK021 — Is the "≥95% CCI mapping success" criterion measurable? [Measurability, Spec §10]
+  > **PASS**: Measurable from import results: (resolved CCI refs / total CCI refs) × 100. The 5% margin accounts for CCI entries not yet in cci-nist-mapping.json.
+
+- [x] CHK022 — Is "CKL export re-importable by STIG Viewer" verifiable? [Measurability, Spec §10]
+  > **PASS**: Verifiable via round-trip test: export CKL → re-parse with CklParser → compare data. Manual verification with STIG Viewer is an acceptance test, not automated.
+
+## Scenario Coverage — Happy Path
+
+- [x] CHK023 — Is the end-to-end import flow fully specified as a connected workflow? [Coverage, Spec §6]
+  > **PASS**: Spec §6 defines pipeline: Parse → Resolve STIG → Resolve NIST → Check Conflicts → Apply → Record. Integration test T060 validates full flow: register → categorize → baseline → import CKL → verify findings → export CKL → re-import.
+
+- [x] CHK024 — Is the CKL round-trip (import → modify → export → re-import) tested? [Coverage, Tasks T047]
+  > **PASS**: T047 includes "Exported CKL re-parseable by CklParser (round-trip)" test. T060 integration test covers import → export → re-import with Skip.
+
+## Scenario Coverage — Exception Flows
+
+- [x] CHK025 — What happens when all CKL entries are Not_Applicable? [Edge Case]
+  > **PASS**: Import completes with `openCount=0, passCount=0, notApplicableCount=N`. No ComplianceFindings created. No ControlEffectiveness records. `ImportStatus = Completed` (not an error — valid assessment outcome).
+
+- [x] CHK026 — What happens when a CKL contains VULNs for a STIG that has no overlap with the system's control baseline? [Edge Case]
+  > **PASS**: CCI→NIST resolution produces NIST controls. Controls not in baseline → logged as warnings in `ScanImportRecord.Warnings`. Findings still created (audit trail). ControlEffectiveness NOT created for out-of-baseline controls (clarified 2026-03-03).
+
+- [x] CHK027 — What happens when the same CKL file is imported twice with Skip resolution? [Edge Case]
+  > **PASS**: Second import detects all findings as conflicts, skips all, `SkippedCount = N`, `FindingsCreated = 0`. Import record still created for audit trail. T060 tests this scenario.
+
+- [x] CHK028 — What happens when the system has no ControlBaseline selected? [Edge Case]
+  > **PASS**: Spec §7.1 requires `IBaselineService.GetBaselineAsync`. If no baseline → all NIST controls are "not in baseline" → warnings logged. Findings still created but no ControlEffectiveness records. Warning: "System has no control baseline — NIST control mapping skipped."
+
+- [x] CHK029 — What happens with a CKL from a very old STIG version not in the curated library? [Edge Case]
+  > **PASS**: All VULNs will be "unmatched." Import completes with `unmatchedCount = totalEntries`. `ImportStatus = CompletedWithWarnings`. Unmatched rules listed in summary for library expansion consideration.
+
+- [x] CHK030 — Is the behavior defined for concurrent imports of the same system? [Concurrency]
+  > **PASS**: Imports operate within an assessment context (AssessmentId). Multiple concurrent imports to the same system will create separate ScanImportRecords. Conflict detection uses per-finding StigId+AssessmentId locking. EF Core optimistic concurrency handles rare row-level conflicts.
+
+## Cross-Cutting Concerns
+
+- [x] CHK031 — Is audit logging sufficient for compliance requirements? [Audit]
+  > **PASS**: `ScanImportRecord` logs who, when, what file (hash), what system, what results. `ScanImportFinding` logs per-rule action taken. Evidence includes file content hash for tamper detection. All tools log input/duration/outcome per constitution.
+
+- [x] CHK032 — Is the data model backward-compatible with existing data? [Migration]
+  > **PASS**: Only addition: nullable `ImportRecordId` on `ComplianceFinding`. Existing findings unaffected (null). New entities are additive. EF Core migration (T006) is non-destructive.
+
+- [x] CHK033 — Are all new tools discoverable by the AI agent tool selection? [Integration]
+  > **PASS**: 5 new tools registered in ComplianceMcpTools.cs. Agent's `SelectToolsForMessage` will match on keywords: "import", "CKL", "STIG", "SCAP", "XCCDF", "checklist", "scan results", "export CKL".
+
+## Analysis-Driven Additions (2026-03-03)
+
+- [x] CHK034 — Is duplicate file detection behavior defined? [Completeness, Spec §1.10]
+  > **PASS**: Capability 1.10 added. Check FileHash + RegisteredSystemId on import. If match found: warn but proceed. Task T030 implements detection with warning message.
+
+- [x] CHK035 — Is the base64 decoding boundary (tool vs service layer) clarified? [Clarity, Tasks T013/T030]
+  > **PASS**: Tool layer decodes base64 → byte[]. Service layer receives raw bytes. Explicitly stated in T030 and T013 interface signature.
+
+- [x] CHK036 — Is `ScanTimestamp` handling for CKL (which has no scan timestamp) clarified? [Clarity, Data Model]
+  > **PASS**: Data model field description updated: CKL → null (no scan timestamp in format), XCCDF → `start-time` attribute.
+
+- [x] CHK037 — Is date range filtering available for import history? [Completeness, Contracts]
+  > **PASS**: `from_date` and `to_date` ISO 8601 parameters added to `compliance_list_imports` tool contract and `ListImportsAsync` interface.
+
+- [x] CHK038 — Are structured logging requirements covered by tasks? [Constitution V, Tasks T061]
+  > **PASS**: Task T061 adds ILogger-based structured logging to ScanImportService: import started/completed events, parse errors, unmatched rules, out-of-baseline controls.
+
+- [x] CHK039 — Are performance benchmarks covered by tasks? [Constitution VIII, Tasks T062]
+  > **PASS**: Task T062 adds performance tests: CKL 500 VULNs < 10s, XCCDF 500 rules < 5s, measured with Stopwatch and asserted.
+
+- [x] CHK040 — Does `FindingSeverity.Informational` exist for XCCDF `informational` result mapping? [Consistency, ComplianceModels.cs]
+  > **PASS**: Verified in source code — `FindingSeverity` enum includes `Informational` value with XML doc "No risk — informational observation only."

--- a/specs/017-scap-stig-import/contracts/mcp-tools.md
+++ b/specs/017-scap-stig-import/contracts/mcp-tools.md
@@ -1,0 +1,296 @@
+# Contracts: 017 — MCP Tool Contracts
+
+**Date**: 2026-03-01 | **Plan**: [plan.md](plan.md) | **Data Model**: [data-model.md](../data-model.md)
+
+All tools follow the existing MCP JSON-RPC 2.0 protocol (`McpRequest`/`McpResponse`) and the standard tool envelope:
+
+```json
+{
+  "content": [{ "type": "text", "text": "<response>" }],
+  "isError": false
+}
+```
+
+Errors use `McpToolResult.Error(message)`. All tools extend `BaseTool` and are registered via `RegisterTool()`.
+
+---
+
+## Phase 1 — CKL Import
+
+### `compliance_import_ckl`
+
+Import a DISA STIG Viewer checklist (.ckl) file for a registered system.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | yes | RegisteredSystem ID |
+| `file_content` | string | yes | Base64-encoded .ckl file content |
+| `file_name` | string | yes | Original file name (e.g., `Windows_Server_2022_STIG_V1R1.ckl`) |
+| `conflict_resolution` | string | no | `"skip"` (default) \| `"overwrite"` \| `"merge"` |
+| `dry_run` | bool | no | Default: false. When true, preview import without persisting. |
+| `assessment_id` | string | no | Existing ComplianceAssessment ID. If omitted, creates or reuses active assessment. |
+
+**Returns**: Import summary JSON:
+
+```json
+{
+  "importRecordId": "guid",
+  "status": "CompletedWithWarnings",
+  "benchmarkId": "Windows_Server_2022_STIG",
+  "benchmarkTitle": "Microsoft Windows Server 2022 Security Technical Implementation Guide",
+  "targetHostName": "web-server-01",
+  "totalEntries": 284,
+  "openCount": 12,
+  "passCount": 245,
+  "notApplicableCount": 22,
+  "notReviewedCount": 5,
+  "skippedCount": 0,
+  "unmatchedCount": 3,
+  "findingsCreated": 12,
+  "findingsUpdated": 0,
+  "effectivenessRecordsCreated": 8,
+  "effectivenessRecordsUpdated": 0,
+  "nistControlsAffected": 8,
+  "warnings": [
+    "3 STIG rules not found in curated library: V-999001, V-999002, V-999003",
+    "2 NIST controls resolved but not in system baseline: SI-16, SC-28(1)"
+  ],
+  "unmatchedRules": [
+    { "vulnId": "V-999001", "ruleId": null, "ruleTitle": "Custom local rule", "severity": "medium" }
+  ],
+  "isDryRun": false
+}
+```
+
+**RBAC**: `Compliance.SecurityLead`, `Compliance.Analyst`, `Compliance.Administrator`
+
+**Validation**:
+- System must exist and be active
+- File content must be valid base64
+- Decoded file must be ≤ 5MB
+- XML must parse as valid CKL (contains `<CHECKLIST>` root)
+- System should be in RMF step Assess or later (warning if not, still allowed)
+- Duplicate file detection: if `FileHash` + `RegisteredSystemId` matches an existing import, add warning "File previously imported on {date} (import ID: {id})" — import still proceeds
+
+**Error cases**:
+- `system_id` not found → `"System '{system_id}' not found"`
+- Invalid base64 → `"Invalid base64 encoding in file_content"`
+- File too large → `"File exceeds 5MB limit (actual: {size}MB). Consider splitting by benchmark."`
+- Invalid XML → `"Failed to parse CKL file: {xml_error}"`
+- No VULN entries → `"CKL file contains no VULN entries"`
+
+---
+
+## Phase 2 — XCCDF Import
+
+### `compliance_import_xccdf`
+
+Import SCAP Compliance Checker XCCDF results (.xccdf) file for a registered system.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | yes | RegisteredSystem ID |
+| `file_content` | string | yes | Base64-encoded .xccdf file content |
+| `file_name` | string | yes | Original file name |
+| `conflict_resolution` | string | no | `"skip"` (default) \| `"overwrite"` \| `"merge"` |
+| `dry_run` | bool | no | Default: false |
+| `assessment_id` | string | no | Existing ComplianceAssessment ID |
+
+**Returns**: Same `ImportResult` format as CKL import, plus:
+
+```json
+{
+  "xccdfScore": 72.5,
+  "scanStartTime": "2026-02-15T14:30:00Z",
+  "scanEndTime": "2026-02-15T14:45:22Z"
+}
+```
+
+**RBAC**: `Compliance.SecurityLead`, `Compliance.Analyst`, `Compliance.Administrator`
+
+**Validation**: Same as CKL import, plus:
+- XML must contain `<TestResult>` element (XCCDF 1.1 or 1.2 namespace)
+
+**Error cases**: Same as CKL import, plus:
+- No TestResult element → `"XCCDF file does not contain a TestResult element"`
+
+---
+
+## Phase 3 — CKL Export
+
+### `compliance_export_ckl`
+
+Generate a DISA STIG Viewer checklist (.ckl) file from assessment data.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | yes | RegisteredSystem ID |
+| `benchmark_id` | string | yes | STIG Benchmark ID (e.g., `Windows_Server_2022_STIG`) |
+| `assessment_id` | string | no | Specific assessment. Default: most recent. |
+
+**Returns**: Export result JSON:
+
+```json
+{
+  "fileName": "Windows_Server_2022_STIG_V1R1_ACME_Portal.ckl",
+  "fileContent": "<base64-encoded-ckl-xml>",
+  "fileSizeBytes": 245760,
+  "totalVulns": 284,
+  "openCount": 8,
+  "notAFindingCount": 249,
+  "notApplicableCount": 22,
+  "notReviewedCount": 5,
+  "generatedAt": "2026-03-01T15:00:00Z"
+}
+```
+
+**RBAC**: `Compliance.SecurityLead`, `Compliance.Analyst`, `Compliance.PlatformEngineer`, `Compliance.Administrator`
+
+**Validation**:
+- System must exist
+- Benchmark must exist in `StigControl` library (at least one rule with matching `BenchmarkId`)
+- Assessment data is optional — rules without matching `ComplianceFinding` records are exported as `Not_Reviewed`
+
+**Error cases**:
+- Benchmark not found in StigControl library → `"No STIG benchmark '{benchmark_id}' found in curated library"`
+- System not found → standard error
+
+---
+
+## Phase 4 — Import Management
+
+### `compliance_list_imports`
+
+List import history for a registered system.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | yes | RegisteredSystem ID |
+| `page` | int | no | 1-based page number. Default: 1 |
+| `page_size` | int | no | Default: 20, max: 100 |
+| `benchmark_id` | string | no | Filter by STIG benchmark |
+| `import_type` | string | no | `"ckl"` \| `"xccdf"` to filter by type |
+| `from_date` | string | no | ISO 8601 date. Only imports on or after this date. |
+| `to_date` | string | no | ISO 8601 date. Only imports on or before this date. |
+| `include_dry_runs` | bool | no | Default: false |
+
+**Returns**: Paginated import records:
+
+```json
+{
+  "systemId": "guid",
+  "systemName": "ACME Portal",
+  "totalImports": 12,
+  "page": 1,
+  "pageSize": 20,
+  "imports": [
+    {
+      "importId": "guid",
+      "importType": "Ckl",
+      "fileName": "Windows_Server_2022_STIG_V1R1.ckl",
+      "benchmarkId": "Windows_Server_2022_STIG",
+      "benchmarkTitle": "Microsoft Windows Server 2022 STIG",
+      "targetHostName": "web-server-01",
+      "status": "CompletedWithWarnings",
+      "totalEntries": 284,
+      "openCount": 12,
+      "passCount": 245,
+      "findingsCreated": 12,
+      "findingsUpdated": 0,
+      "unmatchedCount": 3,
+      "conflictResolution": "Skip",
+      "isDryRun": false,
+      "importedBy": "john.doe@example.mil",
+      "importedAt": "2026-03-01T14:30:00Z"
+    }
+  ]
+}
+```
+
+**RBAC**: `Compliance.SecurityLead`, `Compliance.Analyst`, `Compliance.Auditor`, `Compliance.Administrator`
+
+---
+
+### `compliance_get_import_summary`
+
+Get detailed breakdown of a specific import operation.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `import_id` | string | yes | ScanImportRecord ID |
+
+**Returns**: Full import details with per-finding breakdown:
+
+```json
+{
+  "importRecord": {
+    "id": "guid",
+    "importType": "Ckl",
+    "fileName": "Windows_Server_2022_STIG_V1R1.ckl",
+    "fileHash": "sha256:abc123...",
+    "benchmarkId": "Windows_Server_2022_STIG",
+    "status": "CompletedWithWarnings",
+    "totalEntries": 284,
+    "openCount": 12,
+    "passCount": 245,
+    "notApplicableCount": 22,
+    "notReviewedCount": 5,
+    "unmatchedCount": 3,
+    "findingsCreated": 12,
+    "findingsUpdated": 0,
+    "effectivenessRecordsCreated": 8,
+    "nistControlsAffected": 8,
+    "importedBy": "john.doe@example.mil",
+    "importedAt": "2026-03-01T14:30:00Z",
+    "warnings": ["..."]
+  },
+  "nistControlBreakdown": [
+    {
+      "controlId": "AC-2",
+      "controlTitle": "Account Management",
+      "stigRulesMatched": 4,
+      "openFindings": 1,
+      "passedFindings": 3,
+      "effectiveness": "OtherThanSatisfied"
+    }
+  ],
+  "unmatchedRules": [
+    { "vulnId": "V-999001", "ruleTitle": "Custom rule", "severity": "medium" }
+  ],
+  "findings": [
+    {
+      "vulnId": "V-254239",
+      "ruleId": "SV-254239r849090_rule",
+      "rawStatus": "Open",
+      "severity": "high",
+      "catSeverity": "CatI",
+      "action": "Created",
+      "nistControls": ["AU-3", "AU-3(1)"],
+      "findingDetails": "Audit policy not configured..."
+    }
+  ]
+}
+```
+
+**RBAC**: `Compliance.SecurityLead`, `Compliance.Analyst`, `Compliance.Auditor`, `Compliance.Administrator`
+
+**Error cases**:
+- Import not found → `"Import record '{import_id}' not found"`
+
+---
+
+## RBAC Summary
+
+| Tool | Administrator | SecurityLead | Auditor | Analyst | PlatformEngineer | Viewer |
+|------|:---:|:---:|:---:|:---:|:---:|:---:|
+| `compliance_import_ckl` | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| `compliance_import_xccdf` | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| `compliance_export_ckl` | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `compliance_list_imports` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `compliance_get_import_summary` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+**Rationale**:
+- Import (write) requires SecurityLead/Analyst/Admin — assessors who own the scan data
+- Export (read+generate) includes PlatformEngineer — engineers need CKL files for eMASS
+- List/Summary (read) includes Auditor — SCAs reviewing assessment evidence
+- Viewer role excluded from all tools — import/export history is operational, not informational

--- a/specs/017-scap-stig-import/data-model.md
+++ b/specs/017-scap-stig-import/data-model.md
@@ -1,0 +1,355 @@
+# Data Model: 017 — SCAP/STIG Viewer Import
+
+**Date**: 2026-03-01 | **Plan**: [plan.md](plan.md) | **Spec**: [spec.md](spec.md)
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    RegisteredSystem ||--o{ ScanImportRecord : "receives imports"
+    ComplianceAssessment ||--o{ ScanImportRecord : "contains imports"
+
+    ScanImportRecord ||--o{ ScanImportFinding : "produces"
+    ScanImportRecord ||--o{ ComplianceFinding : "creates"
+    ScanImportRecord ||--o{ ComplianceEvidence : "generates"
+
+    ScanImportFinding }o--o| ComplianceFinding : "maps to"
+    ScanImportFinding }o--o| StigControl : "resolves via"
+
+    ComplianceFinding }o--o| ControlEffectiveness : "determines"
+    ComplianceFinding }o--o| ScanImportRecord : "imported from"
+
+    ControlEffectiveness }o--o{ ComplianceEvidence : "linked evidence"
+```
+
+## New Entities
+
+### ScanImportRecord (Phase 1)
+
+Tracks each file import operation. One record per imported file.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `Id` | `string` | PK, GUID | Unique identifier |
+| `RegisteredSystemId` | `string` | FK → RegisteredSystem, Required | System this import belongs to |
+| `AssessmentId` | `string` | FK → ComplianceAssessment, Required | Assessment context for findings |
+| `ImportType` | `ScanImportType` enum | Required | `Ckl` \| `Xccdf` |
+| `FileName` | `string` | Required, MaxLength(500) | Original file name |
+| `FileHash` | `string` | Required, MaxLength(128) | SHA-256 hash of raw file content |
+| `FileSizeBytes` | `long` | Required | File size before base64 encoding |
+| `BenchmarkId` | `string?` | MaxLength(200) | STIG benchmark ID (e.g., `Windows_Server_2022_STIG`) |
+| `BenchmarkVersion` | `string?` | MaxLength(50) | STIG release version |
+| `BenchmarkTitle` | `string?` | MaxLength(500) | STIG benchmark display title |
+| `TargetHostName` | `string?` | MaxLength(200) | Target system hostname from scan |
+| `TargetIpAddress` | `string?` | MaxLength(50) | Target IP address |
+| `ScanTimestamp` | `DateTime?` | UTC | When the scan was performed. XCCDF: from `start-time` attribute. CKL: `null` (CKL format has no scan timestamp; STIG_INFO `releaseinfo` is the benchmark release date, not the scan date). |
+| `TotalEntries` | `int` | Required | Total rules/VULNs in the file |
+| `OpenCount` | `int` | | Findings with status Open/Fail |
+| `PassCount` | `int` | | Findings with status NotAFinding/Pass |
+| `NotApplicableCount` | `int` | | Findings with status Not_Applicable |
+| `NotReviewedCount` | `int` | | Findings not evaluated (CKL `Not_Reviewed` / XCCDF `notchecked`) |
+| `ErrorCount` | `int` | | XCCDF error/unknown results |
+| `SkippedCount` | `int` | | Entries skipped due to conflict resolution |
+| `UnmatchedCount` | `int` | | STIG rules not found in curated library |
+| `FindingsCreated` | `int` | | New `ComplianceFinding` records created |
+| `FindingsUpdated` | `int` | | Existing findings updated (overwrite/merge) |
+| `EffectivenessRecordsCreated` | `int` | | New `ControlEffectiveness` records created |
+| `EffectivenessRecordsUpdated` | `int` | | Existing effectiveness records updated |
+| `NistControlsAffected` | `int` | | Unique NIST controls touched by this import |
+| `ConflictResolution` | `ImportConflictResolution` enum | Required | `Skip` \| `Overwrite` \| `Merge` |
+| `IsDryRun` | `bool` | Default: false | Whether this was a preview-only import |
+| `XccdfScore` | `decimal?` | | XCCDF compliance score (if XCCDF import) |
+| `ImportStatus` | `ScanImportStatus` enum | Required | `Completed` \| `CompletedWithWarnings` \| `Failed` |
+| `ErrorMessage` | `string?` | MaxLength(4000) | Error details if import failed |
+| `Warnings` | `List<string>` | JSON column | Non-fatal warnings (unmatched rules, baseline mismatches) |
+| `ImportedBy` | `string` | Required, MaxLength(200) | User who performed the import |
+| `ImportedAt` | `DateTime` | UTC | When the import was performed |
+
+**Unique constraint**: None — same file can be re-imported (conflict resolution handles duplicates).
+
+### ScanImportFinding (Phase 1)
+
+Per-finding audit trail for each import. Links the raw parsed data to the resulting `ComplianceFinding`.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `Id` | `string` | PK, GUID | Unique identifier |
+| `ScanImportRecordId` | `string` | FK → ScanImportRecord, Required | Parent import record |
+| `VulnId` | `string` | Required, MaxLength(20) | STIG Vulnerability ID (e.g., `V-254239`) |
+| `RuleId` | `string?` | MaxLength(100) | STIG Rule ID (e.g., `SV-254239r849090_rule`) |
+| `StigVersion` | `string?` | MaxLength(50) | Rule version (e.g., `WN22-AU-000010`) |
+| `RawStatus` | `string` | Required, MaxLength(50) | Original CKL STATUS or XCCDF result value |
+| `RawSeverity` | `string` | Required, MaxLength(20) | Original severity text (`high`/`medium`/`low`) |
+| `MappedSeverity` | `CatSeverity?` | | Resolved CAT severity |
+| `FindingDetails` | `string?` | MaxLength(8000) | CKL FINDING_DETAILS or XCCDF message |
+| `Comments` | `string?` | MaxLength(8000) | CKL COMMENTS field |
+| `SeverityOverride` | `string?` | MaxLength(20) | CKL SEVERITY_OVERRIDE |
+| `SeverityJustification` | `string?` | MaxLength(4000) | CKL SEVERITY_JUSTIFICATION |
+| `ResolvedStigControlId` | `string?` | MaxLength(20) | Matched `StigControl.StigId` (null if unmatched) |
+| `ResolvedNistControlIds` | `List<string>` | JSON column | NIST 800-53 control IDs resolved via CCI chain |
+| `ResolvedCciRefs` | `List<string>` | JSON column | CCI references from the CKL/XCCDF entry |
+| `ImportAction` | `ImportFindingAction` enum | Required | `Created` \| `Updated` \| `Skipped` \| `Unmatched` \| `NotApplicable` \| `NotReviewed` |
+| `ComplianceFindingId` | `string?` | FK → ComplianceFinding (nullable) | Created/updated finding (null if skipped/unmatched) |
+
+## Modified Entities
+
+### ComplianceFinding — [ComplianceModels.cs](src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs)
+
+| Field | Change | Details |
+|-------|--------|---------|
+| `ImportRecordId` | **ADD** | Nullable FK → `ScanImportRecord`. Set when finding was created/updated via import. |
+
+### ComplianceEvidence — [ComplianceModels.cs](src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs)
+
+No schema change — uses existing fields:
+- `EvidenceType`: new values `"StigChecklist"` and `"ScapResult"` (string field, no enum change needed)
+- `CollectionMethod`: `"Automated"` for XCCDF, `"Manual"` for CKL
+- `EvidenceCategory`: `EvidenceCategory.Configuration`
+
+## New Enums
+
+### ScanImportType
+
+```csharp
+public enum ScanImportType
+{
+    Ckl,    // DISA STIG Viewer checklist
+    Xccdf   // SCAP Compliance Checker XCCDF results
+}
+```
+
+### ScanImportStatus
+
+```csharp
+public enum ScanImportStatus
+{
+    Completed,              // All entries processed successfully
+    CompletedWithWarnings,  // Processed but with unmatched rules or baseline mismatches
+    Failed                  // Fatal error (malformed XML, system not found, etc.)
+}
+```
+
+### ImportConflictResolution
+
+```csharp
+public enum ImportConflictResolution
+{
+    Skip,       // Keep existing findings, skip duplicates
+    Overwrite,  // Replace existing findings with imported data
+    Merge       // Keep more-recent data, append details
+}
+```
+
+### ImportFindingAction
+
+```csharp
+public enum ImportFindingAction
+{
+    Created,        // New ComplianceFinding created
+    Updated,        // Existing finding updated (overwrite/merge)
+    Skipped,        // Duplicate skipped (skip resolution)
+    Unmatched,      // STIG rule not in curated library
+    NotApplicable,  // CKL Not_Applicable / XCCDF notapplicable
+    NotReviewed     // CKL Not_Reviewed / XCCDF notchecked
+}
+```
+
+## EF Core Configuration
+
+### DbContext Changes
+
+```csharp
+// New DbSets
+public DbSet<ScanImportRecord> ScanImportRecords => Set<ScanImportRecord>();
+public DbSet<ScanImportFinding> ScanImportFindings => Set<ScanImportFinding>();
+```
+
+### Relationships
+
+```csharp
+// ScanImportRecord → RegisteredSystem
+modelBuilder.Entity<ScanImportRecord>()
+    .HasOne<RegisteredSystem>()
+    .WithMany()
+    .HasForeignKey(r => r.RegisteredSystemId)
+    .OnDelete(DeleteBehavior.Cascade);
+
+// ScanImportRecord → ComplianceAssessment
+modelBuilder.Entity<ScanImportRecord>()
+    .HasOne<ComplianceAssessment>()
+    .WithMany()
+    .HasForeignKey(r => r.AssessmentId)
+    .OnDelete(DeleteBehavior.Restrict);
+
+// ScanImportFinding → ScanImportRecord
+modelBuilder.Entity<ScanImportFinding>()
+    .HasOne<ScanImportRecord>()
+    .WithMany()
+    .HasForeignKey(f => f.ScanImportRecordId)
+    .OnDelete(DeleteBehavior.Cascade);
+
+// ScanImportFinding → ComplianceFinding (optional)
+modelBuilder.Entity<ScanImportFinding>()
+    .HasOne<ComplianceFinding>()
+    .WithMany()
+    .HasForeignKey(f => f.ComplianceFindingId)
+    .OnDelete(DeleteBehavior.SetNull);
+
+// ComplianceFinding → ScanImportRecord (optional)
+modelBuilder.Entity<ComplianceFinding>()
+    .HasOne<ScanImportRecord>()
+    .WithMany()
+    .HasForeignKey(f => f.ImportRecordId)
+    .OnDelete(DeleteBehavior.SetNull);
+```
+
+### JSON Columns
+
+```csharp
+modelBuilder.Entity<ScanImportRecord>()
+    .Property(r => r.Warnings)
+    .HasConversion(
+        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+        v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new());
+
+modelBuilder.Entity<ScanImportFinding>()
+    .Property(f => f.ResolvedNistControlIds)
+    .HasConversion(/* same JSON pattern */);
+
+modelBuilder.Entity<ScanImportFinding>()
+    .Property(f => f.ResolvedCciRefs)
+    .HasConversion(/* same JSON pattern */);
+```
+
+### Indexes
+
+```csharp
+// Fast lookups by system
+modelBuilder.Entity<ScanImportRecord>()
+    .HasIndex(r => r.RegisteredSystemId);
+
+// Fast lookups by benchmark
+modelBuilder.Entity<ScanImportRecord>()
+    .HasIndex(r => new { r.RegisteredSystemId, r.BenchmarkId });
+
+// Fast lookups by import record
+modelBuilder.Entity<ScanImportFinding>()
+    .HasIndex(f => f.ScanImportRecordId);
+
+// Fast conflict detection
+modelBuilder.Entity<ScanImportFinding>()
+    .HasIndex(f => new { f.ScanImportRecordId, f.VulnId });
+
+// Import source on findings
+modelBuilder.Entity<ComplianceFinding>()
+    .HasIndex(f => f.ImportRecordId);
+```
+
+## DTOs (Not Persisted)
+
+### ParsedCklEntry
+
+Intermediate DTO from CKL parser — not stored in database.
+
+```csharp
+public record ParsedCklEntry(
+    string VulnId,
+    string? RuleId,
+    string? StigVersion,
+    string? RuleTitle,
+    string Severity,        // "high", "medium", "low"
+    string Status,          // "Open", "NotAFinding", "Not_Applicable", "Not_Reviewed"
+    string? FindingDetails,
+    string? Comments,
+    string? SeverityOverride,
+    string? SeverityJustification,
+    List<string> CciRefs,
+    string? GroupTitle);     // SRG reference
+```
+
+### ParsedCklFile
+
+Top-level CKL parse result.
+
+```csharp
+public record ParsedCklFile(
+    CklAssetInfo Asset,
+    CklStigInfo StigInfo,
+    List<ParsedCklEntry> Entries);
+
+public record CklAssetInfo(
+    string? HostName,
+    string? HostIp,
+    string? HostFqdn,
+    string? HostMac,
+    string? AssetType,
+    string? TargetKey);
+
+public record CklStigInfo(
+    string? StigId,         // BenchmarkId
+    string? Version,
+    string? ReleaseInfo,
+    string? Title);
+```
+
+### ParsedXccdfResult
+
+Intermediate DTO from XCCDF parser.
+
+```csharp
+public record ParsedXccdfResult(
+    string RuleIdRef,       // Full XCCDF idref
+    string ExtractedRuleId, // Extracted SV-XXXXX portion
+    string Result,          // "pass", "fail", "error", etc.
+    string Severity,
+    decimal Weight,
+    DateTime? Timestamp,
+    string? Message,
+    string? CheckRef);      // OVAL check reference
+
+public record ParsedXccdfFile(
+    string? BenchmarkHref,
+    string? Title,
+    string? Target,
+    string? TargetAddress,
+    DateTime? StartTime,
+    DateTime? EndTime,
+    decimal? Score,
+    decimal? MaxScore,
+    Dictionary<string, string> TargetFacts,
+    List<ParsedXccdfResult> Results);
+```
+
+### ImportResult
+
+Return value from import operations.
+
+```csharp
+public record ImportResult(
+    string ImportRecordId,
+    ScanImportStatus Status,
+    string BenchmarkId,
+    string? BenchmarkTitle,
+    int TotalEntries,
+    int OpenCount,
+    int PassCount,
+    int NotApplicableCount,
+    int NotReviewedCount,
+    int ErrorCount,
+    int SkippedCount,
+    int UnmatchedCount,
+    int FindingsCreated,
+    int FindingsUpdated,
+    int EffectivenessRecordsCreated,
+    int EffectivenessRecordsUpdated,
+    int NistControlsAffected,
+    List<string> Warnings,
+    List<UnmatchedRuleInfo> UnmatchedRules,
+    string? ErrorMessage);
+
+public record UnmatchedRuleInfo(
+    string VulnId,
+    string? RuleId,
+    string? RuleTitle,
+    string Severity);
+```

--- a/specs/017-scap-stig-import/plan.md
+++ b/specs/017-scap-stig-import/plan.md
@@ -1,0 +1,199 @@
+# Implementation Plan: 017 — SCAP/STIG Viewer Import
+
+**Branch**: `017-scap-stig-import` | **Date**: 2026-03-01 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/017-scap-stig-import/spec.md`
+
+## Summary
+
+Enable ATO Copilot to ingest DISA STIG Viewer checklist (.ckl) and SCAP Compliance Checker XCCDF result (.xccdf) files, parse the XML, resolve STIG findings to NIST 800-53 controls via the CCI mapping chain, create ComplianceFinding and ControlEffectiveness records, track import history, and export CKL files for eMASS upload. Adds 2 new EF Core entities, 1 new service with 2 parsers, and 5 MCP tools.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9.0  
+**Primary Dependencies**: System.Xml.Linq (XDocument/XElement for XML parsing), existing IStigKnowledgeService, IAssessmentArtifactService, cci-nist-mapping.json  
+**Storage**: EF Core with SQL Server (Docker). Adds 2 new DbSets (`ScanImportRecords`, `ScanImportFindings`).  
+**Testing**: xUnit + FluentAssertions + Moq. Target: 200+ new unit tests for parsers, resolver, import service, and tools.  
+**Target Platform**: Docker containers (Linux), Azure Government.  
+**Performance Goals**: CKL import (500 VULNs) < 10s, XCCDF import (500 rule-results) < 5s, CKL export < 5s.  
+**Constraints**: File size limit 5MB after base64 decode. No streaming file upload — base64 in JSON-RPC.  
+**Scale/Scope**: Typical imports: 5–20 CKL files per system per assessment cycle, 100–800 VULNs per file.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Documentation as Source of Truth** | PASS | Spec, data-model, contracts fully defined. Docs written per phase. |
+| **II. BaseAgent/BaseTool Architecture** | PASS | All 5 tools extend `BaseTool`, registered via `RegisterTool()`. No new agents. |
+| **III. Testing Standards** | PASS | Parser tests with sample XML, resolver tests, import service tests, tool tests. Target 200+ tests. |
+| **IV. Azure Government & Compliance First** | PASS | File import is cloud-agnostic. Findings integrate with system-scoped assessments. |
+| **V. Observability & Structured Logging** | PASS | Import operations logged with file hash, finding counts, warnings. Audit trail via ScanImportRecord. |
+| **VI. Code Quality & Maintainability** | PASS | Parsers are stateless, testable. Import service uses DI. No magic values — enums for all status/action types. |
+| **VII. User Experience Consistency** | PASS | Standard MCP envelope. Import summary uses same result format as other compliance tools. |
+| **VIII. Performance Requirements** | PASS | CKL <10s, XCCDF <5s. XDocument streaming for memory efficiency. |
+
+**Gate result**: PASS — proceed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-scap-stig-import/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # CKL/XCCDF format research
+├── data-model.md        # Entity definitions (complete)
+├── quickstart.md        # Quick validation guide
+├── contracts/
+│   └── mcp-tools.md     # MCP tool contracts
+├── checklists/
+│   └── comprehensive.md # Requirements quality checklist
+└── tasks.md             # Task breakdown
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Ato.Copilot.Core/
+│   ├── Models/Compliance/
+│   │   ├── ComplianceModels.cs          # MODIFIED — add ImportRecordId FK to ComplianceFinding
+│   │   └── ScanImportModels.cs          # NEW — ScanImportRecord, ScanImportFinding, enums, DTOs
+│   ├── Data/Context/
+│   │   └── AtoCopilotContext.cs         # MODIFIED — add 2 DbSets, relationships, indexes
+│   └── Interfaces/Compliance/
+│       └── IScanImportService.cs        # NEW — import orchestration interface
+│
+├── Ato.Copilot.Agents/
+│   └── Compliance/
+│       ├── Tools/
+│       │   └── ScanImportTools.cs       # NEW — 5 MCP tools
+│       ├── Services/
+│       │   ├── ScanImport/
+│       │   │   ├── ScanImportService.cs # NEW — import orchestration
+│       │   │   ├── CklParser.cs         # NEW — CKL XML parser
+│       │   │   ├── XccdfParser.cs       # NEW — XCCDF XML parser
+│       │   │   └── CklGenerator.cs      # NEW — CKL XML generator
+│       │   └── KnowledgeBase/
+│       │       └── StigKnowledgeService.cs  # MODIFIED — add GetStigControlByRuleIdAsync
+│       └── Resources/
+│           └── (no new resources — uses existing cci-nist-mapping.json and stig-controls.json)
+│
+├── Ato.Copilot.Mcp/
+│   └── Tools/
+│       └── ComplianceMcpTools.cs        # MODIFIED — register 5 new tools
+│
+└── Ato.Copilot.State/                   # No changes
+
+tests/
+├── Ato.Copilot.Tests.Unit/
+│   ├── Parsers/
+│   │   ├── CklParserTests.cs            # NEW — CKL parsing tests
+│   │   └── XccdfParserTests.cs          # NEW — XCCDF parsing tests
+│   ├── Services/
+│   │   └── ScanImportServiceTests.cs    # NEW — import orchestration tests
+│   ├── Tools/
+│   │   └── ScanImportToolTests.cs       # NEW — MCP tool tests
+│   └── TestData/
+│       ├── sample-valid.ckl             # NEW — test CKL file
+│       ├── sample-malformed.ckl         # NEW — malformed CKL for error testing
+│       ├── sample-valid.xccdf           # NEW — test XCCDF file
+│       └── sample-malformed.xccdf       # NEW — malformed XCCDF for error testing
+│
+└── Ato.Copilot.Tests.Integration/
+    └── Tools/
+        └── ScanImportIntegrationTests.cs # NEW — end-to-end import tests
+```
+
+## Implementation Phases
+
+### Phase 1: CKL Parser & Core Import Pipeline
+
+**Goal**: Parse CKL files and create ComplianceFinding + ControlEffectiveness records.
+
+**New files**:
+- `src/Ato.Copilot.Core/Models/Compliance/ScanImportModels.cs` — entities, enums, DTOs
+- `src/Ato.Copilot.Core/Interfaces/Compliance/IScanImportService.cs` — interface
+- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklParser.cs` — CKL XML parser
+- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/ScanImportService.cs` — orchestration
+- `src/Ato.Copilot.Agents/Compliance/Tools/ScanImportTools.cs` — `ImportCklTool`
+- Test files for all new components
+- Test data files (sample CKL)
+
+**Modified files**:
+- `AtoCopilotContext.cs` — add `ScanImportRecords`, `ScanImportFindings` DbSets
+- `ComplianceModels.cs` — add `ImportRecordId` to `ComplianceFinding`
+- `ComplianceMcpTools.cs` — register `compliance_import_ckl`
+- `ServiceCollectionExtensions.cs` — register new services
+
+**Checkpoint**: CKL files can be imported, findings created, effectiveness records upserted.
+
+### Phase 2: XCCDF Parser & Import
+
+**Goal**: Parse XCCDF results with same downstream pipeline.
+
+**New files**:
+- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/XccdfParser.cs`
+- XCCDF import tool in `ScanImportTools.cs`
+- Test files
+
+**Modified files**:
+- `ComplianceMcpTools.cs` — register `compliance_import_xccdf`
+- `IStigKnowledgeService.cs` — add `GetStigControlByRuleIdAsync`
+- `StigKnowledgeService.cs` — implement RuleId lookup
+
+**Checkpoint**: XCCDF files can be imported, reusing Phase 1 pipeline.
+
+### Phase 3: CKL Export
+
+**Goal**: Generate CKL files from assessment data.
+
+**New files**:
+- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklGenerator.cs`
+- Export tool in `ScanImportTools.cs`
+- Test files
+
+**Modified files**:
+- `ComplianceMcpTools.cs` — register `compliance_export_ckl`
+
+**Checkpoint**: CKL files can be exported for eMASS upload.
+
+### Phase 4: Import Management Tools
+
+**Goal**: Import history and summary reports.
+
+**New files**:
+- List/summary tools in `ScanImportTools.cs`
+- Test files
+
+**Modified files**:
+- `ComplianceMcpTools.cs` — register `compliance_list_imports`, `compliance_get_import_summary`
+
+**Checkpoint**: Full feature complete — import, export, history, summaries.
+
+## Dependencies
+
+### Internal Dependencies
+
+| Dependency | Required For | Risk |
+|------------|--------------|------|
+| `IStigKnowledgeService` | STIG resolution | None — stable interface |
+| `IAssessmentArtifactService` | ControlEffectiveness upsert | None — stable interface |
+| `IBaselineService` | Baseline validation | None — stable interface |
+| `IRmfLifecycleService` | System validation | None — stable interface |
+| `cci-nist-mapping.json` | CCI→NIST resolution | None — 7,575 entries loaded |
+| `stig-controls.json` | STIG knowledge lookup | Low — may need STIG library expansion for full coverage |
+
+### External Dependencies
+
+None — all XML parsing uses `System.Xml.Linq` (built into .NET).
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| STIG rules in CKL not matching curated library | High | Medium | Report unmatched rules; don't fail import — partial results are still valuable |
+| CKL format variations across STIG Viewer versions | Medium | Medium | Test with CKL files from versions 2.14–2.17; handle missing optional fields gracefully |
+| Large CKL files (>1000 VULNs) causing timeout | Low | Medium | XDocument streaming; async processing with CancellationToken |
+| Base64 encoding doubling message size | Low | Low | 5MB limit reasonable for typical CKL/XCCDF; warn on large files |
+| XCCDF namespace variations | Medium | Low | Parse with namespace-agnostic queries as fallback |

--- a/specs/017-scap-stig-import/quickstart.md
+++ b/specs/017-scap-stig-import/quickstart.md
@@ -1,0 +1,115 @@
+# Quickstart: 017 — SCAP/STIG Viewer Import
+
+**Date**: 2026-03-01 | **Plan**: [plan.md](plan.md) | **Spec**: [spec.md](spec.md)
+
+## What This Feature Adds
+
+Feature 017 enables ATO Copilot to ingest real-world STIG assessment data:
+
+- **CKL import** — Parse DISA STIG Viewer checklist files, create compliance findings and control effectiveness records
+- **XCCDF import** — Parse SCAP Compliance Checker results with automated evidence chains
+- **CKL export** — Generate CKL files from assessment data for eMASS upload
+- **Import management** — Track import history, view summaries, detect unmatched rules
+- **Automatic NIST mapping** — STIG → CCI → NIST 800-53 control resolution on import
+
+## Prerequisites
+
+- ATO Copilot running (Feature 015+ deployed)
+- At least one registered system with a control baseline selected
+- STIG Viewer CKL file or SCAP SCC XCCDF results file
+- .NET 9.0 SDK, Docker
+
+## Build & Run (After Implementation)
+
+```bash
+# From repo root
+cd src/Ato.Copilot.Mcp
+dotnet build
+dotnet run
+
+# Or via Docker
+docker compose -f docker-compose.mcp.yml up --build
+```
+
+## Quick Validation
+
+After the feature is implemented, verify the core import workflow:
+
+### 1. Import a CKL file (dry-run first)
+
+```
+@ato Import this STIG Viewer checklist for "ACME Portal" in dry-run mode
+```
+
+Or via MCP tool directly:
+```json
+{
+  "tool": "compliance_import_ckl",
+  "arguments": {
+    "system_id": "<system-id>",
+    "file_content": "<base64-encoded-ckl>",
+    "file_name": "Windows_Server_2022_STIG_V1R1.ckl",
+    "dry_run": true,
+    "conflict_resolution": "skip"
+  }
+}
+```
+
+**Expected output**: Import summary showing finding counts (Open, NotAFinding, N/A, Not_Reviewed), NIST controls affected, and any unmatched rules.
+
+### 2. Run actual import
+
+```
+@ato Import this CKL file for "ACME Portal"
+```
+
+**Expected output**: Import completed — findings created, effectiveness records upserted, evidence attached with SHA-256 hash.
+
+### 3. Import XCCDF results
+
+```
+@ato Import these SCAP SCC results for "ACME Portal"
+```
+
+### 4. View import history
+
+```
+@ato Show import history for "ACME Portal"
+```
+
+### 5. Export CKL for eMASS
+
+```
+@ato Export a CKL file for "ACME Portal" using the Windows Server 2022 STIG
+```
+
+## Verification Checklist
+
+- [ ] CKL import creates `ComplianceFinding` records with `StigFinding = true`
+- [ ] STIG findings map to NIST controls via CCI chain
+- [ ] `ControlEffectiveness` records created for each affected NIST control
+- [ ] Evidence created with SHA-256 hash of source file
+- [ ] Dry-run shows accurate preview without persisting
+- [ ] Conflict resolution (Skip/Overwrite/Merge) works on re-import
+- [ ] XCCDF import captures compliance score
+- [ ] CKL export produces valid XML re-importable by STIG Viewer
+- [ ] Import history queryable by system and benchmark
+
+## Key Files to Know
+
+| File | Purpose |
+|------|---------|
+| `src/Ato.Copilot.Core/Models/Compliance/ScanImportModels.cs` | New entities, enums, DTOs |
+| `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/` | Parser and import service implementations |
+| `src/Ato.Copilot.Agents/Compliance/Tools/ScanImportTools.cs` | 5 MCP tools |
+| `src/Ato.Copilot.Agents/Compliance/Resources/cci-nist-mapping.json` | CCI→NIST mapping (existing, 7,575 entries) |
+| `src/Ato.Copilot.Agents/Compliance/Resources/stig-controls.json` | STIG knowledge base (existing, 880 entries) |
+| `specs/017-scap-stig-import/` | Spec, plan, research, data model, contracts |
+
+## Reference
+
+- [Spec](spec.md) — Full feature specification with CKL/XCCDF format documentation
+- [Plan](plan.md) — Phased implementation plan with 60 tasks
+- [Research](research.md) — CKL/XCCDF format deep dive, integration point analysis
+- [Data Model](data-model.md) — Entity definitions, enums, DTOs, EF Core configuration
+- [MCP Tool Contracts](contracts/mcp-tools.md) — All 5 tool input/output contracts

--- a/specs/017-scap-stig-import/research.md
+++ b/specs/017-scap-stig-import/research.md
@@ -1,0 +1,249 @@
+# Research: CKL & XCCDF File Formats for SCAP/STIG Import
+
+**Feature**: 017-scap-stig-import | **Date**: 2026-03-01
+
+## R1: DISA STIG Viewer CKL Format
+
+### What CKL Is
+
+CKL (Checklist) is the XML export format produced by DISA STIG Viewer — the official DoD tool for manually evaluating STIG compliance. Every DoD team performing an ATO uses STIG Viewer to review systems against applicable STIGs and record compliance status per-rule.
+
+**Key facts**:
+- CKL is proprietary to DISA STIG Viewer (not a NIST standard)
+- One CKL file per STIG benchmark per target system (e.g., `Windows_Server_2022_STIG_V1R1_web-server-01.ckl`)
+- Typical ATO package contains 5–20 CKL files
+- CKL files range from 50KB (small STIG with ~50 rules) to 5MB (large STIG with ~500+ rules)
+- eMASS accepts CKL uploads as assessment evidence
+- STIG Viewer versions 2.14–2.17 all produce the same XML structure
+
+### CKL XML Structure Analysis
+
+**Root element**: `<CHECKLIST>` (no namespace)
+
+**Two main sections**:
+1. `<ASSET>` — Target system identification (hostname, IP, MAC, FQDN)
+2. `<STIGS>` → `<iSTIG>` — contains `<STIG_INFO>` (benchmark metadata) and `<VULN>` entries (per-rule results)
+
+**STIG_INFO encoding**: Uses a flat `<SI_DATA>` list with `<SID_NAME>` / `<SID_DATA>` pairs rather than structured attributes. Must iterate all SI_DATA elements to find `stigid`, `version`, `title`, `releaseinfo`.
+
+**VULN encoding**: Similar flat structure — `<STIG_DATA>` list with `<VULN_ATTRIBUTE>` / `<ATTRIBUTE_DATA>` pairs. Critical attributes:
+- `Vuln_Num` — the V-XXXXX vulnerability number (primary key for matching)
+- `Rule_ID` — the SV-XXXXX rule ID with revision (secondary key)
+- `Rule_Ver` — the WN22-XX-XXXXXX version string (tertiary key)
+- `Severity` — `high`, `medium`, `low`
+- `CCI_REF` — appears multiple times per VULN (one per CCI)
+- `STIGRef` — benchmark name + version string
+
+**STATUS values** (direct children of `<VULN>`, not inside STIG_DATA):
+- `Open` — finding exists, not remediated
+- `NotAFinding` — checked, compliant
+- `Not_Applicable` — rule doesn't apply
+- `Not_Reviewed` — not yet evaluated
+
+### Parsing Strategy
+
+**Decision**: Use `System.Xml.Linq.XDocument` for parsing.
+
+**Rationale**: CKL files are small enough to load fully into memory (max ~5MB). XDocument provides LINQ queries that are more readable than XmlReader for the flat `SI_DATA`/`STIG_DATA` attribute lists. No streaming needed.
+
+**Alternatives considered**:
+- `XmlReader` (streaming): Overkill for files < 5MB. More complex code for marginal performance gain.
+- `XmlSerializer` (deserialization): CKL's flat attribute structure doesn't map naturally to C# classes. Would require excessive `[XmlElement]` annotations.
+- Third-party library (e.g., STIG parsing NuGet): No mature packages exist for CKL parsing in .NET.
+
+### Edge Cases
+
+1. **Multiple iSTIG sections**: Some CKL files contain multiple `<iSTIG>` elements (one per STIG in a multi-STIG checklist). Parser must handle iteration over all iSTIGs.
+2. **Missing CCI_REF**: Some older STIGs have VULNs without CCI references. These cannot be mapped to NIST controls — logged as warnings.
+3. **Severity Override**: When `<SEVERITY_OVERRIDE>` is non-empty, it supersedes the STIG_DATA Severity. Must check for override first.
+4. **HTML in FINDING_DETAILS**: Some assessors paste HTML or rich text into finding details. Store as-is (the field is a string).
+5. **Encoding**: CKL files are UTF-8, but some tools produce UTF-16 BOM. XDocument handles both.
+
+---
+
+## R2: SCAP/XCCDF Results Format
+
+### What XCCDF Is
+
+XCCDF (Extensible Configuration Checklist Description Format) is an NIST standard (SP 800-126 Rev 3) for expressing security checklists and benchmark results. DISA's SCAP Compliance Checker (SCC) produces XCCDF results files after automated scanning.
+
+**Key facts**:
+- XCCDF is a NIST standard — defined in SP 800-126 Rev 3 (SCAP 1.3)
+- Automated results (machine-verified) vs. CKL (human-verified)
+- Produced by DISA SCC, OpenSCAP, and other SCAP-compliant scanners
+- XCCDF results reference OVAL definitions for the actual check logic (we don't parse OVAL)
+- Typical file size: 50KB–500KB
+- Contains a `<score>` element with overall compliance percentage
+
+### XCCDF XML Structure Analysis
+
+**Root element**: `<TestResult>` in namespace `http://checklists.nist.gov/xccdf/1.2`
+
+**Note on XCCDF versions**: XCCDF 1.1 uses namespace `http://checklists.nist.gov/xccdf/1.1`, XCCDF 1.2 uses `http://checklists.nist.gov/xccdf/1.2`. DISA SCC outputs 1.2 but older tools may use 1.1. Parser should handle both.
+
+**Key elements**:
+- `<benchmark>` — STIG benchmark reference (href attribute)
+- `<target>` — scanned system hostname
+- `<target-address>` — IP address
+- `<target-facts>` — OS name, version, etc.
+- `<rule-result>` — per-rule result with `idref`, `severity`, `weight` attributes and `<result>` child
+- `<score>` — overall compliance score
+
+**Rule ID format in XCCDF**: DISA uses a prefixed format:
+```
+xccdf_mil.disa.stig_rule_SV-254239r849090_rule
+```
+The important part is `SV-254239r849090_rule` — this matches `StigControl.RuleId`.
+
+### XCCDF Result Values
+
+| Value | Meaning | Frequency |
+|-------|---------|-----------|
+| `pass` | Compliant | Most common |
+| `fail` | Non-compliant | Most common |
+| `error` | Scanner error | Rare |
+| `unknown` | Could not determine | Rare |
+| `notapplicable` | Rule N/A | Common |
+| `notchecked` | Rule not evaluated | Occasional |
+| `notselected` | Rule deselected | Rare |
+| `informational` | Info only | Rare |
+| `fixed` | Was failing, auto-fixed | Rare (SCAP auto-remediation) |
+
+### Parsing Strategy
+
+**Decision**: Use `System.Xml.Linq.XDocument` with namespace-aware queries.
+
+**Rationale**: Same as CKL — files are small, LINQ queries are readable. Namespace handling is required for XCCDF.
+
+**Namespace handling approach**: Define both XCCDF 1.1 and 1.2 namespaces. Try 1.2 first (most common for DISA SCC), fall back to 1.1. If neither matches, attempt namespace-agnostic local-name matching as last resort.
+
+```csharp
+XNamespace xccdf12 = "http://checklists.nist.gov/xccdf/1.2";
+XNamespace xccdf11 = "http://checklists.nist.gov/xccdf/1.1";
+```
+
+### Edge Cases
+
+1. **Multiple TestResult elements**: XCCDF can contain multiple TestResult elements in a wrapper. We process the first (or all if in an ARF).
+2. **Missing severity attribute**: Some rule-results omit severity. Fall back to the benchmark definition severity (which we may not have — log warning).
+3. **XCCDF inside ARF (Asset Report Format)**: DISA SCC can produce ARF files that wrap XCCDF results. ARF uses namespace `http://scap.nist.gov/schema/asset-reporting-format/1.1`. Parser should detect ARF and extract the embedded TestResult.
+4. **OVAL references**: `<check>` elements reference OVAL definitions. We capture the reference string for audit but don't parse OVAL XML.
+
+---
+
+## R3: Existing ATO Copilot Integration Points
+
+### StigControl Record (read-only, from curated JSON)
+
+`StigControl` is loaded from `stig-controls.json` into memory via `IStigKnowledgeService`. Currently 880 entries covering common DoD technologies.
+
+**Lookup methods available**:
+- `GetStigControlAsync(stigId)` — by VulnId (e.g., "V-254239") ✅
+- `SearchStigsAsync(query, severity)` — keyword search ✅
+- `GetStigCrossReferenceAsync(stigId)` — cross-reference ✅
+- `GetStigsByCciChainAsync(controlId)` — NIST→CCI→STIG ✅
+- `GetStigControlByRuleIdAsync(ruleId)` — by RuleId ❌ **MISSING — need to add**
+
+**Gap**: The XCCDF parser produces RuleIds (e.g., `SV-254239r849090_rule`), but `IStigKnowledgeService` only supports lookup by VulnId. Need to add a RuleId index.
+
+### CCI→NIST Mapping (read-only, from curated JSON)
+
+`cci-nist-mapping.json` contains ~7,575 CCI entries, each mapping to one or more NIST 800-53 control IDs. Loaded via `IStigKnowledgeService.GetCciMappingsAsync(controlId)`.
+
+**Usage for import**: Given a CKL VULN with `CCI_REF` values:
+1. Each CCI-XXXXXX → lookup in mapping → NIST control ID(s)
+2. Collected NIST controls → validate against system baseline
+3. Create/update ControlEffectiveness per unique NIST control
+
+**Coverage**: Most DoD STIGs include CCI references. Older STIGs (pre-2015) may have VULNs without CCI refs — these can only be mapped via the curated `StigControl.NistControls` field.
+
+### ComplianceFinding Integration
+
+`ComplianceFinding` already has:
+- `StigFinding` (bool) — set `true` for CKL/XCCDF imports
+- `StigId` (string?) — set to VulnId
+- `CatSeverity` (CatSeverity? enum) — mapped from CKL/XCCDF severity
+- `Source` (string) — set to `"CKL Import"` or `"SCAP Import"`
+- `ScanSource` (ScanSourceType enum) — use `Combined`
+
+**New field needed**: `ImportRecordId` (nullable FK to `ScanImportRecord`) — tracks which import created the finding.
+
+### ControlEffectiveness Integration
+
+`IAssessmentArtifactService.AssessControlAsync` creates/upserts `ControlEffectiveness` records:
+- `ControlId` — NIST control (resolved via CCI chain)
+- `Determination` — `Satisfied` / `OtherThanSatisfied`
+- `AssessmentMethod` — `"Test"` (scanner-verified)
+- `EvidenceIds` — link to created `ComplianceEvidence`
+
+**Aggregation rule**: If multiple STIG rules map to the same NIST control, the effectiveness is determined by the **worst result** — any `Open` finding → `OtherThanSatisfied`.
+
+### ComplianceEvidence Integration
+
+`ComplianceEvidence` supports:
+- `EvidenceType` — string field, new values `"StigChecklist"` / `"ScapResult"`
+- `CollectionMethod` — `"Manual"` for CKL (human-evaluated), `"Automated"` for XCCDF (machine-scanned)
+- `ContentHash` — SHA-256 of raw file content for tamper detection
+- `EvidenceCategory` — `Configuration`
+- `CollectorIdentity` — user who performed the import
+
+---
+
+## R4: File Transfer via MCP Protocol
+
+### The Challenge
+
+MCP tools communicate via JSON-RPC 2.0. The protocol supports arbitrary JSON parameters but has no built-in concept of binary file upload (no multipart/form-data).
+
+### Approach: Base64 Encoding
+
+Encode file content as a base64 string in the tool parameter. This is the simplest approach and works within the existing MCP infrastructure.
+
+**Size analysis**:
+| File Type | Typical Size | Base64 Size | Within Limits? |
+|-----------|-------------|-------------|---------------|
+| Small CKL (~50 rules) | 50KB | 67KB | ✅ |
+| Medium CKL (~200 rules) | 200KB | 267KB | ✅ |
+| Large CKL (~500 rules) | 500KB | 667KB | ✅ |
+| Very large CKL (~1000 rules) | 1.5MB | 2MB | ✅ |
+| Extreme CKL (multi-STIG) | 3MB | 4MB | ✅ (under 5MB limit) |
+| XCCDF results (~500 rules) | 100KB | 133KB | ✅ |
+
+**Decision**: 5MB limit after base64 decoding. This covers >99% of real-world CKL/XCCDF files.
+
+**Alternative considered**: Add a file upload HTTP endpoint to the MCP server. Rejected for this feature — adds transport complexity. The existing chat attachment endpoint (`POST /api/messages/{messageId}/attachments`, 10MB limit) is chat-only. A general compliance file upload endpoint could be added in a future feature.
+
+---
+
+## R5: Conflict Resolution Design
+
+### The Problem
+
+Users will re-import CKL files as they progress through assessment cycles. The same STIG rules will appear in multiple imports. Need a strategy for handling duplicates.
+
+### Pattern: Follow EmassImportOptions
+
+The eMASS import already implements conflict resolution with three strategies. We reuse this proven pattern.
+
+| Strategy | Behavior | When to Use |
+|----------|----------|-------------|
+| **Skip** | Keep existing finding unchanged | Safe default; preserving manual annotations |
+| **Overwrite** | Replace finding with imported data entirely | Fresh scan replacing stale data |
+| **Merge** | Keep more-recent status; append new details | Incremental updates from ongoing assessment |
+
+**Merge rules for SCAP/STIG import**:
+- **Status**: Take the imported status (scan is more current than DB state)
+- **Severity**: Take the higher severity (conservative approach)
+- **Finding details**: If imported details differ from existing, append imported text with timestamp separator
+- **Comments**: Append imported comments with timestamp
+- **CatSeverity**: If severity override present in import, use it; otherwise keep existing
+- **Timestamps**: Update `DiscoveredAt` to import timestamp; preserve `RemediatedAt` if finding was already remediated
+
+### Conflict Detection Key
+
+A finding is considered a "conflict" when:
+- Same `StigId` (VulnId)
+- Same `AssessmentId` (within same assessment context)
+- Existing `StigFinding = true`
+
+This allows multiple imports of the same STIG benchmark within one assessment cycle, with each import updating or supplementing the previous data.

--- a/specs/017-scap-stig-import/spec.md
+++ b/specs/017-scap-stig-import/spec.md
@@ -1,0 +1,538 @@
+# Feature 017: SCAP/STIG Viewer Import (.ckl/.xccdf)
+
+**Created**: 2026-03-01  
+**Status**: Strategic Plan  
+**Purpose**: Enable ATO Copilot to ingest real-world assessment scan results from DISA STIG Viewer (.ckl) and SCAP Compliance Checker (.xccdf) files, mapping them to registered systems, creating compliance findings, and linking evidence to the existing assessment pipeline.
+
+---
+
+## Clarifications
+
+### Session 2026-03-03
+
+- Q: How should `Not_Reviewed` CKL entries be handled — skip (no finding) or create as Open? → A: Create `ComplianceFinding` with `FindingStatus.Open` and note "Not yet reviewed" — unreviewed rules are tracked as open until explicitly assessed.
+- Q: When re-importing, should effectiveness re-evaluate all findings for a NIST control or only consider the latest import? → A: Re-evaluate all `ComplianceFinding` records for the NIST control after each import — effectiveness always reflects the aggregate current state of all mapped rules.
+- Q: What happens when the exact same file (identical SHA-256 hash) is imported twice for the same system? → A: Warn but allow — proceed with import, include a warning in the response: "File previously imported on {date}". This supports legitimate re-imports (e.g., retry with different conflict resolution) while catching accidental duplicates.
+- Q: Should findings and effectiveness records be created for NIST controls resolved via CCI but outside the system's control baseline? → A: Create `ComplianceFinding` records (for audit trail) but skip `ControlEffectiveness` for controls outside the baseline. Include out-of-baseline controls in import warnings.
+- Q: Should CKL export include only rules with assessment data, or the full STIG benchmark? → A: Export the complete STIG benchmark — all rules from `StigControl` for the selected benchmark, filling in statuses from matching `ComplianceFinding` records, defaulting to `Not_Reviewed` for rules with no assessment data. This produces eMASS-compliant CKL files.
+
+---
+
+## Part 1: The Problem
+
+### Why This Matters
+
+In every DoD ATO process, engineers and ISSOs run DISA STIG Viewer and SCAP Compliance Checker (SCC) against their systems to evaluate compliance with Security Technical Implementation Guides. These tools produce structured XML output:
+
+- **STIG Viewer** exports `.ckl` (Checklist) files — one per STIG benchmark per system. A typical ATO package has 5–20 CKL files (Windows Server, SQL Server, IIS, .NET, etc.).
+- **SCAP Compliance Checker (SCC)** exports `.xccdf` (XCCDF Results) files — automated scan results from DISA's SCAP benchmarks.
+
+Today, these results live in files on shared drives or in eMASS. Teams manually cross-reference CKL findings against their control baselines, hand-copy finding details into POA&Ms, and re-enter data into multiple systems. **There is no automated path to get scan results into ATO Copilot.**
+
+### The Current Gap
+
+| What Teams Do Today | What ATO Copilot Can Do Today |
+|---------------------|-------------------------------|
+| Run STIG Viewer, save .ckl files per system | Nothing — no CKL parser exists |
+| Run SCAP SCC, export .xccdf results | Nothing — XCCDF fields exist on `StigControl` but no import |
+| Manually count Open/Not A Finding/Not Applicable | `ComplianceFinding` tracks findings but only from Azure scans |
+| Copy finding details into POA&M spreadsheets | POA&M tools exist but require manual finding creation |
+| Upload CKL files to eMASS | eMASS export exists but no CKL/XCCDF round-trip |
+| Cross-reference STIG findings to NIST controls | STIG→CCI→NIST mapping exists in `cci-nist-mapping.json` |
+
+### The Opportunity
+
+ATO Copilot already has:
+- `StigControl` records with XCCDF fields (StigId, VulnId, RuleId, BenchmarkId, StigVersion)
+- `ComplianceFinding` with `StigFinding` bool and `StigId` field
+- `ControlEffectiveness` for per-control assessment determinations
+- `ComplianceEvidence` with `CollectionMethod` supporting "Automated" and "Manual"
+- CCI→NIST mapping (~7,575 entries) linking STIGs to NIST 800-53 controls
+- `IAssessmentArtifactService` with `AssessControlAsync` for effectiveness upsert
+- `IEmassExportService` with conflict resolution pattern (Skip/Overwrite/Merge + dry-run)
+
+The missing piece is **file parsing** — getting data out of CKL/XCCDF XML and into the existing entity pipeline.
+
+---
+
+## Part 2: The Product
+
+### What We're Building
+
+**SCAP/STIG Viewer Import** allows users to upload `.ckl` and `.xccdf` files through MCP tools, parse the XML, map findings to the registered system's control baseline, and create `ComplianceFinding` + `ControlEffectiveness` + `ComplianceEvidence` records automatically.
+
+### What It Is
+
+- A **file import pipeline** that parses DISA-standard XML formats
+- A **mapping engine** that resolves STIG findings → CCI references → NIST 800-53 controls
+- An **assessment integration** that feeds parsed scan results into the existing assessment workflow
+- A **CKL export** capability that generates `.ckl` files from ATO Copilot assessment data (for eMASS upload)
+
+### What It Is NOT
+
+- Not a SCAP scanner — we import results from DISA SCC, we don't run scans
+- Not a STIG Viewer replacement — we import/export CKL files, we don't provide a STIG editing UI
+- Not an ACAS/Nessus integration — vulnerability scan import is a separate feature
+- Not an eMASS API integration — file-based exchange only (API integration is a separate feature)
+
+### Interfaces
+
+| Surface | User | Purpose |
+|---------|------|---------|
+| **MCP Tools** | ISSO, SCA | `compliance_import_ckl`, `compliance_import_xccdf`, `compliance_export_ckl`, `compliance_list_imports`, `compliance_get_import_summary` |
+| **VS Code (@ato)** | Engineer, ISSO | `@ato Import my STIG Viewer checklist` → triggers file picker → parses and imports |
+| **Teams Bot** | ISSM, SCA | Upload CKL attachment → bot detects file type → imports and shows summary card |
+
+---
+
+## Part 3: CKL and XCCDF File Formats
+
+### 3.1 DISA STIG Viewer CKL Format
+
+The `.ckl` file is an XML document produced by DISA STIG Viewer. Each CKL represents one STIG benchmark evaluated against one target system.
+
+**Structure:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.17-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>None</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>web-server-01</HOST_NAME>
+    <HOST_IP>10.0.1.100</HOST_IP>
+    <HOST_MAC>00:0A:95:9D:68:16</HOST_MAC>
+    <HOST_FQDN>web-server-01.example.mil</HOST_FQDN>
+    <TARGET_COMMENT></TARGET_COMMENT>
+    <TECH_AREA></TECH_AREA>
+    <TARGET_KEY>4089</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+    <WEB_DB_SITE></WEB_DB_SITE>
+    <WEB_DB_INSTANCE></WEB_DB_INSTANCE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>3</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>Windows_Server_2022_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 1 Benchmark Date: 23 Mar 2023</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Microsoft Windows Server 2022 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <!-- ... more SI_DATA elements ... -->
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254239</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000003-GPOS-00004</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254239r849090_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-AU-000010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must be configured to audit...</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000018</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000172</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <!-- ... more STIG_DATA attributes per VULN ... -->
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>Audit policy not configured for Account Management - User Account Management.</FINDING_DETAILS>
+        <COMMENTS>Remediation scheduled for Sprint 42.</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <!-- ... hundreds more VULN elements ... -->
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>
+```
+
+**Key CKL Fields:**
+
+| Field | Location | Maps To |
+|-------|----------|---------|
+| `HOST_NAME` | `ASSET` | Target system hostname |
+| `stigid` | `STIG_INFO/SI_DATA` | `StigControl.BenchmarkId` |
+| `version` | `STIG_INFO/SI_DATA` | STIG release version |
+| `Vuln_Num` | `VULN/STIG_DATA` | `StigControl.VulnId` / `ComplianceFinding.StigId` |
+| `Rule_ID` | `VULN/STIG_DATA` | `StigControl.RuleId` |
+| `Rule_Ver` | `VULN/STIG_DATA` | `StigControl.StigVersion` |
+| `Severity` | `VULN/STIG_DATA` | `StigSeverity` → `CatSeverity` |
+| `CCI_REF` | `VULN/STIG_DATA` (multiple) | CCI→NIST mapping → `ControlEffectiveness.ControlId` |
+| `STATUS` | `VULN` | `Open` / `NotAFinding` / `Not_Applicable` / `Not_Reviewed` |
+| `FINDING_DETAILS` | `VULN` | `ComplianceFinding.Description` |
+| `COMMENTS` | `VULN` | `ComplianceFinding.RemediationGuidance` (if relevant) |
+| `SEVERITY_OVERRIDE` | `VULN` | Override the default severity |
+| `SEVERITY_JUSTIFICATION` | `VULN` | Justification for severity override |
+
+**CKL STATUS Values:**
+
+| CKL Status | Meaning | Maps To |
+|------------|---------|---------|
+| `Open` | Finding is present, not remediated | `FindingStatus.Open` + `EffectivenessDetermination.OtherThanSatisfied` |
+| `NotAFinding` | Checked, no vulnerability found | `FindingStatus.Remediated` + `EffectivenessDetermination.Satisfied` |
+| `Not_Applicable` | Rule doesn't apply to this system | `FindingStatus.Accepted` (N/A) + no `ControlEffectiveness` record |
+| `Not_Reviewed` | Not yet evaluated | `FindingStatus.Open` with note "Not yet reviewed" — tracked as open until explicitly assessed |
+
+### 3.2 XCCDF Results Format
+
+SCAP Compliance Checker (SCC) produces XCCDF results — an NIST-standardized XML format defined in NIST SP 800-126 Rev 3.
+
+**Structure (simplified):**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<TestResult xmlns="http://checklists.nist.gov/xccdf/1.2"
+            id="xccdf_mil.disa.stig_testresult_default"
+            start-time="2026-02-15T14:30:00"
+            end-time="2026-02-15T14:45:22">
+  <benchmark href="xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG"/>
+  <title>SCAP SCC Scan Results</title>
+  <identity authenticated="true" privileged="true">SYSTEM</identity>
+  <target>web-server-01</target>
+  <target-address>10.0.1.100</target-address>
+  <target-facts>
+    <fact name="urn:scap:fact:asset:identifier:host_name" type="string">web-server-01</fact>
+    <fact name="urn:scap:fact:asset:identifier:os_name" type="string">Microsoft Windows Server 2022</fact>
+    <fact name="urn:scap:fact:asset:identifier:os_version" type="string">10.0.20348</fact>
+    <!-- ... more facts ... -->
+  </target-facts>
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254239r849090_rule" time="2026-02-15T14:32:11"
+               severity="high" weight="10.0">
+    <result>fail</result>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="scap_mil.disa.stig_comp_U_MS_Windows_Server_2022_STIG_V1R1_SCAP_1-2_Benchmark-oval.xml"
+                         name="oval:mil.disa.stig.windows_server_2022:def:254239"/>
+    </check-check>
+    <message severity="info">Registry value not configured as expected.</message>
+  </rule-result>
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254240r849093_rule" time="2026-02-15T14:32:15"
+               severity="medium" weight="10.0">
+    <result>pass</result>
+  </rule-result>
+  <!-- ... more rule-result elements ... -->
+  <score system="urn:xccdf:scoring:default" maximum="100">72.5</score>
+</TestResult>
+```
+
+**Key XCCDF Result Fields:**
+
+| Field | Location | Maps To |
+|-------|----------|---------|
+| `benchmark/@href` | `TestResult` | `StigControl.BenchmarkId` |
+| `target` | `TestResult` | Target system hostname |
+| `start-time` / `end-time` | `TestResult` | Scan timestamp |
+| `rule-result/@idref` | `rule-result` | `StigControl.RuleId` (extract `SV-XXXXXX` portion) |
+| `rule-result/@severity` | `rule-result` | `StigSeverity` → `CatSeverity` |
+| `rule-result/@weight` | `rule-result` | `StigControl.Weight` |
+| `rule-result/result` | `rule-result` | See mapping below |
+| `rule-result/message` | `rule-result` | `ComplianceFinding.Description` |
+| `score` | `TestResult` | Import metadata (XCCDF compliance score) |
+
+**XCCDF Result Values:**
+
+| XCCDF Result | Meaning | Maps To |
+|-------------|---------|---------|
+| `pass` | Rule requirement satisfied | `EffectivenessDetermination.Satisfied` |
+| `fail` | Rule requirement not met | `FindingStatus.Open` + `EffectivenessDetermination.OtherThanSatisfied` |
+| `error` | Scan encountered an error | Flagged for manual review |
+| `unknown` | Could not determine result | Flagged for manual review |
+| `notapplicable` | Rule not applicable to target | No finding created; mark N/A |
+| `notchecked` | Rule was not evaluated | Skipped (log warning) |
+| `notselected` | Rule was not selected for scan | Skipped |
+| `informational` | Informational only | `FindingSeverity.Informational` (enum value exists), no effectiveness impact |
+| `fixed` | Was failing, auto-remediated by SCAP | `FindingStatus.Remediated` + evidence of auto-fix |
+
+---
+
+## Part 4: Personas & Needs
+
+### ISSO (Information System Security Officer)
+
+| Need | Description | Status |
+|------|-------------|--------|
+| Import CKL files from STIG Viewer | Upload one or more CKL files for a registered system | **MISSING** |
+| Import XCCDF results from SCAP SCC | Upload automated scan results | **MISSING** |
+| See import summary with pass/fail/N-A counts | After import, see a dashboard of results | **MISSING** |
+| View import history for a system | Track which scans were imported, when, by whom | **MISSING** |
+| Resolve conflicts when re-importing | Choose skip/overwrite/merge for existing findings | **MISSING** |
+| Map STIG findings to NIST controls automatically | CCI→NIST resolution happens on import | **MISSING** |
+| Export CKL for eMASS upload | Generate .ckl from assessment data | **MISSING** |
+
+### SCA (Security Control Assessor)
+
+| Need | Description | Status |
+|------|-------------|--------|
+| Validate imported scan results | Review what was imported before accepting into assessment | **MISSING** |
+| Use imported data for effectiveness determinations | SCAP results auto-populate `ControlEffectiveness` | **MISSING** |
+| Compare SCAP results across scan cycles | Trend analysis between imports | **MISSING** |
+| Verify evidence chain from scan import | Imported CKL/XCCDF becomes tamper-evident evidence | **MISSING** |
+
+### Engineer
+
+| Need | Description | Status |
+|------|-------------|--------|
+| Upload STIG Viewer CKL from VS Code | `@ato Import this CKL file` with file picker | **MISSING** |
+| See which STIG findings were imported as Open | Filter findings by STIG import source | **MISSING** |
+| Export updated CKL after remediation | Generate CKL reflecting current remediation status | **MISSING** |
+
+---
+
+## Part 5: Capabilities
+
+### Phase 1: CKL Import & Mapping (Core)
+
+| # | Capability | Persona | Description |
+|---|-----------|---------|-------------|
+| 1.1 | **CKL File Parser** | — | Parse DISA STIG Viewer `.ckl` XML files. Extract ASSET info, STIG_INFO metadata, and all VULN entries with STATUS, FINDING_DETAILS, COMMENTS, severity, CCI references. Handle malformed/truncated XML gracefully with detailed error reporting. |
+| 1.2 | **STIG Finding Resolution** | — | Map parsed VULN entries to existing `StigControl` records via VulnId/RuleId/StigVersion. Report unmatched entries (STIG rules not in the curated library). |
+| 1.3 | **CCI→NIST Control Mapping** | — | For each matched STIG finding, resolve CCI references to NIST 800-53 control IDs using the existing `cci-nist-mapping.json`. Link findings to the registered system's control baseline. |
+| 1.4 | **ComplianceFinding Creation** | ISSO, SCA | Create `ComplianceFinding` records for each `Open` CKL entry. Set `StigFinding = true`, `StigId`, `CatSeverity`, `Source = "CKL Import"`, `ScanSource = ScanSourceType.Combined`. |
+| 1.5 | **ControlEffectiveness Upsert** | SCA | For each unique NIST control resolved from CKL findings **that exists in the system's control baseline**, upsert `ControlEffectiveness` via `IAssessmentArtifactService.AssessControlAsync`. `NotAFinding` → Satisfied; `Open` → OtherThanSatisfied. Set `AssessmentMethod = "Test"`. Controls outside the baseline get `ComplianceFinding` records only (no effectiveness). |
+| 1.6 | **Evidence Auto-Creation** | ISSO | Create `ComplianceEvidence` records from the CKL file. `EvidenceType = "StigChecklist"`, `EvidenceCategory = Configuration`, `CollectionMethod = "Manual"` (CKL is human-evaluated; XCCDF uses `"Automated"`). Content contains parsed finding summary. `ContentHash` computed via SHA-256. |
+| 1.7 | **Import Conflict Resolution** | ISSO | When importing a CKL for a system that already has findings for the same STIG rules: `skip` (keep existing), `overwrite` (replace with imported), `merge` (keep more-recent, append details). Follows the `EmassImportOptions` pattern. |
+| 1.10 | **Duplicate File Detection** | ISSO | On import, check if a `ScanImportRecord` with the same `FileHash` + `RegisteredSystemId` already exists. If so, proceed with the import but include a warning: "File previously imported on {date} (import ID: {id})". This supports legitimate re-imports with different conflict resolution while alerting to accidental duplicates. |
+| 1.8 | **Dry-Run Mode** | ISSO, SCA | Preview import results without persisting changes. Show: findings to create, findings to update, controls affected, conflicts detected. |
+| 1.9 | **Import MCP Tool** | ISSO | `compliance_import_ckl` tool accepting base64-encoded file content, system_id, conflict_resolution strategy, and dry_run flag. Returns import summary. |
+
+### Phase 2: XCCDF Import
+
+| # | Capability | Persona | Description |
+|---|-----------|---------|-------------|
+| 2.1 | **XCCDF Results Parser** | — | Parse SCAP SCC XCCDF results XML (NIST SP 800-126 Rev 3). Extract TestResult metadata, target info, rule-result elements with pass/fail/error status, severity, and check references. |
+| 2.2 | **Rule ID Resolution** | — | Extract DISA STIG rule IDs from XCCDF `idref` attributes (e.g., `xccdf_mil.disa.stig_rule_SV-254239r849090_rule` → `SV-254239r849090_rule`). Match to `StigControl.RuleId`. |
+| 2.3 | **Automated Scan Evidence** | SCA | XCCDF results are more authoritative than manual CKL checks (machine-verified). Evidence records include scan timestamps, tool identity, OVAL check references. `CollectionMethod = "Automated"`. |
+| 2.4 | **XCCDF Score Capture** | SCA | Capture the XCCDF compliance score from the `<score>` element. Store as import metadata for trend tracking. |
+| 2.5 | **Import MCP Tool** | ISSO | `compliance_import_xccdf` tool with same interface pattern as CKL import. |
+
+### Phase 3: CKL Export
+
+| # | Capability | Persona | Description |
+|---|-----------|---------|-------------|
+| 3.1 | **CKL Generation** | ISSO, Engineer | Generate a complete `.ckl` file for a STIG benchmark from ATO Copilot assessment data. Enumerate **all** `StigControl` records matching the benchmark, fill in statuses from corresponding `ComplianceFinding` records, and default unassessed rules to `Not_Reviewed`. Includes ASSET metadata from `RegisteredSystem`. Produces eMASS-compliant CKL files with no gaps. |
+| 3.2 | **Benchmark Selection** | ISSO | Choose which STIG benchmark to export (system may have findings from multiple STIGs). List available benchmarks based on imported/assessed STIG data. |
+| 3.3 | **Export MCP Tool** | ISSO | `compliance_export_ckl` tool returning base64-encoded CKL XML content. |
+
+### Phase 4: Import Management & Observability
+
+| # | Capability | Persona | Description |
+|---|-----------|---------|-------------|
+| 4.1 | **Import History Tracking** | ISSO, SCA | Track all imports: file name, file hash, import timestamp, imported by, system, finding counts (open/pass/N-A/skipped), conflict resolution used. |
+| 4.2 | **Import Summary Dashboard** | ISSM, SCA | View import statistics per system: total imports, latest import date, STIG benchmarks covered, overall pass rate, trend across imports. |
+| 4.3 | **List Imports Tool** | ISSO | `compliance_list_imports` tool with filtering by system, date range, benchmark. |
+| 4.4 | **Get Import Summary Tool** | SCA | `compliance_get_import_summary` tool returning detailed breakdown of a specific import with finding-level details. |
+| 4.5 | **Unmatched Rules Report** | ISSO | List STIG rules from imported files that don't match any `StigControl` in the curated library. Helps identify gaps in STIG coverage. |
+
+---
+
+## Part 6: Mapping Pipeline Architecture
+
+### Import Flow (CKL)
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│  CKL File    │────▶│  CKL Parser  │────▶│  STIG Resolver   │────▶│  CCI→NIST Mapper │
+│  (XML)       │     │  (extract    │     │  (match VulnId/  │     │  (CCI refs →     │
+│              │     │   VULNs)     │     │   RuleId to      │     │   NIST controls) │
+└──────────────┘     └──────────────┘     │   StigControl)   │     └────────┬─────────┘
+                                          └──────────────────┘              │
+                                                                            ▼
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│  Import Record   │◀────│  Evidence Creator │◀────│  Effectiveness   │◀────│  Finding Creator  │
+│  (history)       │     │  (SHA-256 hash,  │     │  Upsert          │     │  (ComplianceFinding│
+│                  │     │   chain of       │     │  (per NIST       │     │   with StigFinding │
+│                  │     │   custody)       │     │   control)       │     │   = true)          │
+└──────────────────┘     └──────────────────┘     └──────────────────┘     └──────────────────┘
+```
+
+### Resolution Logic
+
+1. **Parse** CKL/XCCDF XML → list of `ParsedCklEntry` or `ParsedXccdfResult` DTOs
+2. **Resolve STIG** — For each result, lookup `StigControl` by:
+   - Primary: `VulnId` (e.g., `V-254239`)
+   - Fallback: `RuleId` (e.g., `SV-254239r849090_rule`)
+   - Fallback: `StigVersion` (e.g., `WN22-AU-000010`)
+   - Log unmatched entries
+3. **Resolve NIST controls** — For each matched STIG, use CCI references:
+   - CCI → `cci-nist-mapping.json` → NIST 800-53 control IDs
+   - Validate each NIST control exists in the system's `ControlBaseline.ControlIds`
+   - For controls **in baseline**: create `ComplianceFinding` + `ControlEffectiveness` records
+   - For controls **outside baseline**: create `ComplianceFinding` only (audit trail), skip `ControlEffectiveness`, add warning: "{N} NIST controls resolved but not in system baseline: {list}"
+4. **Check conflicts** — For each finding, check if a `ComplianceFinding` already exists with the same `StigId` + `AssessmentId`
+5. **Apply** — Based on conflict resolution strategy, create/update/skip
+6. **Re-evaluate effectiveness** — For each NIST control affected by this import, query **all** current `ComplianceFinding` records (not just those from this import). If any finding for the control is `Open`, determination = `OtherThanSatisfied`. Only when all findings are `NotAFinding`/`Remediated` does the determination become `Satisfied`. This ensures effectiveness reflects the aggregate state across all imports and manual assessments.
+7. **Record** — Create `ScanImportRecord` with summary statistics
+
+### Severity Mapping
+
+| CKL/XCCDF Severity | `StigSeverity` | `CatSeverity` | `FindingSeverity` |
+|---------------------|----------------|---------------|-------------------|
+| `high` | `High` | `CatI` | `High` |
+| `medium` | `Medium` | `CatII` | `Medium` |
+| `low` | `Low` | `CatIII` | `Low` |
+
+---
+
+## Part 7: Integration Points
+
+### 7.1 Existing Services Used
+
+| Service | How It's Used |
+|---------|--------------|
+| `IStigKnowledgeService` | Lookup `StigControl` by VulnId/RuleId for resolution |
+| `IAssessmentArtifactService` | `AssessControlAsync` — upsert `ControlEffectiveness` from parsed results |
+| `IBaselineService` | `GetBaselineAsync` — validate NIST controls are in system's baseline |
+| `IRmfLifecycleService` | `GetSystemAsync` — validate system exists and is in appropriate RMF step |
+| `IComplianceAssessmentService` | Create/get assessment context for findings |
+
+### 7.2 New Service
+
+| Service | Purpose |
+|---------|---------|
+| `IScanImportService` | Core import orchestration: parse, resolve, map, create findings, track history |
+
+### 7.3 File Transfer
+
+**Challenge**: MCP tools communicate via JSON-RPC. There is no multipart file upload endpoint on the MCP server.
+
+**Solution**: Accept file content as **base64-encoded string** in the MCP tool parameter. This works because:
+- CKL files are typically 100KB–2MB (XML, highly compressible)
+- XCCDF results are typically 50KB–500KB
+- Base64 encoding adds ~33% overhead, keeping payloads under 3MB
+- The MCP JSON-RPC protocol has no hard message size limit in our implementation
+- The existing chat attachment endpoint (10MB limit) could be extended for larger files in the future
+
+**File size limit**: 5MB after base64 decoding. Files larger than this are rejected with a helpful error suggesting splitting by benchmark.
+
+### 7.4 Assessment Context
+
+Imported findings need an `AssessmentId` (FK to `ComplianceAssessment`). On import:
+1. If `assessment_id` is provided, use it (must be active, not completed)
+2. If no assessment exists for the system, create one automatically with `source = "STIG/SCAP Import"`
+3. If an active assessment exists, use it (warn if not the most recent)
+
+---
+
+## Part 8: What This Changes
+
+### Entity Model Changes
+
+| Entity | Change | Details |
+|--------|--------|---------|
+| `ScanImportRecord` | **NEW** | Import history tracking with file metadata, finding counts, status |
+| `ScanImportFinding` | **NEW** | Per-finding import detail for audit trail |
+| `ComplianceFinding` | **ENRICHED** | New `ImportRecordId` FK (nullable), new `ScanSource` value |
+| `ComplianceEvidence` | **ENRICHED** | New `EvidenceType` value: `"StigChecklist"`, `"ScapResult"` |
+
+### Service Layer Changes
+
+| Component | Change |
+|-----------|--------|
+| `IScanImportService` / `ScanImportService` | **NEW** — CKL/XCCDF parsing, STIG resolution, finding creation, import history |
+| `ICklParser` / `CklParser` | **NEW** — CKL XML parsing with XElement/XDocument |
+| `IXccdfParser` / `XccdfParser` | **NEW** — XCCDF XML parsing |
+| `IStigKnowledgeService` | **EXTENDED** — Add `GetStigControlByRuleIdAsync(string ruleId)` for XCCDF resolution |
+| `AtoCopilotContext` | **MODIFIED** — Add `ScanImportRecords`, `ScanImportFindings` DbSets |
+
+### Tool Layer Changes
+
+| Tool | Parent File | Description |
+|------|-------------|-------------|
+| `ImportCklTool` | `ScanImportTools.cs` | Parse and import .ckl file |
+| `ImportXccdfTool` | `ScanImportTools.cs` | Parse and import .xccdf file |
+| `ExportCklTool` | `ScanImportTools.cs` | Generate .ckl from assessment data |
+| `ListImportsTool` | `ScanImportTools.cs` | List import history for a system |
+| `GetImportSummaryTool` | `ScanImportTools.cs` | Detailed import result breakdown |
+
+### MCP Registration
+
+5 new tools registered in `ComplianceMcpTools.cs`.
+
+---
+
+## Part 9: What We're NOT Building
+
+| Out of Scope | Reason |
+|-------------|--------|
+| **SCAP Scanner** | We import results, we don't run DISA SCC |
+| **ACAS/Nessus .nessus import** | Different format, different parser — separate feature |
+| **OVAL Definition parsing** | XCCDF results reference OVAL but we don't parse the OVAL XML itself |
+| **Real-time scan triggering** | No API to invoke SCAP SCC remotely |
+| **Streaming file upload** | MCP protocol uses JSON-RPC; multipart upload is a future enhancement |
+| **CKL editing UI** | We're an import/export pipeline, not a STIG Viewer replacement |
+| **Automatic STIG library expansion from CKL** | Unmatched rules are logged, not auto-added to the curated library |
+| **Batch import of ZIP archives** | Single file per tool call; batch via multiple calls |
+
+---
+
+## Part 10: Success Criteria
+
+| Criterion | Measurement |
+|-----------|-------------|
+| CKL import parses all VULN entries correctly | 100% of STIG Viewer-exported CKL files parse without error (tested with 5+ benchmark types) |
+| XCCDF import parses all rule-result entries correctly | 100% of SCAP SCC-exported XCCDF files parse without error |
+| STIG→CCI→NIST mapping resolves correctly | ≥95% of CKL findings with CCI references map to valid NIST controls |
+| Findings created with correct severity and status | All CKL STATUS values correctly mapped to ComplianceFinding status |
+| ControlEffectiveness records created per NIST control | One effectiveness record per unique NIST control from resolved findings |
+| Evidence chain integrity | Imported file content hashed with SHA-256; hash verifiable post-import |
+| Conflict resolution works correctly | Skip/Overwrite/Merge strategies produce expected results |
+| Dry-run shows accurate preview | Dry-run output matches actual import results when run non-dry |
+| CKL export produces valid XML | Exported CKL files re-importable by DISA STIG Viewer |
+| Import history queryable | All imports tracked with searchable metadata |
+| Performance: CKL import < 10s for 500 VULNs | Single CKL file with ~500 VULN entries processed in < 10 seconds |
+| Performance: XCCDF import < 5s for 500 rule-results | XCCDF with ~500 rules processed in < 5 seconds |
+
+---
+
+## Part 11: Build Sequence & Rationale
+
+### Why This Order?
+
+1. **Phase 1 (CKL Import) first** because CKL is the most common format. Every DoD team uses STIG Viewer, and CKL files are the universal exchange format for STIG assessment results.
+
+2. **Phase 2 (XCCDF Import) second** because XCCDF extends the same pipeline with a different parser. The STIG resolution and NIST mapping logic from Phase 1 is reused.
+
+3. **Phase 3 (CKL Export) third** because export completes the round-trip. Teams need to upload CKL files to eMASS after updating remediation status in ATO Copilot.
+
+4. **Phase 4 (Management) last** because import history and summary tools are observability features built on top of working import functionality.
+
+### Timeline Estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| Phase 1 | CKL parser, STIG resolver, finding/evidence creation, conflict resolution, MCP tool | 3–4 days |
+| Phase 2 | XCCDF parser, rule-result mapping, MCP tool | 1–2 days |
+| Phase 3 | CKL generator, benchmark selection, MCP tool | 1–2 days |
+| Phase 4 | Import history entity, list/summary tools, unmatched rules report | 1–2 days |
+| **Total** | **5 tools, 2 parsers, 2 new entities, 1 new service** | **6–10 days** |

--- a/specs/017-scap-stig-import/tasks.md
+++ b/specs/017-scap-stig-import/tasks.md
@@ -1,0 +1,358 @@
+# Tasks: 017 — SCAP/STIG Viewer Import
+
+**Input**: Design documents from `/specs/017-scap-stig-import/`  
+**Prerequisites**: plan.md ✅, spec.md ✅, data-model.md ✅, contracts/mcp-tools.md ✅, research.md ✅, quickstart.md ✅
+
+**Tests**: Included per constitution principle III. Each parser/service/tool gets positive + negative tests.
+
+**Organization**: Tasks grouped by implementation phase. Each phase is independently testable.
+
+## Format: `[ID] [P?] [Cap#] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Cap#]**: Maps to spec capability numbers (1.x = Phase 1, 2.x = Phase 2, etc.)
+
+---
+
+## Phase 1: Setup & Foundation
+
+**Purpose**: New enums, entities, DTOs, DbContext scaffolding.
+
+- [X] T001 Create branch `017-scap-stig-import` from `main` and verify clean build
+- [X] T002 [P] Create `src/Ato.Copilot.Core/Models/Compliance/ScanImportModels.cs` — enums (`ScanImportType`, `ScanImportStatus`, `ImportConflictResolution`, `ImportFindingAction`), `ScanImportRecord` entity, `ScanImportFinding` entity per data-model.md
+- [X] T003 [P] Create parsed DTOs in `ScanImportModels.cs` — `ParsedCklEntry`, `ParsedCklFile`, `CklAssetInfo`, `CklStigInfo`, `ParsedXccdfResult`, `ParsedXccdfFile`, `ImportResult`, `UnmatchedRuleInfo`
+- [X] T004 Add nullable `ImportRecordId` FK (string?) to `ComplianceFinding` in `src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs`
+- [X] T005 Add `ScanImportRecords` and `ScanImportFindings` DbSets to `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs` with EF Core configuration per data-model.md (relationships, JSON columns, indexes)
+- [X] T006 EF Core migration not needed — project uses EnsureCreatedAsync pattern
+- [X] T007 [P] Create unit tests for new enums and entity validation in `tests/Ato.Copilot.Tests.Unit/Models/ScanImportModelTests.cs` (25 tests pass)
+
+**Checkpoint**: All entities, enums, and DTOs exist. Build passes with zero warnings.
+
+---
+
+## Phase 2: CKL Parser (Spec §1.1)
+
+**Purpose**: Parse DISA STIG Viewer CKL XML files into typed DTOs.
+
+- [X] T008 Create `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklParser.cs` implementing `ICklParser` — parse CHECKLIST XML with XDocument, extract ASSET info, STIG_INFO SI_DATA elements, and all VULN entries. Handle malformed XML with XmlException catching and descriptive error messages.
+- [X] T009 [P] Create test data file `tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.ckl` — valid CKL with 5 VULNs: 2 Open (high/medium), 2 NotAFinding, 1 Not_Applicable. Include ASSET/STIG_INFO/CCI_REF data.
+- [X] T010 [P] Create test data file `tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.ckl` — truncated XML for error handling tests
+- [X] T011 [P] Create test data file `tests/Ato.Copilot.Tests.Unit/TestData/sample-severity-override.ckl` — CKL with SEVERITY_OVERRIDE and SEVERITY_JUSTIFICATION fields populated
+- [X] T012 Create unit tests in `tests/Ato.Copilot.Tests.Unit/Parsers/CklParserTests.cs` (23 tests pass):
+  - Parse valid CKL → correct entry count, statuses, severities
+  - Parse ASSET section → correct hostname, IP, MAC
+  - Parse STIG_INFO → correct benchmark ID, version, title
+  - Parse CCI_REF → multiple CCI refs per VULN
+  - Parse severity override → override value used
+  - Parse malformed XML → descriptive error, not crash
+  - Parse empty VULN list → empty entries, no error
+  - Parse CKL with Not_Reviewed → correct status mapping
+  - Parse CKL with missing optional fields → null values, no crash
+
+**Checkpoint**: CKL parser handles valid and malformed files. All parser tests pass.
+
+---
+
+## Phase 3: STIG Resolution & CCI→NIST Mapping (Spec §1.2, §1.3)
+
+**Purpose**: Map parsed CKL entries to existing StigControl records and resolve NIST controls via CCI chain.
+
+- [X] T013 Create `src/Ato.Copilot.Core/Interfaces/Compliance/IScanImportService.cs` with methods:
+  - `ImportCklAsync(string systemId, string? assessmentId, byte[] fileContent, string fileName, ImportConflictResolution resolution, bool dryRun, string importedBy, CancellationToken ct)` — service receives raw bytes (tool layer decodes base64)
+  - `ImportXccdfAsync(...)` (same signature pattern)
+  - `ExportCklAsync(string systemId, string benchmarkId, string? assessmentId, CancellationToken ct)`
+  - `ListImportsAsync(string systemId, int page, int pageSize, string? benchmarkId, string? importType, bool includeDryRuns, DateTime? fromDate, DateTime? toDate, CancellationToken ct)`
+  - `GetImportSummaryAsync(string importId, CancellationToken ct)` *(IScanImportService.cs created with 5 methods)*
+- [X] T014 Create STIG resolution logic in `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/ScanImportService.cs`:
+  - Resolve VulnId → `IStigKnowledgeService.GetStigControlAsync(vulnId)`
+  - Fallback: RuleId → `IStigKnowledgeService.GetStigControlByRuleIdAsync(ruleId)` (new method)
+  - Fallback: StigVersion → search by version string
+  - Track unmatched entries with VulnId/RuleId/Title for reporting *(ScanImportService.cs 880 lines, full pipeline)*
+- [X] T015 Implement CCI→NIST mapping in `ScanImportService`:
+  - For each matched StigControl, iterate `CciRefs`
+  - Lookup each CCI in `cci-nist-mapping.json` via `IStigKnowledgeService.GetCciMappingsAsync`
+  - Collect unique NIST control IDs
+  - Validate against system's `ControlBaseline.ControlIds` — log controls not in baseline *(Uses StigControl.NistControls with baseline validation)*
+- [X] T016 Add `GetStigControlByRuleIdAsync(string ruleId)` to `IStigKnowledgeService` interface in `src/Ato.Copilot.Core/Interfaces/Compliance/IComplianceInterfaces.cs`
+- [X] T017 Implement `GetStigControlByRuleIdAsync` in `src/Ato.Copilot.Agents/Compliance/Services/KnowledgeBase/StigKnowledgeService.cs` — index StigControls by RuleId on first call, cache result *(cached Dictionary<string, StigControl> with 24h TTL)*
+- [X] T018 [P] Create unit tests for STIG resolution in `tests/Ato.Copilot.Tests.Unit/Services/ScanImportServiceTests.cs`:
+  - VulnId match → correct StigControl returned
+  - VulnId miss, RuleId match → fallback works
+  - Both miss → unmatched, no error
+  - CCI resolution → correct NIST controls
+  - CCI with no NIST mapping → warning logged
+  - NIST control not in baseline → warning logged
+  - Multiple CCI refs → all NIST controls resolved *(45 tests total, all pass)*
+
+**Checkpoint**: STIG resolution and CCI→NIST mapping working. Unmatched rules tracked.
+
+---
+
+## Phase 4: Finding & Effectiveness Creation (Spec §1.4, §1.5, §1.6)
+
+**Purpose**: Create ComplianceFinding, ControlEffectiveness, and ComplianceEvidence records from parsed CKL data.
+
+- [X] T019 Implement finding creation in `ScanImportService`:
+  - CKL `Open` → `ComplianceFinding` with `StigFinding = true`, `StigId = VulnId`, `CatSeverity` mapped from severity, `Source = "CKL Import"`, `FindingStatus = Open`
+  - CKL `NotAFinding` → `ComplianceFinding` with `FindingStatus = Remediated`
+  - CKL `Not_Applicable` → `ScanImportFinding` with `ImportAction = NotApplicable` (no ComplianceFinding)
+  - CKL `Not_Reviewed` → `ComplianceFinding` with `FindingStatus = Open` and note "Not yet reviewed" in FindingDetails + `ScanImportFinding` with `ImportAction = NotReviewed`
+  - For NIST controls **outside** the system's control baseline: create `ComplianceFinding` only (audit trail), skip `ControlEffectiveness`. Add warning to import result.
+  - Set `ImportRecordId` FK on all created findings
+  - Validate system is in RMF step Assess or later; if not, add warning to import result (do not block)
+- [X] T020 [P] Implement ControlEffectiveness upsert in `ScanImportService`:
+  - Group findings by NIST control ID (only controls **in** system's control baseline)
+  - For each unique in-baseline control: re-evaluate **all** current `ComplianceFinding` records for that control (not just this import's findings) to determine aggregate effectiveness
+  - ALL findings for the control are `NotAFinding`/`Remediated` → `Satisfied`
+  - ANY finding for the control is `Open` → `OtherThanSatisfied`
+  - Set `AssessmentMethod = "Test"`, `AssessorId = importedBy`
+- [X] T021 [P] Implement evidence creation in `ScanImportService`:
+  - Create `ComplianceEvidence` per import (one evidence per CKL file):
+    - `EvidenceType = "StigChecklist"`
+    - `EvidenceCategory = Configuration`
+    - `CollectionMethod = "Manual"` (CKL) or `"Automated"` (XCCDF)
+    - `Content = JSON summary of parsed results`
+    - `ContentHash = SHA-256 of raw file bytes`
+    - `CollectedAt = ScanTimestamp or ImportedAt`
+  - Link evidence to ControlEffectiveness via `EvidenceIds`
+- [X] T022 [P] Create unit tests for finding creation:
+  - Open → ComplianceFinding created with correct fields
+  - NotAFinding → finding with Remediated status
+  - Not_Applicable → no finding, ScanImportFinding with NotApplicable action
+  - Not_Reviewed → ComplianceFinding with FindingStatus.Open and "Not yet reviewed" in FindingDetails
+  - Severity mapping: high→CatI, medium→CatII, low→CatIII
+  - SeverityOverride applied when present
+  - Multiple CCI refs → finding linked to multiple NIST controls
+  - Out-of-baseline NIST control → ComplianceFinding created, no ControlEffectiveness, warning emitted
+  - System not in RMF Assess step → warning emitted, import proceeds
+- [X] T023 [P] Create unit tests for effectiveness upsert:
+  - All rules pass for control → Satisfied
+  - One rule fails for control → OtherThanSatisfied
+  - Mixed results across multiple controls → correct per-control determination
+  - ControlEffectiveness.AssessmentMethod = "Test"
+  - Re-import with Merge: previously-Open rule now NotAFinding + all other rules pass → control flips to Satisfied (aggregate re-evaluation)
+  - Re-import: effectiveness re-evaluates ALL findings for control, not just current import's findings
+  - Out-of-baseline control → no ControlEffectiveness created
+- [X] T024 [P] Create unit tests for evidence creation:
+  - SHA-256 hash computed correctly
+  - EvidenceType = "StigChecklist" for CKL
+  - Content contains summary JSON
+  - Evidence linked to effectiveness records
+
+**Checkpoint**: Full import pipeline working — CKL → findings → effectiveness → evidence.
+
+---
+
+## Phase 5: Conflict Resolution & Dry-Run (Spec §1.7, §1.8)
+
+**Purpose**: Handle re-imports with conflict resolution and provide preview mode.
+
+- [X] T025 Implement conflict detection in `ScanImportService`:
+  - Query existing `ComplianceFinding` by `StigId` + `AssessmentId`
+  - Track conflicts per finding
+- [X] T026 Implement conflict resolution strategies:
+  - **Skip**: Leave existing finding unchanged, log as skipped
+  - **Overwrite**: Update existing finding with imported data (status, details, severity), update `ModifiedAt`
+  - **Merge**: Keep more-recent status; append finding details if different; use imported severity only if higher
+- [X] T027 Implement dry-run mode:
+  - Run full parse, resolution, and conflict detection
+  - Build `ImportResult` with all counts and warnings
+  - Do NOT persist any changes (no DB writes)
+  - Set `ScanImportRecord.IsDryRun = true`
+  - Return `ImportResult` with preview data
+- [X] T028 [P] Create unit tests for conflict resolution:
+  - Skip: existing finding unchanged, import count = 0
+  - Overwrite: finding updated with imported data
+  - Merge: more-recent status wins, details appended
+  - Merge: severity takes higher value
+  - No conflict: new finding created regardless of strategy
+- [X] T029 [P] Create unit tests for dry-run:
+  - Dry-run returns accurate counts
+  - Dry-run creates no DB records
+  - Dry-run results match non-dry-run results
+
+**Checkpoint**: Conflict resolution and dry-run working. Re-imports handled correctly.
+
+---
+
+## Phase 6: CKL Import MCP Tool (Spec §1.9)
+
+**Purpose**: Expose CKL import as an MCP tool.
+
+- [X] T030 Create `ImportCklTool` in `src/Ato.Copilot.Agents/Compliance/Tools/ScanImportTools.cs`:
+  - Extends `BaseTool`
+  - Parameters: `system_id` (required), `file_content` (base64, required), `file_name` (required), `conflict_resolution` (optional, default Skip), `dry_run` (optional, default false), `assessment_id` (optional)
+  - **Tool layer responsibility**: decode base64 string → `byte[]`, validate decoded size ≤ 5MB, then pass `byte[]` to `IScanImportService.ImportCklAsync` (service layer receives raw bytes, not base64)
+  - Check for duplicate file: compute SHA-256 of decoded bytes, query `ScanImportRecord` by `FileHash` + `RegisteredSystemId`. If match found, add warning: "File previously imported on {date} (import ID: {id})" — proceed with import
+  - Return `ImportResult` as formatted summary
+- [X] T031 Register `ImportCklTool` in `src/Ato.Copilot.Mcp/Tools/ComplianceMcpTools.cs`
+- [X] T032 Register `ScanImportService`, `CklParser` in `src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs`
+- [X] T033 [P] Create unit tests for `ImportCklTool`:
+  - Valid import → success with counts
+  - Missing system_id → error
+  - Invalid base64 → error
+  - File too large → error with helpful message
+  - Duplicate file (same SHA-256 + system) → warning present in response, import proceeds
+  - Dry-run flag → no persistence
+  - System not found → error
+  - Invalid CKL XML → error with parse details
+- [X] T034 [P] Create integration test in `tests/Ato.Copilot.Tests.Integration/Tools/ScanImportIntegrationTests.cs`:
+  - Register system → import CKL → verify findings created → verify effectiveness records → verify evidence → verify import history
+
+**Checkpoint**: CKL import available as MCP tool. End-to-end integration tested.
+
+---
+
+## Phase 7: XCCDF Parser & Import (Spec §2.1–§2.5)
+
+**Purpose**: Parse XCCDF results and import with same downstream pipeline.
+
+- [X] T035 Create `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/XccdfParser.cs`:
+  - Parse XCCDF TestResult XML with namespace-aware XDocument parsing
+  - Extract benchmark href, target info, target-facts
+  - Parse all rule-result elements: idref, result, severity, weight, message
+  - Extract DISA rule ID from XCCDF idref (`xccdf_mil.disa.stig_rule_SV-254239r849090_rule` → `SV-254239r849090_rule`)
+  - Parse score element
+  - Handle namespace variations (XCCDF 1.1 and 1.2)
+- [X] T036 [P] Create test data file `tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.xccdf` — valid XCCDF with 5 rule-results: 2 fail, 2 pass, 1 notapplicable
+- [X] T037 [P] Create test data file `tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.xccdf`
+- [X] T038 Implement `ImportXccdfAsync` in `ScanImportService`:
+  - Call `XccdfParser.Parse`
+  - Resolve XCCDF rule IDs → StigControl via `GetStigControlByRuleIdAsync`
+  - Reuse CCI→NIST mapping, finding creation, effectiveness upsert, evidence creation
+  - Set `CollectionMethod = "Automated"` (XCCDF = machine-verified)
+  - Capture XCCDF score in `ScanImportRecord.XccdfScore`
+- [X] T039 Create `ImportXccdfTool` in `ScanImportTools.cs` — same pattern as `ImportCklTool`
+- [X] T040 Register `ImportXccdfTool` in `ComplianceMcpTools.cs` and `XccdfParser` in DI
+- [X] T041 [P] Create unit tests in `tests/Ato.Copilot.Tests.Unit/Parsers/XccdfParserTests.cs`:
+  - Parse valid XCCDF → correct result count, statuses
+  - Parse target info → hostname, IP, OS
+  - Parse score → correct value
+  - Rule ID extraction → `SV-XXXXX` from XCCDF idref
+  - Namespace handling → works with XCCDF 1.1 and 1.2
+  - Malformed XML → descriptive error
+  - Empty results → no error
+  - Error/unknown results → flagged for review
+- [X] T042 [P] Create unit tests for XCCDF import:
+  - `fail` → Open finding + OtherThanSatisfied
+  - `pass` → Satisfied effectiveness
+  - `error` → flagged, no effectiveness change
+  - `notapplicable` → no finding
+  - Score captured in import record
+  - CollectionMethod = "Automated"
+
+**Checkpoint**: XCCDF import fully working. Both CKL and XCCDF share downstream pipeline.
+
+---
+
+## Phase 8: CKL Export (Spec §3.1–§3.3)
+
+**Purpose**: Generate CKL files from assessment data.
+
+- [X] T043 Create `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklGenerator.cs`:
+  - Generate CHECKLIST XML using XDocument/XElement
+  - ASSET section from RegisteredSystem metadata
+  - STIG_INFO from benchmark metadata
+  - Enumerate **all** `StigControl` records matching the benchmark (full STIG coverage)
+  - For each StigControl: left-join with `ComplianceFinding` records for the system/assessment
+  - VULN entries with matching finding: map `FindingStatus` → CKL STATUS (Open→Open, Remediated→NotAFinding, Accepted→Not_Applicable)
+  - VULN entries with **no** matching finding: default to `Not_Reviewed` STATUS
+  - Include FINDING_DETAILS and COMMENTS from finding descriptions (empty string for unassessed rules)
+- [X] T044 Implement `ExportCklAsync` in `ScanImportService`:
+  - Validate system exists
+  - Validate benchmark exists in `StigControl` library (at least one rule with matching `BenchmarkId`)
+  - List all StigControl records for the benchmark → pass to CklGenerator
+  - Query `ComplianceFinding` records for system/assessment with `StigFinding = true` → pass to CklGenerator for STATUS lookup
+  - Return base64-encoded XML (assessment data optional — unassessed rules default to Not_Reviewed)
+- [X] T045 Create `ExportCklTool` in `ScanImportTools.cs`:
+  - Parameters: `system_id` (required), `benchmark_id` (required), `assessment_id` (optional)
+  - Return base64-encoded CKL content with file name suggestion
+- [X] T046 Register `ExportCklTool` in `ComplianceMcpTools.cs` and `CklGenerator` in DI
+- [X] T047 [P] Create unit tests for CKL generation:
+  - Generated XML is well-formed
+  - ASSET section contains system metadata
+  - VULN entries have correct STATUS mapping
+  - CCI_REF elements included
+  - Exported CKL re-parseable by CklParser (round-trip)
+  - No findings for benchmark → CKL with all VULNs set to Not_Reviewed (full benchmark, not empty)
+  - Only StigControl entries for selected benchmark included
+  - Partial assessment: some findings assessed, rest default to Not_Reviewed
+
+**Checkpoint**: CKL round-trip verified — import → modify → export → re-import.
+
+---
+
+## Phase 9: Import Management Tools (Spec §4.1–§4.5)
+
+**Purpose**: Import history tracking and summary tools.
+
+- [X] T048 Implement `ListImportsAsync` in `ScanImportService`:
+  - Filter by system_id, optional date range, optional benchmark_id
+  - Paginated (default 20, max 100)
+  - Order by ImportedAt descending
+  - Exclude dry-run records by default (optional flag to include)
+- [X] T049 Implement `GetImportSummaryAsync` in `ScanImportService`:
+  - Load ScanImportRecord with all ScanImportFindings
+  - Include unmatched rules list
+  - Include per-NIST-control breakdown showing effectiveness outcomes
+- [X] T050 Create `ListImportsTool` in `ScanImportTools.cs`:
+  - Parameters: `system_id` (required), `page` (optional), `page_size` (optional), `benchmark_id` (optional), `include_dry_runs` (optional)
+  - Return paginated list of import summaries
+- [X] T051 Create `GetImportSummaryTool` in `ScanImportTools.cs`:
+  - Parameters: `import_id` (required)
+  - Return detailed import breakdown with finding-level details
+- [X] T052 Register `ListImportsTool` and `GetImportSummaryTool` in `ComplianceMcpTools.cs`
+- [X] T053 [P] Create unit tests for list/summary tools:
+  - List by system → correct results, pagination
+  - List by benchmark → filtered correctly
+  - Summary includes finding counts
+  - Summary includes unmatched rules
+  - Summary includes NIST control breakdown
+  - Import not found → error
+  - System with no imports → empty list
+
+**Checkpoint**: Full import management capability. Feature complete.
+
+---
+
+## Phase 10: Polish & Documentation
+
+**Purpose**: Final integration, documentation, and validation.
+
+- [X] T054 Update `docs/architecture/agent-tool-catalog.md` with 5 new tool entries
+- [X] T055 [P] Update `docs/guides/issm-guide.md` with STIG import workflow section
+- [X] T056 [P] Update `docs/guides/sca-guide.md` with SCAP import for assessment section
+- [X] T057 [P] Update `docs/guides/engineer-guide.md` with CKL import/export from VS Code
+- [X] T058 [P] Update `docs/reference/stig-coverage.md` with import capability
+- [X] T059 Add `[1.18.0]` entry to `CHANGELOG.md` documenting SCAP/STIG Viewer import feature
+- [X] T060 Final integration test: register system → categorize → select baseline → import CKL → verify findings map to baseline controls → export CKL → re-import with Skip → verify no duplicates
+- [X] T061 [P] Add structured logging to `ScanImportService` using `ILogger<ScanImportService>`:
+  - Log import started: file name, file hash, system ID, import type, conflict resolution
+  - Log import completed: duration, finding counts, effectiveness counts, warnings count
+  - Log parse errors at Warning level with file name and error details
+  - Log unmatched rules at Warning level with VulnId/RuleId list
+  - Log out-of-baseline controls at Information level
+- [X] T062 [P] Create performance benchmark tests in `tests/Ato.Copilot.Tests.Unit/Performance/ScanImportPerformanceTests.cs`:
+  - Generate sample CKL with 500 VULNs programmatically → import must complete in < 10 seconds
+  - Generate sample XCCDF with 500 rule-results → import must complete in < 5 seconds
+  - Measure and assert wall-clock time using `System.Diagnostics.Stopwatch`
+
+**Checkpoint**: Feature 017 complete. All tests pass, docs updated, changelog written.
+
+---
+
+## Task Count Summary
+
+| Phase | Tasks | Parallelizable | Description |
+|-------|-------|---------------|-------------|
+| Phase 1 | 7 | 3 | Setup & foundation entities |
+| Phase 2 | 5 | 3 | CKL parser |
+| Phase 3 | 6 | 1 | STIG resolution & CCI mapping |
+| Phase 4 | 6 | 4 | Finding & effectiveness creation |
+| Phase 5 | 5 | 2 | Conflict resolution & dry-run |
+| Phase 6 | 5 | 2 | CKL import MCP tool |
+| Phase 7 | 8 | 4 | XCCDF parser & import |
+| Phase 8 | 5 | 1 | CKL export |
+| Phase 9 | 6 | 1 | Import management tools |
+| Phase 10 | 9 | 6 | Polish & documentation |
+| **Total** | **62** | **27** | |

--- a/src/Ato.Copilot.Agents/Compliance/Services/KnowledgeBase/StigKnowledgeService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/KnowledgeBase/StigKnowledgeService.cs
@@ -20,6 +20,7 @@ public class StigKnowledgeService : IStigKnowledgeService
 
     private const string CacheKey = "kb:stig:all_controls";
     private const string CciCacheKey = "kb:cci:all_mappings";
+    private const string RuleIdIndexCacheKey = "kb:stig:rule_id_index";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -59,6 +60,44 @@ public class StigKnowledgeService : IStigKnowledgeService
         var controls = await LoadControlsAsync();
         return controls.FirstOrDefault(c =>
             string.Equals(c.StigId, stigId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public async Task<StigControl?> GetStigControlByRuleIdAsync(string ruleId, CancellationToken cancellationToken = default)
+    {
+        var index = await LoadRuleIdIndexAsync();
+        index.TryGetValue(ruleId, out var control);
+        return control;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<StigControl>> GetStigControlsByBenchmarkAsync(string benchmarkId, CancellationToken cancellationToken = default)
+    {
+        var controls = await LoadControlsAsync();
+        return controls
+            .Where(c => string.Equals(c.BenchmarkId, benchmarkId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Builds and caches a dictionary keyed by RuleId (case-insensitive) for fast lookups.
+    /// </summary>
+    private async Task<Dictionary<string, StigControl>> LoadRuleIdIndexAsync()
+    {
+        if (_cache.TryGetValue(RuleIdIndexCacheKey, out Dictionary<string, StigControl>? cached) && cached != null)
+            return cached;
+
+        var controls = await LoadControlsAsync();
+        var index = new Dictionary<string, StigControl>(StringComparer.OrdinalIgnoreCase);
+        foreach (var control in controls)
+        {
+            if (!string.IsNullOrEmpty(control.RuleId) && !index.ContainsKey(control.RuleId))
+                index[control.RuleId] = control;
+        }
+
+        _cache.Set(RuleIdIndexCacheKey, index, CacheTtl);
+        _logger.LogDebug("Built RuleId index with {Count} entries", index.Count);
+        return index;
     }
 
     /// <inheritdoc />

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklGenerator.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklGenerator.cs
@@ -1,0 +1,189 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Import: CKL Generator (T043)
+// Generates DISA STIG Viewer CKL XML from assessment data.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Xml.Linq;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Agents.Compliance.Services.ScanImport;
+
+/// <summary>
+/// Generates DISA STIG Viewer CKL XML from STIG controls and assessment findings.
+/// </summary>
+public interface ICklGenerator
+{
+    /// <summary>
+    /// Generate a CKL XML document for the given system, benchmark controls, and findings.
+    /// </summary>
+    /// <param name="system">Registered system for ASSET section.</param>
+    /// <param name="stigControls">All STIG controls for the benchmark (full checklist).</param>
+    /// <param name="findings">Findings keyed by VulnId/StigId for STATUS lookup.</param>
+    /// <param name="benchmarkId">STIG benchmark identifier.</param>
+    /// <param name="benchmarkVersion">STIG version number.</param>
+    /// <param name="benchmarkTitle">Human-readable STIG title.</param>
+    /// <returns>CKL XML as a string.</returns>
+    string Generate(
+        RegisteredSystem system,
+        List<StigControl> stigControls,
+        Dictionary<string, ComplianceFinding> findings,
+        string benchmarkId,
+        string? benchmarkVersion,
+        string? benchmarkTitle);
+}
+
+/// <summary>
+/// Implementation of <see cref="ICklGenerator"/>.
+/// Produces well-formed DISA STIG Viewer-compatible CHECKLIST XML.
+/// </summary>
+public class CklGenerator : ICklGenerator
+{
+    private readonly ILogger<CklGenerator> _logger;
+
+    public CklGenerator(ILogger<CklGenerator> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Generate(
+        RegisteredSystem system,
+        List<StigControl> stigControls,
+        Dictionary<string, ComplianceFinding> findings,
+        string benchmarkId,
+        string? benchmarkVersion,
+        string? benchmarkTitle)
+    {
+        var checklist = new XElement("CHECKLIST",
+            GenerateAsset(system),
+            new XElement("STIGS",
+                new XElement("iSTIG",
+                    GenerateStigInfo(benchmarkId, benchmarkVersion, benchmarkTitle),
+                    stigControls.Select(sc => GenerateVuln(sc, findings)))));
+
+        var doc = new XDocument(
+            new XDeclaration("1.0", "UTF-8", null),
+            new XComment("DISA STIG Viewer :: ATO Copilot Export"),
+            checklist);
+
+        _logger.LogInformation(
+            "Generated CKL for benchmark '{BenchmarkId}': {VulnCount} VULNs, {FindingCount} findings present",
+            benchmarkId, stigControls.Count, findings.Count);
+
+        return doc.Declaration + Environment.NewLine + doc.ToString();
+    }
+
+    /// <summary>Generate the ASSET element from RegisteredSystem metadata.</summary>
+    private static XElement GenerateAsset(RegisteredSystem system)
+    {
+        return new XElement("ASSET",
+            new XElement("ROLE", "None"),
+            new XElement("ASSET_TYPE", "Computing"),
+            new XElement("HOST_NAME", system.Name ?? string.Empty),
+            new XElement("HOST_IP", string.Empty),
+            new XElement("HOST_MAC", string.Empty),
+            new XElement("HOST_FQDN", string.Empty),
+            new XElement("TARGET_COMMENT", string.Empty),
+            new XElement("TECH_AREA", string.Empty),
+            new XElement("TARGET_KEY", string.Empty),
+            new XElement("WEB_OR_DATABASE", "false"),
+            new XElement("WEB_DB_SITE", string.Empty),
+            new XElement("WEB_DB_INSTANCE", string.Empty));
+    }
+
+    /// <summary>Generate the STIG_INFO element.</summary>
+    private static XElement GenerateStigInfo(string benchmarkId, string? version, string? title)
+    {
+        return new XElement("STIG_INFO",
+            SiData("version", version ?? "1"),
+            SiData("stigid", benchmarkId),
+            SiData("releaseinfo", string.Empty),
+            SiData("title", title ?? benchmarkId));
+    }
+
+    /// <summary>Create a STIG_INFO SI_DATA element.</summary>
+    private static XElement SiData(string name, string value)
+    {
+        return new XElement("SI_DATA",
+            new XElement("SID_NAME", name),
+            new XElement("SID_DATA", value));
+    }
+
+    /// <summary>Generate a VULN element from a StigControl and optional matching finding.</summary>
+    private static XElement GenerateVuln(StigControl stigControl, Dictionary<string, ComplianceFinding> findings)
+    {
+        // Try to find a matching finding by StigId/VulnId
+        findings.TryGetValue(stigControl.VulnId ?? stigControl.StigId, out var finding);
+
+        var status = MapFindingStatus(finding);
+        var findingDetails = finding?.Description ?? string.Empty;
+        var comments = string.Empty;
+
+        var vuln = new XElement("VULN",
+            StigData("Vuln_Num", stigControl.VulnId ?? stigControl.StigId),
+            StigData("Severity", MapSeverity(stigControl.Severity)),
+            StigData("Group_Title", string.Empty),
+            StigData("Rule_ID", stigControl.RuleId ?? string.Empty),
+            StigData("Rule_Ver", stigControl.StigVersion ?? string.Empty),
+            StigData("Rule_Title", stigControl.Title ?? string.Empty));
+
+        // Add CCI_REF entries
+        if (stigControl.CciRefs is { Count: > 0 })
+        {
+            foreach (var cci in stigControl.CciRefs)
+            {
+                vuln.Add(StigData("CCI_REF", cci));
+            }
+        }
+
+        vuln.Add(
+            new XElement("STATUS", status),
+            new XElement("FINDING_DETAILS", findingDetails),
+            new XElement("COMMENTS", comments),
+            new XElement("SEVERITY_OVERRIDE", string.Empty),
+            new XElement("SEVERITY_JUSTIFICATION", string.Empty));
+
+        return vuln;
+    }
+
+    /// <summary>Create a STIG_DATA element for a VULN entry.</summary>
+    private static XElement StigData(string attribute, string value)
+    {
+        return new XElement("STIG_DATA",
+            new XElement("VULN_ATTRIBUTE", attribute),
+            new XElement("ATTRIBUTE_DATA", value));
+    }
+
+    /// <summary>
+    /// Map <see cref="FindingStatus"/> to CKL STATUS string.
+    /// </summary>
+    private static string MapFindingStatus(ComplianceFinding? finding)
+    {
+        if (finding is null)
+            return "Not_Reviewed";
+
+        return finding.Status switch
+        {
+            FindingStatus.Open => "Open",
+            FindingStatus.InProgress => "Open",
+            FindingStatus.Remediated => "NotAFinding",
+            FindingStatus.Accepted => "Not_Applicable",
+            _ => "Not_Reviewed"
+        };
+    }
+
+    /// <summary>
+    /// Map <see cref="StigSeverity"/> to CKL severity string.
+    /// </summary>
+    private static string MapSeverity(StigSeverity severity)
+    {
+        return severity switch
+        {
+            StigSeverity.High => "high",
+            StigSeverity.Medium => "medium",
+            StigSeverity.Low => "low",
+            _ => "medium"
+        };
+    }
+}

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklParser.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CklParser.cs
@@ -1,0 +1,206 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: CKL XML Parser
+// Parses DISA STIG Viewer .ckl files into typed ParsedCklFile DTOs.
+// See specs/017-scap-stig-import/spec.md §3.1 for CKL format documentation.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Xml;
+using System.Xml.Linq;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Agents.Compliance.Services.ScanImport;
+
+/// <summary>
+/// Interface for parsing DISA STIG Viewer CKL XML files.
+/// </summary>
+public interface ICklParser
+{
+    /// <summary>
+    /// Parses a CKL file from raw bytes into a <see cref="ParsedCklFile"/> DTO.
+    /// </summary>
+    /// <param name="fileContent">Raw CKL file bytes (UTF-8 XML).</param>
+    /// <param name="fileName">Original file name for error messages.</param>
+    /// <returns>Parsed CKL data.</returns>
+    /// <exception cref="CklParseException">Thrown when XML is malformed or missing required elements.</exception>
+    ParsedCklFile Parse(byte[] fileContent, string fileName);
+}
+
+/// <summary>
+/// Exception thrown when CKL parsing fails.
+/// </summary>
+public class CklParseException : Exception
+{
+    /// <summary>Original file name that failed to parse.</summary>
+    public string FileName { get; }
+
+    public CklParseException(string fileName, string message)
+        : base($"Failed to parse CKL file '{fileName}': {message}")
+    {
+        FileName = fileName;
+    }
+
+    public CklParseException(string fileName, string message, Exception innerException)
+        : base($"Failed to parse CKL file '{fileName}': {message}", innerException)
+    {
+        FileName = fileName;
+    }
+}
+
+/// <summary>
+/// Parses DISA STIG Viewer CKL XML files into typed <see cref="ParsedCklFile"/> DTOs.
+/// Uses <see cref="XDocument"/> for XML parsing with descriptive error handling.
+/// </summary>
+public class CklParser : ICklParser
+{
+    private readonly ILogger<CklParser> _logger;
+
+    public CklParser(ILogger<CklParser> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ParsedCklFile Parse(byte[] fileContent, string fileName)
+    {
+        XDocument doc;
+        try
+        {
+            using var stream = new MemoryStream(fileContent);
+            doc = XDocument.Load(stream);
+        }
+        catch (XmlException ex)
+        {
+            _logger.LogWarning(ex, "Malformed XML in CKL file {FileName}", fileName);
+            throw new CklParseException(fileName, $"Malformed XML at line {ex.LineNumber}, position {ex.LinePosition}: {ex.Message}", ex);
+        }
+
+        var checklist = doc.Element("CHECKLIST");
+        if (checklist is null)
+            throw new CklParseException(fileName, "Missing root <CHECKLIST> element.");
+
+        var asset = ParseAsset(checklist.Element("ASSET"));
+        var iStig = checklist.Element("STIGS")?.Element("iSTIG");
+        if (iStig is null)
+            throw new CklParseException(fileName, "Missing <STIGS>/<iSTIG> element.");
+
+        var stigInfo = ParseStigInfo(iStig.Element("STIG_INFO"));
+        var entries = ParseVulnEntries(iStig.Elements("VULN"));
+
+        _logger.LogDebug("Parsed CKL file {FileName}: {EntryCount} VULN entries, benchmark={BenchmarkId}",
+            fileName, entries.Count, stigInfo.StigId);
+
+        return new ParsedCklFile(asset, stigInfo, entries);
+    }
+
+    /// <summary>
+    /// Parses the ASSET element into a <see cref="CklAssetInfo"/> DTO.
+    /// </summary>
+    private static CklAssetInfo ParseAsset(XElement? assetElement)
+    {
+        if (assetElement is null)
+            return new CklAssetInfo(null, null, null, null, null, null);
+
+        return new CklAssetInfo(
+            HostName: GetElementValue(assetElement, "HOST_NAME"),
+            HostIp: GetElementValue(assetElement, "HOST_IP"),
+            HostFqdn: GetElementValue(assetElement, "HOST_FQDN"),
+            HostMac: GetElementValue(assetElement, "HOST_MAC"),
+            AssetType: GetElementValue(assetElement, "ASSET_TYPE"),
+            TargetKey: GetElementValue(assetElement, "TARGET_KEY"));
+    }
+
+    /// <summary>
+    /// Parses the STIG_INFO element's SI_DATA children into a <see cref="CklStigInfo"/> DTO.
+    /// </summary>
+    private static CklStigInfo ParseStigInfo(XElement? stigInfoElement)
+    {
+        if (stigInfoElement is null)
+            return new CklStigInfo(null, null, null, null);
+
+        var siData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var si in stigInfoElement.Elements("SI_DATA"))
+        {
+            var name = si.Element("SID_NAME")?.Value;
+            var data = si.Element("SID_DATA")?.Value;
+            if (!string.IsNullOrEmpty(name))
+                siData[name] = data ?? string.Empty;
+        }
+
+        return new CklStigInfo(
+            StigId: siData.GetValueOrDefault("stigid"),
+            Version: siData.GetValueOrDefault("version"),
+            ReleaseInfo: siData.GetValueOrDefault("releaseinfo"),
+            Title: siData.GetValueOrDefault("title"));
+    }
+
+    /// <summary>
+    /// Parses all VULN elements into a list of <see cref="ParsedCklEntry"/> DTOs.
+    /// </summary>
+    private static List<ParsedCklEntry> ParseVulnEntries(IEnumerable<XElement> vulnElements)
+    {
+        var entries = new List<ParsedCklEntry>();
+
+        foreach (var vuln in vulnElements)
+        {
+            // Parse STIG_DATA attributes into a dictionary; CCI_REF can appear multiple times
+            var attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var cciRefs = new List<string>();
+
+            foreach (var stigData in vuln.Elements("STIG_DATA"))
+            {
+                var attrName = stigData.Element("VULN_ATTRIBUTE")?.Value;
+                var attrData = stigData.Element("ATTRIBUTE_DATA")?.Value ?? string.Empty;
+
+                if (string.IsNullOrEmpty(attrName))
+                    continue;
+
+                if (string.Equals(attrName, "CCI_REF", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!string.IsNullOrWhiteSpace(attrData))
+                        cciRefs.Add(attrData);
+                }
+                else
+                {
+                    attributes[attrName] = attrData;
+                }
+            }
+
+            var vulnId = attributes.GetValueOrDefault("Vuln_Num") ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(vulnId))
+                continue; // Skip VULN entries without a VulnId
+
+            entries.Add(new ParsedCklEntry(
+                VulnId: vulnId,
+                RuleId: attributes.GetValueOrDefault("Rule_ID"),
+                StigVersion: attributes.GetValueOrDefault("Rule_Ver"),
+                RuleTitle: attributes.GetValueOrDefault("Rule_Title"),
+                Severity: attributes.GetValueOrDefault("Severity") ?? string.Empty,
+                Status: vuln.Element("STATUS")?.Value ?? string.Empty,
+                FindingDetails: NullIfEmpty(vuln.Element("FINDING_DETAILS")?.Value),
+                Comments: NullIfEmpty(vuln.Element("COMMENTS")?.Value),
+                SeverityOverride: NullIfEmpty(vuln.Element("SEVERITY_OVERRIDE")?.Value),
+                SeverityJustification: NullIfEmpty(vuln.Element("SEVERITY_JUSTIFICATION")?.Value),
+                CciRefs: cciRefs,
+                GroupTitle: attributes.GetValueOrDefault("Group_Title")));
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Gets the text value of a child element, or null if empty/missing.
+    /// </summary>
+    private static string? GetElementValue(XElement parent, string elementName)
+    {
+        return NullIfEmpty(parent.Element(elementName)?.Value);
+    }
+
+    /// <summary>
+    /// Returns null if the string is null, empty, or whitespace; otherwise returns the trimmed value.
+    /// </summary>
+    private static string? NullIfEmpty(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/ScanImportService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/ScanImportService.cs
@@ -1,0 +1,1455 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: Core Import Service
+// Implements IScanImportService — CKL/XCCDF import, CKL export, import mgmt.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Agents.Compliance.Services.ScanImport;
+
+/// <summary>
+/// Core import orchestration service for SCAP/STIG scan results.
+/// Parses CKL/XCCDF XML, resolves STIG→CCI→NIST, creates findings and
+/// effectiveness records, handles conflict resolution and dry-run mode.
+/// </summary>
+public class ScanImportService : IScanImportService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IStigKnowledgeService _stigService;
+    private readonly IBaselineService _baselineService;
+    private readonly IRmfLifecycleService _rmfService;
+    private readonly IAssessmentArtifactService _artifactService;
+    private readonly ICklParser _cklParser;
+    private readonly IXccdfParser _xccdfParser;
+    private readonly ICklGenerator _cklGenerator;
+    private readonly ILogger<ScanImportService> _logger;
+
+    public ScanImportService(
+        IServiceScopeFactory scopeFactory,
+        IStigKnowledgeService stigService,
+        IBaselineService baselineService,
+        IRmfLifecycleService rmfService,
+        IAssessmentArtifactService artifactService,
+        ICklParser cklParser,
+        IXccdfParser xccdfParser,
+        ICklGenerator cklGenerator,
+        ILogger<ScanImportService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _stigService = stigService;
+        _baselineService = baselineService;
+        _rmfService = rmfService;
+        _artifactService = artifactService;
+        _cklParser = cklParser;
+        _xccdfParser = xccdfParser;
+        _cklGenerator = cklGenerator;
+        _logger = logger;
+    }
+
+    // ─── ImportCklAsync (T014, T015, T019, T020, T021, T025–T027) ────────
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportCklAsync(
+        string systemId,
+        string? assessmentId,
+        byte[] fileContent,
+        string fileName,
+        ImportConflictResolution resolution,
+        bool dryRun,
+        string importedBy,
+        CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var warnings = new List<string>();
+        var unmatchedRules = new List<UnmatchedRuleInfo>();
+        var fileHash = ComputeSha256(fileContent);
+
+        _logger.LogInformation(
+            "CKL import started: file={FileName}, hash={FileHash}, system={SystemId}, type=CKL, resolution={Resolution}, dryRun={DryRun}",
+            fileName, fileHash, systemId, resolution, dryRun);
+
+        // ── Step 1: Parse CKL ────────────────────────────────────────────
+        ParsedCklFile parsedCkl;
+        try
+        {
+            parsedCkl = _cklParser.Parse(fileContent, fileName);
+        }
+        catch (CklParseException ex)
+        {
+            _logger.LogWarning(ex, "CKL parse failed for file {FileName}", fileName);
+            return CreateFailedResult(
+                $"CKL parse error: {ex.Message}",
+                fileName);
+        }
+
+        // ── Step 2: Validate system ──────────────────────────────────────
+        var system = await _rmfService.GetSystemAsync(systemId, ct);
+        if (system is null)
+        {
+            return CreateFailedResult(
+                $"System '{systemId}' not found.",
+                fileName);
+        }
+
+        // ── Step 3: Check RMF step (warn if < Assess) ───────────────────
+        if (system.CurrentRmfStep < RmfPhase.Assess)
+        {
+            warnings.Add(
+                $"System is in RMF step '{system.CurrentRmfStep}' (expected Assess or later). " +
+                "Import will proceed, but findings may not be visible in assessment workflows.");
+        }
+
+        // ── Step 4: Get control baseline ─────────────────────────────────
+        var baseline = await _baselineService.GetBaselineAsync(systemId, cancellationToken: ct);
+        var baselineControlIds = baseline?.ControlIds ?? new List<string>();
+        var baselineSet = new HashSet<string>(baselineControlIds, StringComparer.OrdinalIgnoreCase);
+
+        if (baseline is null)
+        {
+            warnings.Add("No control baseline found for system. " +
+                          "All NIST controls will be treated as out-of-baseline (no ControlEffectiveness records).");
+        }
+
+        // ── Step 5: Resolve/create assessment context ────────────────────
+        using var scope = _scopeFactory.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        string resolvedAssessmentId;
+        if (!string.IsNullOrEmpty(assessmentId))
+        {
+            var existing = await ctx.Assessments.FindAsync(new object[] { assessmentId }, ct);
+            if (existing is null)
+                return CreateFailedResult($"Assessment '{assessmentId}' not found.", fileName);
+            resolvedAssessmentId = assessmentId;
+        }
+        else
+        {
+            resolvedAssessmentId = await GetOrCreateAssessmentAsync(ctx, systemId, importedBy, ct);
+        }
+
+        // ── Step 6: Duplicate detection ───────────────────────────────
+        var duplicateImport = await ctx.ScanImportRecords
+            .Where(r => r.FileHash == fileHash && r.RegisteredSystemId == systemId && !r.IsDryRun)
+            .OrderByDescending(r => r.ImportedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (duplicateImport is not null)
+        {
+            warnings.Add(
+                $"File previously imported on {duplicateImport.ImportedAt:yyyy-MM-dd HH:mm} UTC " +
+                $"(import ID: {duplicateImport.Id}).");
+        }
+
+        // ── Step 7: Create ScanImportRecord ──────────────────────────────
+        var importRecord = new ScanImportRecord
+        {
+            RegisteredSystemId = systemId,
+            AssessmentId = resolvedAssessmentId,
+            ImportType = ScanImportType.Ckl,
+            FileName = fileName,
+            FileHash = fileHash,
+            FileSizeBytes = fileContent.Length,
+            BenchmarkId = parsedCkl.StigInfo.StigId,
+            BenchmarkVersion = parsedCkl.StigInfo.Version,
+            BenchmarkTitle = parsedCkl.StigInfo.Title,
+            TargetHostName = parsedCkl.Asset.HostName,
+            TargetIpAddress = parsedCkl.Asset.HostIp,
+            ScanTimestamp = null, // CKL has no scan timestamp
+            ConflictResolution = resolution,
+            IsDryRun = dryRun,
+            ImportedBy = importedBy
+        };
+
+        // ── Step 8: Process each CKL entry ───────────────────────────────
+        int openCount = 0, passCount = 0, naCount = 0, notReviewedCount = 0;
+        int findingsCreated = 0, findingsUpdated = 0, skippedCount = 0, unmatchedCount = 0;
+        var affectedNistControls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var importFindings = new List<ScanImportFinding>();
+        var newFindings = new List<ComplianceFinding>();
+        var updatedFindings = new List<ComplianceFinding>();
+
+        // Preload existing findings for conflict detection
+        var existingFindings = await ctx.Findings
+            .Where(f => f.AssessmentId == resolvedAssessmentId &&
+                        f.StigFinding &&
+                        f.StigId != null)
+            .ToListAsync(ct);
+
+        var existingByStigId = existingFindings
+            .Where(f => f.StigId is not null)
+            .GroupBy(f => f.StigId!)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in parsedCkl.Entries)
+        {
+            var importFinding = new ScanImportFinding
+            {
+                ScanImportRecordId = importRecord.Id,
+                VulnId = entry.VulnId,
+                RuleId = entry.RuleId,
+                StigVersion = entry.StigVersion,
+                RawStatus = entry.Status,
+                RawSeverity = entry.Severity,
+                FindingDetails = entry.FindingDetails,
+                Comments = entry.Comments,
+                SeverityOverride = entry.SeverityOverride,
+                SeverityJustification = entry.SeverityJustification,
+                ResolvedCciRefs = entry.CciRefs
+            };
+
+            // Count by status
+            switch (entry.Status)
+            {
+                case "Open":
+                    openCount++;
+                    break;
+                case "NotAFinding":
+                    passCount++;
+                    break;
+                case "Not_Applicable":
+                    naCount++;
+                    break;
+                case "Not_Reviewed":
+                    notReviewedCount++;
+                    break;
+            }
+
+            // ── Step 8a: Resolve STIG control (T014) ─────────────────────
+            var stigControl = await ResolveStigControlAsync(entry, ct);
+
+            if (stigControl is null)
+            {
+                importFinding.ImportAction = ImportFindingAction.Unmatched;
+                unmatchedCount++;
+                unmatchedRules.Add(new UnmatchedRuleInfo(
+                    entry.VulnId,
+                    entry.RuleId,
+                    entry.RuleTitle,
+                    entry.Severity));
+                importFindings.Add(importFinding);
+                continue;
+            }
+
+            importFinding.ResolvedStigControlId = stigControl.StigId;
+
+            // ── Step 8b: Resolve NIST controls (T015) ────────────────────
+            var nistControls = stigControl.NistControls ?? new List<string>();
+            importFinding.ResolvedNistControlIds = nistControls;
+
+            // Track out-of-baseline controls
+            var outOfBaseline = nistControls
+                .Where(c => !baselineSet.Contains(c))
+                .ToList();
+            if (outOfBaseline.Count > 0 && baseline is not null)
+            {
+                warnings.Add(
+                    $"VULN {entry.VulnId}: NIST controls [{string.Join(", ", outOfBaseline)}] " +
+                    "resolved but not in system baseline. Finding created, no effectiveness.");
+            }
+
+            // ── Step 8c: Map severity ────────────────────────────────────
+            var (findingSeverity, catSeverity) = MapSeverity(
+                entry.Severity, entry.SeverityOverride);
+            importFinding.MappedSeverity = catSeverity;
+
+            // ── Step 8d: Handle Not_Applicable — no finding ──────────────
+            if (entry.Status == "Not_Applicable")
+            {
+                importFinding.ImportAction = ImportFindingAction.NotApplicable;
+                importFindings.Add(importFinding);
+                continue;
+            }
+
+            // ── Step 8e: Map finding status ──────────────────────────────
+            var (findingStatus, findingDetails) = MapCklStatus(entry);
+
+            // ── Step 8f: Conflict detection (T025) ───────────────────────
+            var primaryControl = nistControls.FirstOrDefault() ?? string.Empty;
+            var controlFamily = ExtractControlFamily(primaryControl);
+            existingByStigId.TryGetValue(entry.VulnId, out var existingFinding);
+
+            if (existingFinding is not null)
+            {
+                // ── Step 8g: Apply conflict resolution (T026) ────────────
+                var conflictAction = ApplyConflictResolution(
+                    existingFinding, entry, findingStatus, findingSeverity,
+                    catSeverity, findingDetails, resolution, importRecord.Id);
+
+                if (conflictAction == ImportFindingAction.Skipped)
+                {
+                    importFinding.ImportAction = ImportFindingAction.Skipped;
+                    importFinding.ComplianceFindingId = existingFinding.Id;
+                    skippedCount++;
+                    importFindings.Add(importFinding);
+                    continue;
+                }
+
+                // Overwrite or Merge updated the existing finding in-place
+                importFinding.ImportAction = ImportFindingAction.Updated;
+                importFinding.ComplianceFindingId = existingFinding.Id;
+                findingsUpdated++;
+                if (!updatedFindings.Contains(existingFinding))
+                    updatedFindings.Add(existingFinding);
+            }
+            else
+            {
+                // ── Step 8h: Create new ComplianceFinding (T019) ─────────
+                var newFinding = new ComplianceFinding
+                {
+                    ControlId = primaryControl,
+                    ControlFamily = controlFamily,
+                    Title = entry.RuleTitle ?? $"STIG Finding {entry.VulnId}",
+                    Description = findingDetails,
+                    Severity = findingSeverity,
+                    Status = findingStatus,
+                    ResourceId = system.Name,
+                    ResourceType = "RegisteredSystem",
+                    RemediationGuidance = entry.Comments ?? string.Empty,
+                    Source = "CKL Import",
+                    ScanSource = ScanSourceType.Combined,
+                    StigFinding = true,
+                    StigId = entry.VulnId,
+                    CatSeverity = catSeverity,
+                    AssessmentId = resolvedAssessmentId,
+                    ImportRecordId = importRecord.Id
+                };
+
+                importFinding.ImportAction = entry.Status == "Not_Reviewed"
+                    ? ImportFindingAction.NotReviewed
+                    : ImportFindingAction.Created;
+                importFinding.ComplianceFindingId = newFinding.Id;
+
+                newFindings.Add(newFinding);
+                findingsCreated++;
+            }
+
+            // Track affected NIST controls (in-baseline only) for effectiveness
+            foreach (var nist in nistControls.Where(c => baselineSet.Contains(c)))
+            {
+                affectedNistControls.Add(nist);
+            }
+
+            importFindings.Add(importFinding);
+        }
+
+        // Log unmatched rules
+        if (unmatchedRules.Count > 0)
+        {
+            _logger.LogWarning(
+                "CKL import {FileName}: {Count} unmatched rules: {VulnIds}",
+                fileName, unmatchedRules.Count,
+                string.Join(", ", unmatchedRules.Select(u => u.VulnId)));
+            warnings.Add(
+                $"{unmatchedRules.Count} STIG rule(s) not found in curated library: " +
+                string.Join(", ", unmatchedRules.Select(u => u.VulnId)));
+        }
+
+        // ── Step 9: Create evidence (T021) ───────────────────────────────
+        var evidenceContent = JsonSerializer.Serialize(new
+        {
+            ImportType = "CKL",
+            FileName = fileName,
+            BenchmarkId = parsedCkl.StigInfo.StigId,
+            TotalEntries = parsedCkl.Entries.Count,
+            OpenCount = openCount,
+            PassCount = passCount,
+            NotApplicableCount = naCount,
+            NotReviewedCount = notReviewedCount,
+            UnmatchedCount = unmatchedCount
+        });
+
+        var evidence = new ComplianceEvidence
+        {
+            ControlId = affectedNistControls.FirstOrDefault() ?? string.Empty,
+            SubscriptionId = string.Empty,
+            EvidenceType = "StigChecklist",
+            Description = $"CKL Import: {fileName} ({parsedCkl.StigInfo.Title ?? parsedCkl.StigInfo.StigId})",
+            Content = evidenceContent,
+            CollectedAt = DateTime.UtcNow,
+            CollectedBy = importedBy,
+            AssessmentId = resolvedAssessmentId,
+            EvidenceCategory = EvidenceCategory.Configuration,
+            ContentHash = fileHash,
+            CollectionMethod = "Manual"
+        };
+
+        // ── Step 10: Upsert effectiveness (T020) ─────────────────────────
+        int effectivenessCreated = 0, effectivenessUpdated = 0;
+        if (!dryRun && affectedNistControls.Count > 0)
+        {
+            // Build aggregate status map: for each NIST control, check all current findings
+            // across ALL imports (re-evaluate aggregate state)
+            var allStigFindings = await ctx.Findings
+                .Where(f => f.AssessmentId == resolvedAssessmentId && f.StigFinding)
+                .ToListAsync(ct);
+
+            // Include newly created findings (not yet in DB)
+            var allFindings = allStigFindings.Concat(newFindings).ToList();
+
+            // Build control → findings lookup (primary control only)
+            var controlFindingMap = allFindings
+                .Where(f => !string.IsNullOrEmpty(f.ControlId))
+                .GroupBy(f => f.ControlId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var controlId in affectedNistControls)
+            {
+                controlFindingMap.TryGetValue(controlId, out var controlFindings);
+                var findingsForControl = controlFindings ?? new List<ComplianceFinding>();
+
+                // Determine aggregate effectiveness
+                var anyOpen = findingsForControl.Any(f =>
+                    f.Status == FindingStatus.Open || f.Status == FindingStatus.InProgress);
+                var determination = anyOpen
+                    ? EffectivenessDetermination.OtherThanSatisfied
+                    : EffectivenessDetermination.Satisfied;
+
+                // Find highest severity among open findings for CAT
+                CatSeverity? controlCatSeverity = null;
+                if (anyOpen)
+                {
+                    var openFindings = findingsForControl
+                        .Where(f => f.Status == FindingStatus.Open || f.Status == FindingStatus.InProgress)
+                        .Where(f => f.CatSeverity.HasValue)
+                        .Select(f => f.CatSeverity!.Value)
+                        .ToList();
+                    if (openFindings.Count > 0)
+                        controlCatSeverity = openFindings.Min(); // CatI < CatII < CatIII (lowest ordinal = highest severity)
+                }
+
+                // Check existing effectiveness record
+                var existingEffectiveness = await ctx.ControlEffectivenessRecords
+                    .Where(e => e.AssessmentId == resolvedAssessmentId &&
+                                e.RegisteredSystemId == systemId &&
+                                e.ControlId == controlId)
+                    .FirstOrDefaultAsync(ct);
+
+                if (existingEffectiveness is not null)
+                {
+                    existingEffectiveness.Determination = determination;
+                    existingEffectiveness.AssessmentMethod = "Test";
+                    existingEffectiveness.AssessorId = importedBy;
+                    existingEffectiveness.AssessedAt = DateTime.UtcNow;
+                    existingEffectiveness.CatSeverity = controlCatSeverity;
+                    if (!existingEffectiveness.EvidenceIds.Contains(evidence.Id))
+                        existingEffectiveness.EvidenceIds.Add(evidence.Id);
+                    existingEffectiveness.Notes = $"Re-evaluated via CKL import '{fileName}'";
+                    effectivenessUpdated++;
+                }
+                else
+                {
+                    var effectiveness = new ControlEffectiveness
+                    {
+                        AssessmentId = resolvedAssessmentId,
+                        RegisteredSystemId = systemId,
+                        ControlId = controlId,
+                        Determination = determination,
+                        AssessmentMethod = "Test",
+                        EvidenceIds = new List<string> { evidence.Id },
+                        AssessorId = importedBy,
+                        CatSeverity = controlCatSeverity,
+                        Notes = $"Auto-determined via CKL import '{fileName}'"
+                    };
+                    ctx.ControlEffectivenessRecords.Add(effectiveness);
+                    effectivenessCreated++;
+                }
+            }
+        }
+
+        // Out-of-baseline summary
+        var outOfBaselineControls = importFindings
+            .SelectMany(f => f.ResolvedNistControlIds)
+            .Where(c => !baselineSet.Contains(c))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (outOfBaselineControls.Count > 0)
+        {
+            _logger.LogInformation(
+                "CKL import {FileName}: {Count} NIST controls outside baseline: {Controls}",
+                fileName, outOfBaselineControls.Count, string.Join(", ", outOfBaselineControls));
+        }
+
+        // ── Step 11: Update import record counts ─────────────────────────
+        importRecord.TotalEntries = parsedCkl.Entries.Count;
+        importRecord.OpenCount = openCount;
+        importRecord.PassCount = passCount;
+        importRecord.NotApplicableCount = naCount;
+        importRecord.NotReviewedCount = notReviewedCount;
+        importRecord.SkippedCount = skippedCount;
+        importRecord.UnmatchedCount = unmatchedCount;
+        importRecord.FindingsCreated = findingsCreated;
+        importRecord.FindingsUpdated = findingsUpdated;
+        importRecord.EffectivenessRecordsCreated = effectivenessCreated;
+        importRecord.EffectivenessRecordsUpdated = effectivenessUpdated;
+        importRecord.NistControlsAffected = affectedNistControls.Count;
+        importRecord.Warnings = warnings;
+        importRecord.ImportStatus = warnings.Count > 0 || unmatchedCount > 0
+            ? ScanImportStatus.CompletedWithWarnings
+            : ScanImportStatus.Completed;
+
+        // ── Step 12: Persist (unless dry-run) (T027) ─────────────────────
+        if (!dryRun)
+        {
+            ctx.ScanImportRecords.Add(importRecord);
+            ctx.ScanImportFindings.AddRange(importFindings);
+            ctx.Findings.AddRange(newFindings);
+            ctx.Evidence.Add(evidence);
+            // Updated findings are already tracked by EF change tracker
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        sw.Stop();
+        _logger.LogInformation(
+            "CKL import completed: file={FileName}, duration={DurationMs}ms, findings={FindingsCreated}/{FindingsUpdated}, " +
+            "effectiveness={EffCreated}/{EffUpdated}, warnings={WarningCount}",
+            fileName, sw.ElapsedMilliseconds, findingsCreated, findingsUpdated,
+            effectivenessCreated, effectivenessUpdated, warnings.Count);
+
+        return new ImportResult(
+            ImportRecordId: importRecord.Id,
+            Status: importRecord.ImportStatus,
+            BenchmarkId: parsedCkl.StigInfo.StigId ?? string.Empty,
+            BenchmarkTitle: parsedCkl.StigInfo.Title,
+            TotalEntries: importRecord.TotalEntries,
+            OpenCount: openCount,
+            PassCount: passCount,
+            NotApplicableCount: naCount,
+            NotReviewedCount: notReviewedCount,
+            ErrorCount: 0,
+            SkippedCount: skippedCount,
+            UnmatchedCount: unmatchedCount,
+            FindingsCreated: findingsCreated,
+            FindingsUpdated: findingsUpdated,
+            EffectivenessRecordsCreated: effectivenessCreated,
+            EffectivenessRecordsUpdated: effectivenessUpdated,
+            NistControlsAffected: affectedNistControls.Count,
+            Warnings: warnings,
+            UnmatchedRules: unmatchedRules,
+            ErrorMessage: null);
+    }
+
+    // ─── ImportXccdfAsync (Phase 7 — T038) ───────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportXccdfAsync(
+        string systemId,
+        string? assessmentId,
+        byte[] fileContent,
+        string fileName,
+        ImportConflictResolution resolution,
+        bool dryRun,
+        string importedBy,
+        CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var warnings = new List<string>();
+        var unmatchedRules = new List<UnmatchedRuleInfo>();
+        var fileHash = ComputeSha256(fileContent);
+
+        _logger.LogInformation(
+            "XCCDF import started: file={FileName}, hash={FileHash}, system={SystemId}, type=XCCDF, resolution={Resolution}, dryRun={DryRun}",
+            fileName, fileHash, systemId, resolution, dryRun);
+
+        // ── Step 1: Parse XCCDF ──────────────────────────────────────────
+        ParsedXccdfFile parsedXccdf;
+        try
+        {
+            parsedXccdf = _xccdfParser.Parse(fileContent, fileName);
+        }
+        catch (XccdfParseException ex)
+        {
+            _logger.LogWarning(ex, "XCCDF parse failed for file {FileName}", fileName);
+            return CreateFailedResult($"XCCDF parse error: {ex.Message}", fileName);
+        }
+
+        // ── Step 2: Validate system ──────────────────────────────────────
+        var system = await _rmfService.GetSystemAsync(systemId, ct);
+        if (system is null)
+            return CreateFailedResult($"System '{systemId}' not found.", fileName);
+
+        // ── Step 3: Check RMF step ───────────────────────────────────────
+        if (system.CurrentRmfStep < RmfPhase.Assess)
+        {
+            warnings.Add(
+                $"System is in RMF step '{system.CurrentRmfStep}' (expected Assess or later). " +
+                "Import will proceed, but findings may not be visible in assessment workflows.");
+        }
+
+        // ── Step 4: Get control baseline ─────────────────────────────────
+        var baseline = await _baselineService.GetBaselineAsync(systemId, cancellationToken: ct);
+        var baselineControlIds = baseline?.ControlIds ?? new List<string>();
+        var baselineSet = new HashSet<string>(baselineControlIds, StringComparer.OrdinalIgnoreCase);
+
+        if (baseline is null)
+        {
+            warnings.Add("No control baseline found for system. " +
+                          "All NIST controls will be treated as out-of-baseline (no ControlEffectiveness records).");
+        }
+
+        // ── Step 5: Resolve/create assessment context ────────────────────
+        using var scope = _scopeFactory.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        string resolvedAssessmentId;
+        if (!string.IsNullOrEmpty(assessmentId))
+        {
+            var existing = await ctx.Assessments.FindAsync(new object[] { assessmentId }, ct);
+            if (existing is null)
+                return CreateFailedResult($"Assessment '{assessmentId}' not found.", fileName);
+            resolvedAssessmentId = assessmentId;
+        }
+        else
+        {
+            resolvedAssessmentId = await GetOrCreateAssessmentAsync(ctx, systemId, importedBy, ct);
+        }
+
+        // ── Step 6: Extract benchmark ID ──────────────────────────────
+        // Extract benchmark ID from href (e.g., "xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG")
+        var benchmarkId = ExtractBenchmarkId(parsedXccdf.BenchmarkHref);
+        var benchmarkTitle = parsedXccdf.Title;
+
+        // ── Step 7: Create ScanImportRecord ──────────────────────────────
+        var importRecord = new ScanImportRecord
+        {
+            RegisteredSystemId = systemId,
+            AssessmentId = resolvedAssessmentId,
+            ImportType = ScanImportType.Xccdf,
+            FileName = fileName,
+            FileHash = fileHash,
+            FileSizeBytes = fileContent.Length,
+            BenchmarkId = benchmarkId,
+            BenchmarkTitle = benchmarkTitle,
+            TargetHostName = parsedXccdf.Target,
+            TargetIpAddress = parsedXccdf.TargetAddress,
+            ScanTimestamp = parsedXccdf.StartTime,
+            XccdfScore = parsedXccdf.Score,
+            ConflictResolution = resolution,
+            IsDryRun = dryRun,
+            ImportedBy = importedBy
+        };
+
+        // ── Step 8: Process each XCCDF rule-result ───────────────────────
+        int openCount = 0, passCount = 0, naCount = 0, errorCount = 0;
+        int findingsCreated = 0, findingsUpdated = 0, skippedCount = 0, unmatchedCount = 0;
+        var affectedNistControls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var importFindings = new List<ScanImportFinding>();
+        var newFindings = new List<ComplianceFinding>();
+        var updatedFindings = new List<ComplianceFinding>();
+
+        // Preload existing findings for conflict detection
+        var existingFindings = await ctx.Findings
+            .Where(f => f.AssessmentId == resolvedAssessmentId && f.StigFinding && f.StigId != null)
+            .ToListAsync(ct);
+
+        var existingByStigId = existingFindings
+            .Where(f => f.StigId is not null)
+            .GroupBy(f => f.StigId!)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ruleResult in parsedXccdf.Results)
+        {
+            var importFinding = new ScanImportFinding
+            {
+                ScanImportRecordId = importRecord.Id,
+                VulnId = ruleResult.ExtractedRuleId,
+                RuleId = ruleResult.ExtractedRuleId,
+                RawStatus = ruleResult.Result,
+                RawSeverity = ruleResult.Severity
+            };
+
+            // Map XCCDF result → status/counts
+            var (xccdfStatus, xccdfDetails) = MapXccdfResult(ruleResult);
+
+            switch (ruleResult.Result)
+            {
+                case "fail":
+                    openCount++;
+                    break;
+                case "pass":
+                    passCount++;
+                    break;
+                case "notapplicable":
+                    naCount++;
+                    break;
+                case "error":
+                case "unknown":
+                case "notchecked":
+                    errorCount++;
+                    break;
+            }
+
+            // ── Step 8a: Resolve STIG control by rule ID ─────────────────
+            var stigControl = await ResolveStigControlByRuleIdAsync(ruleResult.ExtractedRuleId, ct);
+
+            if (stigControl is null)
+            {
+                importFinding.ImportAction = ImportFindingAction.Unmatched;
+                unmatchedCount++;
+                unmatchedRules.Add(new UnmatchedRuleInfo(
+                    ruleResult.RuleIdRef,
+                    ruleResult.ExtractedRuleId,
+                    null,
+                    ruleResult.Severity));
+                importFindings.Add(importFinding);
+                continue;
+            }
+
+            importFinding.ResolvedStigControlId = stigControl.StigId;
+
+            // ── Step 8b: Resolve NIST controls ───────────────────────────
+            var nistControls = stigControl.NistControls ?? new List<string>();
+            importFinding.ResolvedNistControlIds = nistControls;
+
+            // ── Step 8c: Map severity ────────────────────────────────────
+            var (findingSeverity, catSeverity) = MapSeverity(ruleResult.Severity, null);
+            importFinding.MappedSeverity = catSeverity;
+
+            // ── Step 8d: Handle notapplicable ────────────────────────────
+            if (ruleResult.Result == "notapplicable")
+            {
+                importFinding.ImportAction = ImportFindingAction.NotApplicable;
+                importFindings.Add(importFinding);
+                continue;
+            }
+
+            // ── Step 8e: Handle error/unknown/notchecked → flag for review ──
+            if (ruleResult.Result is "error" or "unknown" or "notchecked")
+            {
+                importFinding.ImportAction = ImportFindingAction.Error;
+                importFinding.FindingDetails = xccdfDetails;
+                importFindings.Add(importFinding);
+                warnings.Add($"Rule {ruleResult.ExtractedRuleId}: XCCDF result '{ruleResult.Result}' flagged for manual review.");
+                continue;
+            }
+
+            // ── Step 8f: Conflict detection ──────────────────────────────
+            var primaryControl = nistControls.FirstOrDefault() ?? string.Empty;
+            var controlFamily = ExtractControlFamily(primaryControl);
+            var vulnId = stigControl.VulnId ?? ruleResult.ExtractedRuleId;
+            existingByStigId.TryGetValue(vulnId, out var existingFinding);
+
+            // Build a pseudo CKL entry for conflict resolution reuse
+            var pseudoEntry = new ParsedCklEntry(
+                VulnId: vulnId,
+                RuleId: ruleResult.ExtractedRuleId,
+                StigVersion: null,
+                RuleTitle: null,
+                Severity: ruleResult.Severity,
+                Status: ruleResult.Result == "fail" ? "Open" : "NotAFinding",
+                FindingDetails: xccdfDetails,
+                Comments: ruleResult.Message,
+                SeverityOverride: null,
+                SeverityJustification: null,
+                CciRefs: new List<string>(),
+                GroupTitle: null);
+
+            if (existingFinding is not null)
+            {
+                var conflictAction = ApplyConflictResolution(
+                    existingFinding, pseudoEntry, xccdfStatus, findingSeverity,
+                    catSeverity, xccdfDetails, resolution, importRecord.Id);
+
+                if (conflictAction == ImportFindingAction.Skipped)
+                {
+                    importFinding.ImportAction = ImportFindingAction.Skipped;
+                    importFinding.ComplianceFindingId = existingFinding.Id;
+                    skippedCount++;
+                    importFindings.Add(importFinding);
+                    continue;
+                }
+
+                importFinding.ImportAction = ImportFindingAction.Updated;
+                importFinding.ComplianceFindingId = existingFinding.Id;
+                findingsUpdated++;
+                if (!updatedFindings.Contains(existingFinding))
+                    updatedFindings.Add(existingFinding);
+            }
+            else
+            {
+                // ── Step 8g: Create new ComplianceFinding ────────────────
+                var newFinding = new ComplianceFinding
+                {
+                    ControlId = primaryControl,
+                    ControlFamily = controlFamily,
+                    Title = $"STIG Finding {vulnId}",
+                    Description = xccdfDetails,
+                    Severity = findingSeverity,
+                    Status = xccdfStatus,
+                    ResourceId = system.Name,
+                    ResourceType = "RegisteredSystem",
+                    RemediationGuidance = ruleResult.Message ?? string.Empty,
+                    Source = "XCCDF Import",
+                    ScanSource = ScanSourceType.Combined,
+                    StigFinding = true,
+                    StigId = vulnId,
+                    CatSeverity = catSeverity,
+                    AssessmentId = resolvedAssessmentId,
+                    ImportRecordId = importRecord.Id
+                };
+
+                importFinding.ImportAction = ImportFindingAction.Created;
+                importFinding.ComplianceFindingId = newFinding.Id;
+                newFindings.Add(newFinding);
+                findingsCreated++;
+            }
+
+            // Track affected NIST controls
+            foreach (var nist in nistControls.Where(c => baselineSet.Contains(c)))
+                affectedNistControls.Add(nist);
+
+            importFindings.Add(importFinding);
+        }
+
+        // Log unmatched rules
+        if (unmatchedRules.Count > 0)
+        {
+            _logger.LogWarning(
+                "XCCDF import {FileName}: {Count} unmatched rules: {RuleIds}",
+                fileName, unmatchedRules.Count,
+                string.Join(", ", unmatchedRules.Select(u => u.RuleId ?? u.VulnId)));
+            warnings.Add(
+                $"{unmatchedRules.Count} XCCDF rule(s) not found in curated library.");
+        }
+
+        // ── Step 9: Create evidence ──────────────────────────────────────
+        var evidenceContent = JsonSerializer.Serialize(new
+        {
+            ImportType = "XCCDF",
+            FileName = fileName,
+            BenchmarkId = benchmarkId,
+            TotalEntries = parsedXccdf.Results.Count,
+            Score = parsedXccdf.Score,
+            MaxScore = parsedXccdf.MaxScore,
+            OpenCount = openCount,
+            PassCount = passCount,
+            NotApplicableCount = naCount,
+            ErrorCount = errorCount,
+            UnmatchedCount = unmatchedCount
+        });
+
+        var evidence = new ComplianceEvidence
+        {
+            ControlId = affectedNistControls.FirstOrDefault() ?? string.Empty,
+            SubscriptionId = string.Empty,
+            EvidenceType = "XccdfScanResult",
+            Description = $"XCCDF Import: {fileName} ({benchmarkTitle ?? benchmarkId})",
+            Content = evidenceContent,
+            CollectedAt = DateTime.UtcNow,
+            CollectedBy = importedBy,
+            AssessmentId = resolvedAssessmentId,
+            EvidenceCategory = EvidenceCategory.Configuration,
+            ContentHash = fileHash,
+            CollectionMethod = "Automated" // XCCDF = machine-verified
+        };
+
+        // ── Step 10: Upsert effectiveness ────────────────────────────────
+        int effectivenessCreated = 0, effectivenessUpdated = 0;
+        if (!dryRun && affectedNistControls.Count > 0)
+        {
+            var allStigFindings = await ctx.Findings
+                .Where(f => f.AssessmentId == resolvedAssessmentId && f.StigFinding)
+                .ToListAsync(ct);
+
+            var allFindings = allStigFindings.Concat(newFindings).ToList();
+
+            var controlFindingMap = allFindings
+                .Where(f => !string.IsNullOrEmpty(f.ControlId))
+                .GroupBy(f => f.ControlId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var controlId in affectedNistControls)
+            {
+                controlFindingMap.TryGetValue(controlId, out var controlFindings);
+                var findingsForControl = controlFindings ?? new List<ComplianceFinding>();
+
+                var anyOpen = findingsForControl.Any(f =>
+                    f.Status == FindingStatus.Open || f.Status == FindingStatus.InProgress);
+                var determination = anyOpen
+                    ? EffectivenessDetermination.OtherThanSatisfied
+                    : EffectivenessDetermination.Satisfied;
+
+                CatSeverity? controlCatSeverity = null;
+                if (anyOpen)
+                {
+                    var openCats = findingsForControl
+                        .Where(f => f.Status == FindingStatus.Open || f.Status == FindingStatus.InProgress)
+                        .Where(f => f.CatSeverity.HasValue)
+                        .Select(f => f.CatSeverity!.Value)
+                        .ToList();
+                    if (openCats.Count > 0)
+                        controlCatSeverity = openCats.Min();
+                }
+
+                var existingEffectiveness = await ctx.ControlEffectivenessRecords
+                    .Where(e => e.AssessmentId == resolvedAssessmentId &&
+                                e.RegisteredSystemId == systemId &&
+                                e.ControlId == controlId)
+                    .FirstOrDefaultAsync(ct);
+
+                if (existingEffectiveness is not null)
+                {
+                    existingEffectiveness.Determination = determination;
+                    existingEffectiveness.AssessmentMethod = "Test";
+                    existingEffectiveness.AssessorId = importedBy;
+                    existingEffectiveness.AssessedAt = DateTime.UtcNow;
+                    existingEffectiveness.CatSeverity = controlCatSeverity;
+                    if (!existingEffectiveness.EvidenceIds.Contains(evidence.Id))
+                        existingEffectiveness.EvidenceIds.Add(evidence.Id);
+                    existingEffectiveness.Notes = $"Re-evaluated via XCCDF import '{fileName}'";
+                    effectivenessUpdated++;
+                }
+                else
+                {
+                    var effectiveness = new ControlEffectiveness
+                    {
+                        AssessmentId = resolvedAssessmentId,
+                        RegisteredSystemId = systemId,
+                        ControlId = controlId,
+                        Determination = determination,
+                        AssessmentMethod = "Test",
+                        EvidenceIds = new List<string> { evidence.Id },
+                        AssessorId = importedBy,
+                        CatSeverity = controlCatSeverity,
+                        Notes = $"Auto-determined via XCCDF import '{fileName}'"
+                    };
+                    ctx.ControlEffectivenessRecords.Add(effectiveness);
+                    effectivenessCreated++;
+                }
+            }
+        }
+
+        // ── Step 11: Update import record ────────────────────────────────
+        importRecord.TotalEntries = parsedXccdf.Results.Count;
+        importRecord.OpenCount = openCount;
+        importRecord.PassCount = passCount;
+        importRecord.NotApplicableCount = naCount;
+        importRecord.ErrorCount = errorCount;
+        importRecord.SkippedCount = skippedCount;
+        importRecord.UnmatchedCount = unmatchedCount;
+        importRecord.FindingsCreated = findingsCreated;
+        importRecord.FindingsUpdated = findingsUpdated;
+        importRecord.EffectivenessRecordsCreated = effectivenessCreated;
+        importRecord.EffectivenessRecordsUpdated = effectivenessUpdated;
+        importRecord.NistControlsAffected = affectedNistControls.Count;
+        importRecord.Warnings = warnings;
+        importRecord.ImportStatus = warnings.Count > 0 || unmatchedCount > 0
+            ? ScanImportStatus.CompletedWithWarnings
+            : ScanImportStatus.Completed;
+
+        // ── Step 12: Persist (unless dry-run) ────────────────────────────
+        if (!dryRun)
+        {
+            ctx.ScanImportRecords.Add(importRecord);
+            ctx.ScanImportFindings.AddRange(importFindings);
+            ctx.Findings.AddRange(newFindings);
+            ctx.Evidence.Add(evidence);
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        sw.Stop();
+        _logger.LogInformation(
+            "XCCDF import completed: file={FileName}, duration={DurationMs}ms, findings={FindingsCreated}/{FindingsUpdated}, " +
+            "effectiveness={EffCreated}/{EffUpdated}, score={Score}, warnings={WarningCount}",
+            fileName, sw.ElapsedMilliseconds, findingsCreated, findingsUpdated,
+            effectivenessCreated, effectivenessUpdated, parsedXccdf.Score, warnings.Count);
+
+        return new ImportResult(
+            ImportRecordId: importRecord.Id,
+            Status: importRecord.ImportStatus,
+            BenchmarkId: benchmarkId ?? string.Empty,
+            BenchmarkTitle: benchmarkTitle,
+            TotalEntries: importRecord.TotalEntries,
+            OpenCount: openCount,
+            PassCount: passCount,
+            NotApplicableCount: naCount,
+            NotReviewedCount: 0, // XCCDF has no "not reviewed" state
+            ErrorCount: errorCount,
+            SkippedCount: skippedCount,
+            UnmatchedCount: unmatchedCount,
+            FindingsCreated: findingsCreated,
+            FindingsUpdated: findingsUpdated,
+            EffectivenessRecordsCreated: effectivenessCreated,
+            EffectivenessRecordsUpdated: effectivenessUpdated,
+            NistControlsAffected: affectedNistControls.Count,
+            Warnings: warnings,
+            UnmatchedRules: unmatchedRules,
+            ErrorMessage: null);
+    }
+
+    // ─── ExportCklAsync (Phase 8 — T044) ─────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<string> ExportCklAsync(
+        string systemId,
+        string benchmarkId,
+        string? assessmentId,
+        CancellationToken ct = default)
+    {
+        // ── Step 1: Validate system ──────────────────────────────────────
+        var system = await _rmfService.GetSystemAsync(systemId, ct);
+        if (system is null)
+            throw new InvalidOperationException($"System '{systemId}' not found.");
+
+        // ── Step 2: Get all STIG controls for benchmark ──────────────────
+        var stigControls = await _stigService.GetStigControlsByBenchmarkAsync(benchmarkId, ct);
+        if (stigControls.Count == 0)
+            throw new InvalidOperationException(
+                $"No STIG controls found for benchmark '{benchmarkId}'. " +
+                "Verify the benchmark ID matches the curated STIG library.");
+
+        // ── Step 3: Query findings for the system/assessment ─────────────
+        using var scope = _scopeFactory.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        IQueryable<ComplianceFinding> findingsQuery = ctx.Findings
+            .Where(f => f.StigFinding && f.StigId != null);
+
+        if (!string.IsNullOrEmpty(assessmentId))
+        {
+            findingsQuery = findingsQuery.Where(f => f.AssessmentId == assessmentId);
+        }
+        else
+        {
+            // Find the latest assessment for the system
+            var latestAssessment = await ctx.Assessments
+                .Where(a => a.RegisteredSystemId == systemId)
+                .OrderByDescending(a => a.AssessedAt)
+                .FirstOrDefaultAsync(ct);
+
+            if (latestAssessment is not null)
+            {
+                findingsQuery = findingsQuery.Where(f => f.AssessmentId == latestAssessment.Id);
+            }
+        }
+
+        var findingsList = await findingsQuery.ToListAsync(ct);
+
+        // Build lookup dictionary by StigId (VulnId)
+        var findingsDict = findingsList
+            .Where(f => f.StigId is not null)
+            .GroupBy(f => f.StigId!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        // ── Step 4: Determine benchmark metadata ─────────────────────────
+        var firstControl = stigControls.First();
+        var benchmarkTitle = firstControl.StigFamily is not null
+            ? $"{firstControl.StigFamily} Security Technical Implementation Guide"
+            : benchmarkId;
+        var benchmarkVersion = "1"; // Default; StigControl doesn't carry benchmark version
+
+        // ── Step 5: Generate CKL XML ─────────────────────────────────────
+        var cklXml = _cklGenerator.Generate(
+            system, stigControls, findingsDict,
+            benchmarkId, benchmarkVersion, benchmarkTitle);
+
+        // ── Step 6: Return base64 ────────────────────────────────────────
+        var xmlBytes = System.Text.Encoding.UTF8.GetBytes(cklXml);
+        var base64 = Convert.ToBase64String(xmlBytes);
+
+        _logger.LogInformation(
+            "CKL export completed: system={SystemId}, benchmark={BenchmarkId}, " +
+            "vulnCount={VulnCount}, findingsPresent={FindingsPresent}",
+            systemId, benchmarkId, stigControls.Count, findingsDict.Count);
+
+        return base64;
+    }
+
+    // ─── ListImportsAsync (Phase 9 — T048) ──────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<(List<ScanImportRecord> Records, int TotalCount)> ListImportsAsync(
+        string systemId,
+        int page,
+        int pageSize,
+        string? benchmarkId,
+        string? importType,
+        bool includeDryRuns,
+        DateTime? fromDate,
+        DateTime? toDate,
+        CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var query = ctx.ScanImportRecords
+            .Where(r => r.RegisteredSystemId == systemId);
+
+        if (!includeDryRuns)
+            query = query.Where(r => !r.IsDryRun);
+
+        if (!string.IsNullOrEmpty(benchmarkId))
+            query = query.Where(r => r.BenchmarkId == benchmarkId);
+
+        if (!string.IsNullOrEmpty(importType) &&
+            Enum.TryParse<ScanImportType>(importType, true, out var typeFilter))
+            query = query.Where(r => r.ImportType == typeFilter);
+
+        if (fromDate.HasValue)
+            query = query.Where(r => r.ImportedAt >= fromDate.Value);
+
+        if (toDate.HasValue)
+            query = query.Where(r => r.ImportedAt <= toDate.Value);
+
+        var totalCount = await query.CountAsync(ct);
+
+        pageSize = Math.Clamp(pageSize, 1, 100);
+        page = Math.Max(1, page);
+
+        var records = await query
+            .OrderByDescending(r => r.ImportedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (records, totalCount);
+    }
+
+    // ─── GetImportSummaryAsync (Phase 9 — T049) ─────────────────────────
+
+    /// <inheritdoc />
+    public async Task<(ScanImportRecord Record, List<ScanImportFinding> Findings)?> GetImportSummaryAsync(
+        string importId,
+        CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var record = await ctx.ScanImportRecords.FindAsync(new object[] { importId }, ct);
+        if (record is null)
+            return null;
+
+        var findings = await ctx.ScanImportFindings
+            .Where(f => f.ScanImportRecordId == importId)
+            .ToListAsync(ct);
+
+        return (record, findings);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Private helpers
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ─── STIG Resolution (T014) ──────────────────────────────────────────
+
+    /// <summary>
+    /// Resolve a parsed CKL entry to a StigControl record.
+    /// Tries: VulnId → RuleId → StigVersion (fallback chain).
+    /// </summary>
+    private async Task<StigControl?> ResolveStigControlAsync(
+        ParsedCklEntry entry,
+        CancellationToken ct)
+    {
+        // Primary: VulnId (e.g., "V-254239")
+        var control = await _stigService.GetStigControlAsync(entry.VulnId, ct);
+        if (control is not null)
+            return control;
+
+        // Fallback: RuleId (e.g., "SV-254239r849090_rule")
+        if (!string.IsNullOrEmpty(entry.RuleId))
+        {
+            control = await _stigService.GetStigControlByRuleIdAsync(entry.RuleId, ct);
+            if (control is not null)
+                return control;
+        }
+
+        // Fallback: StigVersion as StigId (e.g., "WN22-AU-000010")
+        if (!string.IsNullOrEmpty(entry.StigVersion))
+        {
+            control = await _stigService.GetStigControlAsync(entry.StigVersion, ct);
+            if (control is not null)
+                return control;
+        }
+
+        return null;
+    }
+
+    // ─── Severity Mapping ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Map CKL severity string → FindingSeverity + CatSeverity.
+    /// Applies severity override if present.
+    /// </summary>
+    private static (FindingSeverity Severity, CatSeverity? Cat) MapSeverity(
+        string rawSeverity,
+        string? severityOverride)
+    {
+        var effective = !string.IsNullOrWhiteSpace(severityOverride)
+            ? severityOverride
+            : rawSeverity;
+
+        return effective.ToLowerInvariant() switch
+        {
+            "high" => (FindingSeverity.High, CatSeverity.CatI),
+            "medium" => (FindingSeverity.Medium, CatSeverity.CatII),
+            "low" => (FindingSeverity.Low, CatSeverity.CatIII),
+            _ => (FindingSeverity.Medium, CatSeverity.CatII) // default to medium
+        };
+    }
+
+    // ─── CKL Status Mapping (T019) ──────────────────────────────────────
+
+    /// <summary>
+    /// Map CKL STATUS to FindingStatus and finding details text.
+    /// </summary>
+    private static (FindingStatus Status, string Details) MapCklStatus(ParsedCklEntry entry)
+    {
+        return entry.Status switch
+        {
+            "Open" => (FindingStatus.Open,
+                entry.FindingDetails ?? $"Open finding from STIG rule {entry.VulnId}"),
+
+            "NotAFinding" => (FindingStatus.Remediated,
+                entry.FindingDetails ?? $"Verified compliant for STIG rule {entry.VulnId}"),
+
+            "Not_Reviewed" => (FindingStatus.Open,
+                !string.IsNullOrEmpty(entry.FindingDetails)
+                    ? $"Not yet reviewed. {entry.FindingDetails}"
+                    : $"Not yet reviewed — STIG rule {entry.VulnId} has not been evaluated."),
+
+            _ => (FindingStatus.Open,
+                entry.FindingDetails ?? $"Unknown status '{entry.Status}' for STIG rule {entry.VulnId}")
+        };
+    }
+
+    // ─── XCCDF Result Mapping (T038) ────────────────────────────────────
+
+    /// <summary>
+    /// Map XCCDF result string → FindingStatus and finding details text.
+    /// </summary>
+    private static (FindingStatus Status, string Details) MapXccdfResult(ParsedXccdfResult ruleResult)
+    {
+        return ruleResult.Result switch
+        {
+            "fail" => (FindingStatus.Open,
+                ruleResult.Message ?? $"XCCDF scan failure for rule {ruleResult.ExtractedRuleId}"),
+
+            "pass" => (FindingStatus.Remediated,
+                ruleResult.Message ?? $"XCCDF scan passed for rule {ruleResult.ExtractedRuleId}"),
+
+            "error" => (FindingStatus.Open,
+                $"XCCDF scan error for rule {ruleResult.ExtractedRuleId}: {ruleResult.Message ?? "check failed with error"}"),
+
+            "notchecked" => (FindingStatus.Open,
+                $"XCCDF rule {ruleResult.ExtractedRuleId} was not checked."),
+
+            "unknown" => (FindingStatus.Open,
+                $"XCCDF result unknown for rule {ruleResult.ExtractedRuleId}."),
+
+            _ => (FindingStatus.Open,
+                ruleResult.Message ?? $"Unrecognized XCCDF result '{ruleResult.Result}' for rule {ruleResult.ExtractedRuleId}")
+        };
+    }
+
+    /// <summary>
+    /// Extract benchmark ID from XCCDF benchmark href.
+    /// E.g., "xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG" → "Windows_Server_2022_STIG"
+    /// </summary>
+    private static string? ExtractBenchmarkId(string? href)
+    {
+        if (string.IsNullOrEmpty(href)) return null;
+
+        const string prefix = "xccdf_mil.disa.stig_benchmark_";
+        if (href.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return href[prefix.Length..];
+
+        return href;
+    }
+
+    /// <summary>
+    /// Resolve a STIG control using the XCCDF extracted rule ID.
+    /// Tries: RuleId → VulnId (derived from rule ID) fallback chain.
+    /// </summary>
+    private async Task<StigControl?> ResolveStigControlByRuleIdAsync(
+        string extractedRuleId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(extractedRuleId)) return null;
+
+        // Primary: RuleId lookup
+        var control = await _stigService.GetStigControlByRuleIdAsync(extractedRuleId, ct);
+        if (control is not null) return control;
+
+        // Fallback: try as VulnId (extract V-XXXXXX from SV-XXXXXX)
+        if (extractedRuleId.StartsWith("SV-", StringComparison.OrdinalIgnoreCase))
+        {
+            var vulnPart = extractedRuleId[1..]; // Remove "S" → "V-XXXXXX..."
+            var dashIdx = vulnPart.IndexOf('r');
+            var vulnId = dashIdx > 0 ? vulnPart[..dashIdx] : vulnPart;
+            control = await _stigService.GetStigControlAsync(vulnId, ct);
+            if (control is not null) return control;
+        }
+
+        // Direct lookup as-is
+        return await _stigService.GetStigControlAsync(extractedRuleId, ct);
+    }
+
+    // ─── Conflict Resolution (T025–T026) ─────────────────────────────────
+
+    /// <summary>
+    /// Apply conflict resolution strategy to an existing finding.
+    /// Returns the action taken: Skipped or Updated.
+    /// For Overwrite/Merge, modifies the existing finding in-place.
+    /// </summary>
+    private static ImportFindingAction ApplyConflictResolution(
+        ComplianceFinding existing,
+        ParsedCklEntry entry,
+        FindingStatus importedStatus,
+        FindingSeverity importedSeverity,
+        CatSeverity? importedCat,
+        string importedDetails,
+        ImportConflictResolution resolution,
+        string importRecordId)
+    {
+        switch (resolution)
+        {
+            case ImportConflictResolution.Skip:
+                return ImportFindingAction.Skipped;
+
+            case ImportConflictResolution.Overwrite:
+                existing.Status = importedStatus;
+                existing.Severity = importedSeverity;
+                existing.CatSeverity = importedCat;
+                existing.Description = importedDetails;
+                existing.RemediationGuidance = entry.Comments ?? existing.RemediationGuidance;
+                existing.ImportRecordId = importRecordId;
+                existing.Title = entry.RuleTitle ?? existing.Title;
+                return ImportFindingAction.Updated;
+
+            case ImportConflictResolution.Merge:
+                // Keep more-recent status (Open takes precedence for safety)
+                if (importedStatus == FindingStatus.Open && existing.Status != FindingStatus.Open)
+                    existing.Status = importedStatus;
+                else if (importedStatus == FindingStatus.Remediated && existing.Status == FindingStatus.Open)
+                {
+                    // If imported says remediated but existing is open, keep open (more conservative)
+                    // unless existing was already remediated
+                }
+                else if (existing.Status == FindingStatus.Remediated && importedStatus == FindingStatus.Remediated)
+                {
+                    // Both say remediated — keep as-is
+                }
+
+                // Use imported severity only if higher (CatI > CatII > CatIII)
+                if (importedCat.HasValue && existing.CatSeverity.HasValue)
+                {
+                    if (importedCat.Value < existing.CatSeverity.Value) // lower enum = higher severity
+                    {
+                        existing.Severity = importedSeverity;
+                        existing.CatSeverity = importedCat;
+                    }
+                }
+                else if (importedCat.HasValue && !existing.CatSeverity.HasValue)
+                {
+                    existing.Severity = importedSeverity;
+                    existing.CatSeverity = importedCat;
+                }
+
+                // Append finding details if different
+                if (!string.IsNullOrEmpty(importedDetails) &&
+                    !existing.Description.Contains(importedDetails, StringComparison.OrdinalIgnoreCase))
+                {
+                    existing.Description = string.IsNullOrEmpty(existing.Description)
+                        ? importedDetails
+                        : $"{existing.Description}\n\n[Merged from import]: {importedDetails}";
+                }
+
+                existing.ImportRecordId = importRecordId;
+                return ImportFindingAction.Updated;
+
+            default:
+                return ImportFindingAction.Skipped;
+        }
+    }
+
+    // ─── Assessment Context ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Get an existing active assessment for the system, or create one.
+    /// </summary>
+    private static async Task<string> GetOrCreateAssessmentAsync(
+        AtoCopilotContext ctx,
+        string systemId,
+        string importedBy,
+        CancellationToken ct)
+    {
+        // Try to find an active (non-completed, non-cancelled) assessment for this system
+        var existing = await ctx.Assessments
+            .Where(a => a.RegisteredSystemId == systemId &&
+                        a.Status != AssessmentStatus.Completed &&
+                        a.Status != AssessmentStatus.Cancelled &&
+                        a.Status != AssessmentStatus.Failed)
+            .OrderByDescending(a => a.AssessedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (existing is not null)
+            return existing.Id;
+
+        // Create a new assessment for STIG/SCAP import
+        var assessment = new ComplianceAssessment
+        {
+            RegisteredSystemId = systemId,
+            Framework = "NIST80053",
+            ScanType = "combined",
+            Status = AssessmentStatus.InProgress,
+            InitiatedBy = importedBy,
+            ProgressMessage = "Created for STIG/SCAP import"
+        };
+
+        ctx.Assessments.Add(assessment);
+        await ctx.SaveChangesAsync(ct);
+
+        return assessment.Id;
+    }
+
+    // ─── Utilities ───────────────────────────────────────────────────────
+
+    /// <summary>Compute SHA-256 hash of raw bytes, returned as lowercase hex.</summary>
+    internal static string ComputeSha256(byte[] data)
+    {
+        var hashBytes = SHA256.HashData(data);
+        return Convert.ToHexStringLower(hashBytes);
+    }
+
+    /// <summary>Extract control family prefix (e.g., "AC" from "AC-2").</summary>
+    private static string ExtractControlFamily(string controlId)
+    {
+        if (string.IsNullOrEmpty(controlId))
+            return string.Empty;
+        var dashIndex = controlId.IndexOf('-');
+        return dashIndex > 0 ? controlId[..dashIndex] : controlId;
+    }
+
+    /// <summary>Create a failed ImportResult with error message.</summary>
+    private static ImportResult CreateFailedResult(string error, string fileName)
+    {
+        return new ImportResult(
+            ImportRecordId: string.Empty,
+            Status: ScanImportStatus.Failed,
+            BenchmarkId: string.Empty,
+            BenchmarkTitle: null,
+            TotalEntries: 0,
+            OpenCount: 0,
+            PassCount: 0,
+            NotApplicableCount: 0,
+            NotReviewedCount: 0,
+            ErrorCount: 0,
+            SkippedCount: 0,
+            UnmatchedCount: 0,
+            FindingsCreated: 0,
+            FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 0,
+            EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 0,
+            Warnings: new List<string>(),
+            UnmatchedRules: new List<UnmatchedRuleInfo>(),
+            ErrorMessage: error);
+    }
+}

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/XccdfParser.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/XccdfParser.cs
@@ -1,0 +1,267 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Import: XCCDF Parser
+// Parses SCAP Compliance Checker XCCDF TestResult XML files.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Globalization;
+using System.Xml.Linq;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Agents.Compliance.Services.ScanImport;
+
+/// <summary>
+/// Parses XCCDF (Extensible Configuration Checklist Description Format) results XML.
+/// Supports both XCCDF 1.1 and 1.2 namespace variations.
+/// </summary>
+public interface IXccdfParser
+{
+    /// <summary>
+    /// Parse XCCDF TestResult XML bytes into a <see cref="ParsedXccdfFile"/>.
+    /// </summary>
+    /// <param name="content">Raw XML bytes.</param>
+    /// <param name="fileName">Original file name (for error messages).</param>
+    /// <returns>Parsed XCCDF file with all rule-results.</returns>
+    /// <exception cref="XccdfParseException">File is not valid XCCDF XML.</exception>
+    ParsedXccdfFile Parse(byte[] content, string fileName);
+}
+
+/// <summary>
+/// Exception thrown when XCCDF parsing fails.
+/// </summary>
+public class XccdfParseException : Exception
+{
+    public string FileName { get; }
+
+    public XccdfParseException(string fileName, string message)
+        : base($"XCCDF parse error in '{fileName}': {message}")
+    {
+        FileName = fileName;
+    }
+
+    public XccdfParseException(string fileName, string message, Exception inner)
+        : base($"XCCDF parse error in '{fileName}': {message}", inner)
+    {
+        FileName = fileName;
+    }
+}
+
+/// <summary>
+/// Implementation of <see cref="IXccdfParser"/>. Uses namespace-aware XDocument parsing
+/// to support XCCDF 1.1 (<c>http://checklists.nist.gov/xccdf/1.1</c>) and
+/// XCCDF 1.2 (<c>http://checklists.nist.gov/xccdf/1.2</c>).
+/// </summary>
+public class XccdfParser : IXccdfParser
+{
+    // XCCDF namespace URIs
+    private static readonly XNamespace Ns12 = "http://checklists.nist.gov/xccdf/1.2";
+    private static readonly XNamespace Ns11 = "http://checklists.nist.gov/xccdf/1.1";
+
+    private readonly ILogger<XccdfParser> _logger;
+
+    public XccdfParser(ILogger<XccdfParser> logger)
+    {
+        _logger = logger;
+    }
+
+    public ParsedXccdfFile Parse(byte[] content, string fileName)
+    {
+        if (content is null || content.Length == 0)
+            throw new XccdfParseException(fileName, "File is empty.");
+
+        XDocument doc;
+        try
+        {
+            using var stream = new MemoryStream(content);
+            doc = XDocument.Load(stream);
+        }
+        catch (Exception ex)
+        {
+            throw new XccdfParseException(fileName, $"Invalid XML: {ex.Message}", ex);
+        }
+
+        var root = doc.Root
+            ?? throw new XccdfParseException(fileName, "XML document has no root element.");
+
+        // Detect XCCDF namespace
+        var ns = DetectNamespace(root, fileName);
+
+        // The root might be <TestResult> directly or <Benchmark> containing <TestResult>
+        var testResult = FindTestResult(root, ns, fileName);
+
+        // Parse benchmark info
+        var benchmarkHref = ParseBenchmarkHref(testResult, ns);
+        var title = testResult.Element(ns + "title")?.Value;
+
+        // Parse target info
+        var target = testResult.Element(ns + "target")?.Value;
+        var targetAddress = testResult.Element(ns + "target-address")?.Value;
+
+        // Parse timestamps
+        var startTime = ParseTimestamp(testResult.Attribute("start-time")?.Value);
+        var endTime = ParseTimestamp(testResult.Attribute("end-time")?.Value);
+
+        // Parse target facts
+        var targetFacts = ParseTargetFacts(testResult, ns);
+
+        // Parse score
+        var (score, maxScore) = ParseScore(testResult, ns);
+
+        // Parse rule results
+        var results = ParseRuleResults(testResult, ns, fileName);
+
+        _logger.LogInformation(
+            "Parsed XCCDF file '{FileName}': {ResultCount} rule-results, target={Target}, score={Score}/{MaxScore}",
+            fileName, results.Count, target ?? "(unknown)", score, maxScore);
+
+        return new ParsedXccdfFile(
+            BenchmarkHref: benchmarkHref,
+            Title: title,
+            Target: target,
+            TargetAddress: targetAddress,
+            StartTime: startTime,
+            EndTime: endTime,
+            Score: score,
+            MaxScore: maxScore,
+            TargetFacts: targetFacts,
+            Results: results);
+    }
+
+    private XNamespace DetectNamespace(XElement root, string fileName)
+    {
+        var rootNs = root.Name.Namespace;
+
+        if (rootNs == Ns12) return Ns12;
+        if (rootNs == Ns11) return Ns11;
+
+        // Try to infer from child elements
+        if (root.Descendants(Ns12 + "TestResult").Any()) return Ns12;
+        if (root.Descendants(Ns11 + "TestResult").Any()) return Ns11;
+
+        // Fallback: no namespace (some tools emit XCCDF without namespace)
+        if (root.Name.LocalName == "TestResult" || root.Name.LocalName == "Benchmark")
+            return XNamespace.None;
+
+        throw new XccdfParseException(fileName,
+            $"Could not detect XCCDF namespace. Root element: <{root.Name}>. " +
+            "Expected XCCDF 1.1 or 1.2 namespace.");
+    }
+
+    private XElement FindTestResult(XElement root, XNamespace ns, string fileName)
+    {
+        // Direct TestResult root
+        if (root.Name.LocalName == "TestResult")
+            return root;
+
+        // TestResult inside Benchmark
+        var testResult = root.Element(ns + "TestResult")
+            ?? root.Descendants(ns + "TestResult").FirstOrDefault();
+
+        return testResult
+            ?? throw new XccdfParseException(fileName,
+                "No <TestResult> element found in XCCDF XML.");
+    }
+
+    private string? ParseBenchmarkHref(XElement testResult, XNamespace ns)
+    {
+        var benchmark = testResult.Element(ns + "benchmark");
+        return benchmark?.Attribute("href")?.Value;
+    }
+
+    private Dictionary<string, string> ParseTargetFacts(XElement testResult, XNamespace ns)
+    {
+        var facts = new Dictionary<string, string>();
+        var factsEl = testResult.Element(ns + "target-facts");
+        if (factsEl is null) return facts;
+
+        foreach (var fact in factsEl.Elements(ns + "fact"))
+        {
+            var name = fact.Attribute("name")?.Value;
+            var value = fact.Value;
+            if (!string.IsNullOrEmpty(name))
+                facts[name] = value;
+        }
+
+        return facts;
+    }
+
+    private (decimal? Score, decimal? MaxScore) ParseScore(XElement testResult, XNamespace ns)
+    {
+        var scoreEl = testResult.Element(ns + "score");
+        if (scoreEl is null) return (null, null);
+
+        decimal? score = decimal.TryParse(scoreEl.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var s)
+            ? s : null;
+        decimal? maxScore = decimal.TryParse(scoreEl.Attribute("maximum")?.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var m)
+            ? m : null;
+
+        return (score, maxScore);
+    }
+
+    private List<ParsedXccdfResult> ParseRuleResults(XElement testResult, XNamespace ns, string fileName)
+    {
+        var results = new List<ParsedXccdfResult>();
+
+        foreach (var rr in testResult.Elements(ns + "rule-result"))
+        {
+            var idref = rr.Attribute("idref")?.Value ?? string.Empty;
+            var extractedRuleId = ExtractRuleId(idref);
+            var result = rr.Element(ns + "result")?.Value ?? "unknown";
+            var severity = rr.Attribute("severity")?.Value ?? "unknown";
+
+            decimal weight = 0;
+            if (decimal.TryParse(rr.Attribute("weight")?.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var w))
+                weight = w;
+
+            var timestamp = ParseTimestamp(rr.Attribute("time")?.Value);
+
+            // Message element
+            var message = rr.Element(ns + "message")?.Value;
+
+            // Check reference
+            var checkEl = rr.Element(ns + "check");
+            var checkRef = checkEl?.Element(ns + "check-content-ref")?.Attribute("name")?.Value;
+
+            results.Add(new ParsedXccdfResult(
+                RuleIdRef: idref,
+                ExtractedRuleId: extractedRuleId,
+                Result: result.ToLowerInvariant(),
+                Severity: severity.ToLowerInvariant(),
+                Weight: weight,
+                Timestamp: timestamp,
+                Message: message,
+                CheckRef: checkRef));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Extract DISA rule ID from XCCDF idref.
+    /// E.g., <c>xccdf_mil.disa.stig_rule_SV-254239r849090_rule</c> → <c>SV-254239r849090_rule</c>
+    /// </summary>
+    internal static string ExtractRuleId(string idref)
+    {
+        if (string.IsNullOrEmpty(idref)) return string.Empty;
+
+        // Pattern: xccdf_mil.disa.stig_rule_SV-XXXXXX...
+        const string prefix = "xccdf_mil.disa.stig_rule_";
+        if (idref.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return idref[prefix.Length..];
+
+        // Also handle direct SV- references
+        if (idref.StartsWith("SV-", StringComparison.OrdinalIgnoreCase))
+            return idref;
+
+        // Return as-is if unrecognized format
+        return idref;
+    }
+
+    private static DateTime? ParseTimestamp(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt)
+            ? dt
+            : null;
+    }
+}

--- a/src/Ato.Copilot.Agents/Compliance/Tools/ScanImportTools.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Tools/ScanImportTools.cs
@@ -1,0 +1,609 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: MCP Tools
+// Tools for importing CKL/XCCDF files, exporting CKL, and managing imports.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Agents.Common;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Agents.Compliance.Tools;
+
+// ─── ImportCklTool ───────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool for importing a DISA STIG Viewer CKL checklist file.
+/// Accepts base64-encoded file content, decodes to bytes, validates size,
+/// checks for duplicate files, and delegates to <see cref="IScanImportService"/>.
+/// </summary>
+public class ImportCklTool : BaseTool
+{
+    private static readonly JsonSerializerOptions s_jsonOpts = new() { WriteIndented = true };
+    private const int MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
+
+    private readonly IScanImportService _importService;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public ImportCklTool(
+        IScanImportService importService,
+        IServiceScopeFactory scopeFactory,
+        ILogger<ImportCklTool> logger)
+        : base(logger)
+    {
+        _importService = importService;
+        _scopeFactory = scopeFactory;
+    }
+
+    public override string Name => "compliance_import_ckl";
+
+    public override string Description =>
+        "Import a DISA STIG Viewer CKL checklist file for a registered system. " +
+        "Creates compliance findings, control effectiveness records, and evidence. " +
+        "Accepts base64-encoded file content (max 5 MB after decoding).";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new()
+        {
+            Name = "system_id",
+            Description = "Registered system ID (required).",
+            Type = "string",
+            Required = true
+        },
+        ["file_content"] = new()
+        {
+            Name = "file_content",
+            Description = "Base64-encoded CKL file content (required, max 5 MB after decoding).",
+            Type = "string",
+            Required = true
+        },
+        ["file_name"] = new()
+        {
+            Name = "file_name",
+            Description = "Original file name (required, e.g., 'windows_server_2022.ckl').",
+            Type = "string",
+            Required = true
+        },
+        ["conflict_resolution"] = new()
+        {
+            Name = "conflict_resolution",
+            Description = "How to handle duplicate findings: 'Skip' (default), 'Overwrite', or 'Merge'.",
+            Type = "string",
+            Required = false
+        },
+        ["dry_run"] = new()
+        {
+            Name = "dry_run",
+            Description = "If true, preview results without persisting changes (default: false).",
+            Type = "boolean",
+            Required = false
+        },
+        ["assessment_id"] = new()
+        {
+            Name = "assessment_id",
+            Description = "Optional assessment ID. If omitted, auto-resolves or creates one.",
+            Type = "string",
+            Required = false
+        }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var systemId = GetArg<string>(arguments, "system_id");
+        var fileContentBase64 = GetArg<string>(arguments, "file_content");
+        var fileName = GetArg<string>(arguments, "file_name");
+        var conflictStr = GetArg<string>(arguments, "conflict_resolution") ?? "Skip";
+        var dryRun = GetArg<bool>(arguments, "dry_run");
+        var assessmentId = GetArg<string>(arguments, "assessment_id");
+
+        // Validate required parameters
+        if (string.IsNullOrWhiteSpace(systemId))
+            return ErrorJson("INVALID_INPUT", "The 'system_id' parameter is required.");
+
+        if (string.IsNullOrWhiteSpace(fileContentBase64))
+            return ErrorJson("INVALID_INPUT", "The 'file_content' parameter is required (base64-encoded CKL data).");
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            return ErrorJson("INVALID_INPUT", "The 'file_name' parameter is required.");
+
+        // Decode base64
+        byte[] fileBytes;
+        try
+        {
+            fileBytes = Convert.FromBase64String(fileContentBase64);
+        }
+        catch (FormatException)
+        {
+            return ErrorJson("INVALID_BASE64", "The 'file_content' parameter is not valid base64. Ensure the CKL file is base64-encoded.");
+        }
+
+        // Validate file size
+        if (fileBytes.Length > MaxFileSizeBytes)
+        {
+            return ErrorJson("FILE_TOO_LARGE",
+                $"File is {fileBytes.Length / 1024.0 / 1024.0:F1} MB, exceeding the 5 MB limit. " +
+                "Consider splitting your STIGs into separate CKL files per benchmark.");
+        }
+
+        // Parse conflict resolution
+        if (!Enum.TryParse<ImportConflictResolution>(conflictStr, ignoreCase: true, out var resolution))
+            resolution = ImportConflictResolution.Skip;
+
+        // Check for duplicate file (same SHA-256 hash + system)
+        var warnings = new List<string>();
+        var hash = ComputeSha256(fileBytes);
+        await CheckDuplicateFile(systemId, hash, warnings, cancellationToken);
+
+        try
+        {
+            var result = await _importService.ImportCklAsync(
+                systemId, assessmentId, fileBytes, fileName,
+                resolution, dryRun, "mcp-user", cancellationToken);
+
+            // Merge duplicate warnings
+            var allWarnings = warnings.Concat(result.Warnings).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                status = result.Status == ScanImportStatus.Failed ? "error" : "success",
+                data = new
+                {
+                    import_record_id = result.ImportRecordId,
+                    import_status = result.Status.ToString(),
+                    dry_run = dryRun,
+                    benchmark = result.BenchmarkId,
+                    benchmark_title = result.BenchmarkTitle,
+                    total_entries = result.TotalEntries,
+                    summary = new
+                    {
+                        open = result.OpenCount,
+                        pass = result.PassCount,
+                        not_applicable = result.NotApplicableCount,
+                        not_reviewed = result.NotReviewedCount,
+                        error = result.ErrorCount,
+                        skipped = result.SkippedCount,
+                        unmatched = result.UnmatchedCount
+                    },
+                    changes = new
+                    {
+                        findings_created = result.FindingsCreated,
+                        findings_updated = result.FindingsUpdated,
+                        effectiveness_created = result.EffectivenessRecordsCreated,
+                        effectiveness_updated = result.EffectivenessRecordsUpdated,
+                        nist_controls_affected = result.NistControlsAffected
+                    },
+                    unmatched_rules = result.UnmatchedRules.Select(r => new
+                    {
+                        vuln_id = r.VulnId,
+                        rule_id = r.RuleId,
+                        title = r.RuleTitle
+                    }),
+                    warnings = allWarnings,
+                    error_message = result.ErrorMessage
+                },
+                metadata = new
+                {
+                    tool = Name,
+                    timestamp = DateTime.UtcNow.ToString("O")
+                }
+            }, s_jsonOpts);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "CKL import failed for system {SystemId}", systemId);
+            return ErrorJson("IMPORT_FAILED", $"CKL import failed: {ex.Message}");
+        }
+    }
+
+    private async Task CheckDuplicateFile(string systemId, string hash, List<string> warnings, CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+            var existing = await ctx.ScanImportRecords
+                .Where(r => r.RegisteredSystemId == systemId && r.FileHash == hash && !r.IsDryRun)
+                .OrderByDescending(r => r.ImportedAt)
+                .FirstOrDefaultAsync(ct);
+
+            if (existing != null)
+            {
+                warnings.Add($"File previously imported on {existing.ImportedAt:yyyy-MM-dd HH:mm} UTC (import ID: {existing.Id}).");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not check for duplicate file");
+        }
+    }
+
+    private static string ComputeSha256(byte[] data)
+    {
+        var hash = SHA256.HashData(data);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private string ErrorJson(string code, string message)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            status = "error",
+            errorCode = code,
+            message,
+            metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") }
+        }, s_jsonOpts);
+    }
+}
+
+// ─── ImportXccdfTool ─────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool for importing a SCAP Compliance Checker XCCDF results file.
+/// Same interface pattern as <see cref="ImportCklTool"/>.
+/// </summary>
+public class ImportXccdfTool : BaseTool
+{
+    private static readonly JsonSerializerOptions s_jsonOpts = new() { WriteIndented = true };
+    private const int MaxFileSizeBytes = 5 * 1024 * 1024;
+
+    private readonly IScanImportService _importService;
+
+    public ImportXccdfTool(IScanImportService importService, ILogger<ImportXccdfTool> logger)
+        : base(logger)
+    {
+        _importService = importService;
+    }
+
+    public override string Name => "compliance_import_xccdf";
+
+    public override string Description =>
+        "Import a SCAP Compliance Checker XCCDF results file for a registered system. " +
+        "Creates compliance findings and control effectiveness records from automated scan results.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "Registered system ID (required).", Type = "string", Required = true },
+        ["file_content"] = new() { Name = "file_content", Description = "Base64-encoded XCCDF file content (required).", Type = "string", Required = true },
+        ["file_name"] = new() { Name = "file_name", Description = "Original file name (required).", Type = "string", Required = true },
+        ["conflict_resolution"] = new() { Name = "conflict_resolution", Description = "How to handle duplicates: 'Skip' (default), 'Overwrite', or 'Merge'.", Type = "string", Required = false },
+        ["dry_run"] = new() { Name = "dry_run", Description = "If true, preview without persisting (default: false).", Type = "boolean", Required = false },
+        ["assessment_id"] = new() { Name = "assessment_id", Description = "Optional assessment ID.", Type = "string", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var systemId = GetArg<string>(arguments, "system_id");
+        var fileContentBase64 = GetArg<string>(arguments, "file_content");
+        var fileName = GetArg<string>(arguments, "file_name");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return ErrorJson("INVALID_INPUT", "The 'system_id' parameter is required.");
+        if (string.IsNullOrWhiteSpace(fileContentBase64))
+            return ErrorJson("INVALID_INPUT", "The 'file_content' parameter is required.");
+        if (string.IsNullOrWhiteSpace(fileName))
+            return ErrorJson("INVALID_INPUT", "The 'file_name' parameter is required.");
+
+        byte[] fileBytes;
+        try { fileBytes = Convert.FromBase64String(fileContentBase64); }
+        catch (FormatException) { return ErrorJson("INVALID_BASE64", "The 'file_content' is not valid base64."); }
+
+        if (fileBytes.Length > MaxFileSizeBytes)
+            return ErrorJson("FILE_TOO_LARGE", $"File exceeds 5 MB limit ({fileBytes.Length / 1024.0 / 1024.0:F1} MB).");
+
+        var conflictStr = GetArg<string>(arguments, "conflict_resolution") ?? "Skip";
+        if (!Enum.TryParse<ImportConflictResolution>(conflictStr, ignoreCase: true, out var resolution))
+            resolution = ImportConflictResolution.Skip;
+        var dryRun = GetArg<bool>(arguments, "dry_run");
+        var assessmentId = GetArg<string>(arguments, "assessment_id");
+
+        try
+        {
+            var result = await _importService.ImportXccdfAsync(
+                systemId, assessmentId, fileBytes, fileName,
+                resolution, dryRun, "mcp-user", cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                status = result.Status == ScanImportStatus.Failed ? "error" : "success",
+                data = new
+                {
+                    import_record_id = result.ImportRecordId,
+                    import_status = result.Status.ToString(),
+                    dry_run = dryRun,
+                    benchmark = result.BenchmarkId,
+                    total_entries = result.TotalEntries,
+                    summary = new { open = result.OpenCount, pass = result.PassCount, not_applicable = result.NotApplicableCount, error = result.ErrorCount, skipped = result.SkippedCount, unmatched = result.UnmatchedCount },
+                    changes = new { findings_created = result.FindingsCreated, findings_updated = result.FindingsUpdated, effectiveness_created = result.EffectivenessRecordsCreated, effectiveness_updated = result.EffectivenessRecordsUpdated, nist_controls_affected = result.NistControlsAffected },
+                    warnings = result.Warnings,
+                    error_message = result.ErrorMessage
+                },
+                metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") }
+            }, s_jsonOpts);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "XCCDF import failed for system {SystemId}", systemId);
+            return ErrorJson("IMPORT_FAILED", $"XCCDF import failed: {ex.Message}");
+        }
+    }
+
+    private string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message, metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") } }, s_jsonOpts);
+}
+
+// ─── ExportCklTool ───────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool for exporting a CKL checklist from assessment data.
+/// </summary>
+public class ExportCklTool : BaseTool
+{
+    private static readonly JsonSerializerOptions s_jsonOpts = new() { WriteIndented = true };
+
+    private readonly IScanImportService _importService;
+
+    public ExportCklTool(IScanImportService importService, ILogger<ExportCklTool> logger)
+        : base(logger)
+    {
+        _importService = importService;
+    }
+
+    public override string Name => "compliance_export_ckl";
+
+    public override string Description =>
+        "Export a CKL checklist file for a system and STIG benchmark. " +
+        "Returns base64-encoded XML content suitable for DISA STIG Viewer or eMASS upload.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "Registered system ID (required).", Type = "string", Required = true },
+        ["benchmark_id"] = new() { Name = "benchmark_id", Description = "STIG benchmark ID (required, e.g., 'Windows_Server_2022_STIG').", Type = "string", Required = true },
+        ["assessment_id"] = new() { Name = "assessment_id", Description = "Optional assessment ID (uses latest if omitted).", Type = "string", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var systemId = GetArg<string>(arguments, "system_id");
+        var benchmarkId = GetArg<string>(arguments, "benchmark_id");
+        var assessmentId = GetArg<string>(arguments, "assessment_id");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return ErrorJson("INVALID_INPUT", "The 'system_id' parameter is required.");
+        if (string.IsNullOrWhiteSpace(benchmarkId))
+            return ErrorJson("INVALID_INPUT", "The 'benchmark_id' parameter is required.");
+
+        try
+        {
+            var base64Content = await _importService.ExportCklAsync(systemId, benchmarkId, assessmentId, cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    file_content = base64Content,
+                    file_name = $"{benchmarkId}_{systemId}.ckl",
+                    content_type = "application/xml",
+                    benchmark_id = benchmarkId,
+                    system_id = systemId
+                },
+                metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") }
+            }, s_jsonOpts);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "CKL export failed for system {SystemId}, benchmark {BenchmarkId}", systemId, benchmarkId);
+            return ErrorJson("EXPORT_FAILED", $"CKL export failed: {ex.Message}");
+        }
+    }
+
+    private string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message, metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") } }, s_jsonOpts);
+}
+
+// ─── ListImportsTool ─────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool for listing import history for a system.
+/// </summary>
+public class ListImportsTool : BaseTool
+{
+    private static readonly JsonSerializerOptions s_jsonOpts = new() { WriteIndented = true };
+
+    private readonly IScanImportService _importService;
+
+    public ListImportsTool(IScanImportService importService, ILogger<ListImportsTool> logger)
+        : base(logger)
+    {
+        _importService = importService;
+    }
+
+    public override string Name => "compliance_list_imports";
+
+    public override string Description =>
+        "List import history for a registered system. Shows CKL and XCCDF imports with summary statistics.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "Registered system ID (required).", Type = "string", Required = true },
+        ["page"] = new() { Name = "page", Description = "Page number, 1-based (default: 1).", Type = "integer", Required = false },
+        ["page_size"] = new() { Name = "page_size", Description = "Items per page (default: 20, max: 100).", Type = "integer", Required = false },
+        ["benchmark_id"] = new() { Name = "benchmark_id", Description = "Optional benchmark filter.", Type = "string", Required = false },
+        ["include_dry_runs"] = new() { Name = "include_dry_runs", Description = "Include dry-run records (default: false).", Type = "boolean", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var systemId = GetArg<string>(arguments, "system_id");
+        if (string.IsNullOrWhiteSpace(systemId))
+            return ErrorJson("INVALID_INPUT", "The 'system_id' parameter is required.");
+
+        var page = GetArg<int>(arguments, "page");
+        if (page <= 0) page = 1;
+        var pageSize = GetArg<int>(arguments, "page_size");
+        if (pageSize <= 0) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+        var benchmarkId = GetArg<string>(arguments, "benchmark_id");
+        var includeDryRuns = GetArg<bool>(arguments, "include_dry_runs");
+
+        try
+        {
+            var (records, totalCount) = await _importService.ListImportsAsync(
+                systemId, page, pageSize, benchmarkId, null, includeDryRuns, null, null, cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    total_count = totalCount,
+                    page,
+                    page_size = pageSize,
+                    imports = records.Select(r => new
+                    {
+                        id = r.Id,
+                        file_name = r.FileName,
+                        import_type = r.ImportType.ToString(),
+                        benchmark_id = r.BenchmarkId,
+                        benchmark_title = r.BenchmarkTitle,
+                        status = r.ImportStatus.ToString(),
+                        imported_by = r.ImportedBy,
+                        imported_at = r.ImportedAt.ToString("O"),
+                        is_dry_run = r.IsDryRun,
+                        total_entries = r.TotalEntries,
+                        open_count = r.OpenCount,
+                        pass_count = r.PassCount,
+                        findings_created = r.FindingsCreated,
+                        findings_updated = r.FindingsUpdated
+                    })
+                },
+                metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") }
+            }, s_jsonOpts);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "List imports failed for system {SystemId}", systemId);
+            return ErrorJson("LIST_FAILED", $"Failed to list imports: {ex.Message}");
+        }
+    }
+
+    private string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message, metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") } }, s_jsonOpts);
+}
+
+// ─── GetImportSummaryTool ────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool for getting detailed summary of a specific import.
+/// </summary>
+public class GetImportSummaryTool : BaseTool
+{
+    private static readonly JsonSerializerOptions s_jsonOpts = new() { WriteIndented = true };
+
+    private readonly IScanImportService _importService;
+
+    public GetImportSummaryTool(IScanImportService importService, ILogger<GetImportSummaryTool> logger)
+        : base(logger)
+    {
+        _importService = importService;
+    }
+
+    public override string Name => "compliance_get_import_summary";
+
+    public override string Description =>
+        "Get detailed summary of a specific import operation, including per-finding breakdown and unmatched rules.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["import_id"] = new() { Name = "import_id", Description = "Import record ID (required).", Type = "string", Required = true }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var importId = GetArg<string>(arguments, "import_id");
+        if (string.IsNullOrWhiteSpace(importId))
+            return ErrorJson("INVALID_INPUT", "The 'import_id' parameter is required.");
+
+        try
+        {
+            var summary = await _importService.GetImportSummaryAsync(importId, cancellationToken);
+            if (summary is null)
+                return ErrorJson("NOT_FOUND", $"Import record '{importId}' not found.");
+
+            var (record, findings) = summary.Value;
+
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    id = record.Id,
+                    file_name = record.FileName,
+                    file_hash = record.FileHash,
+                    import_type = record.ImportType.ToString(),
+                    import_status = record.ImportStatus.ToString(),
+                    benchmark_id = record.BenchmarkId,
+                    benchmark_title = record.BenchmarkTitle,
+                    target_host = record.TargetHostName,
+                    imported_by = record.ImportedBy,
+                    imported_at = record.ImportedAt.ToString("O"),
+                    is_dry_run = record.IsDryRun,
+                    conflict_resolution = record.ConflictResolution.ToString(),
+                    counts = new
+                    {
+                        total = record.TotalEntries,
+                        open = record.OpenCount,
+                        pass = record.PassCount,
+                        not_applicable = record.NotApplicableCount,
+                        not_reviewed = record.NotReviewedCount,
+                        error = record.ErrorCount,
+                        skipped = record.SkippedCount,
+                        unmatched = record.UnmatchedCount,
+                        findings_created = record.FindingsCreated,
+                        findings_updated = record.FindingsUpdated,
+                        effectiveness_created = record.EffectivenessRecordsCreated,
+                        effectiveness_updated = record.EffectivenessRecordsUpdated,
+                        nist_controls_affected = record.NistControlsAffected
+                    },
+                    warnings = record.Warnings,
+                    findings = findings.Select(f => new
+                    {
+                        vuln_id = f.VulnId,
+                        rule_id = f.RuleId,
+                        raw_status = f.RawStatus,
+                        mapped_severity = f.MappedSeverity?.ToString(),
+                        action = f.ImportAction.ToString(),
+                        resolved_stig_id = f.ResolvedStigControlId,
+                        resolved_nist_controls = f.ResolvedNistControlIds,
+                        compliance_finding_id = f.ComplianceFindingId
+                    })
+                },
+                metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") }
+            }, s_jsonOpts);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Get import summary failed for {ImportId}", importId);
+            return ErrorJson("SUMMARY_FAILED", $"Failed to get import summary: {ex.Message}");
+        }
+    }
+
+    private string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message, metadata = new { tool = Name, timestamp = DateTime.UtcNow.ToString("O") } }, s_jsonOpts);
+}

--- a/src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Ato.Copilot.Agents.Compliance.EvidenceCollectors;
 using Ato.Copilot.Agents.Compliance.Scanners;
 using Ato.Copilot.Agents.Compliance.Services;
 using Ato.Copilot.Agents.Compliance.Services.KnowledgeBase;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
 using Ato.Copilot.Agents.Compliance.Tools;
 using Ato.Copilot.Agents.Configuration.Agents;
 using Ato.Copilot.Agents.Configuration.Tools;
@@ -302,6 +303,17 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<UpdateTemplateTool>();
         services.AddSingleton<DeleteTemplateTool>();
 
+        // ─── Feature 017: SCAP/STIG Viewer Import tools ─────────────────────
+        services.AddSingleton<ICklParser, CklParser>();
+        services.AddSingleton<IXccdfParser, XccdfParser>();
+        services.AddSingleton<ICklGenerator, CklGenerator>();
+        services.AddSingleton<IScanImportService, ScanImportService>();
+        services.AddSingleton<ImportCklTool>();
+        services.AddSingleton<ImportXccdfTool>();
+        services.AddSingleton<ExportCklTool>();
+        services.AddSingleton<ListImportsTool>();
+        services.AddSingleton<GetImportSummaryTool>();
+
         // Compliance Watch notification & escalation services (US4)
         services.AddSingleton<AlertNotificationService>();
         services.AddSingleton<IAlertNotificationService>(sp => sp.GetRequiredService<AlertNotificationService>());
@@ -421,6 +433,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<ListTemplatesTool>());
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<UpdateTemplateTool>());
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<DeleteTemplateTool>());
+
+        // Feature 017: SCAP/STIG Import BaseTool wrappers
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<ImportCklTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<ImportXccdfTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<ExportCklTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<ListImportsTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<GetImportSummaryTool>());
 
         // Register the agent
         services.AddSingleton<ComplianceAgent>();

--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -150,6 +150,13 @@ public class AtoCopilotContext : DbContext
     /// <summary>Significant system changes that may trigger reauthorization.</summary>
     public DbSet<SignificantChange> SignificantChanges => Set<SignificantChange>();
 
+    // ─── SCAP/STIG Import DbSets (Feature 017) ──────────────────────────────
+    /// <summary>Tracks each file import operation (one per CKL/XCCDF file).</summary>
+    public DbSet<ScanImportRecord> ScanImportRecords => Set<ScanImportRecord>();
+
+    /// <summary>Per-finding audit trail linking raw parsed data to ComplianceFindings.</summary>
+    public DbSet<ScanImportFinding> ScanImportFindings => Set<ScanImportFinding>();
+
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -253,11 +260,21 @@ public class AtoCopilotContext : DbContext
             // New properties (Feature 015 — US7)
             entity.Property(e => e.CatSeverity).HasConversion<string>().HasMaxLength(10);
 
+            // New properties (Feature 017 — SCAP/STIG Import)
+            entity.Property(e => e.ImportRecordId).HasMaxLength(100);
+
+            // Relationship: ComplianceFinding → ScanImportRecord (optional)
+            entity.HasOne<ScanImportRecord>()
+                .WithMany()
+                .HasForeignKey(e => e.ImportRecordId)
+                .OnDelete(DeleteBehavior.SetNull);
+
             // Indexes
             entity.HasIndex(e => e.ControlId);
             entity.HasIndex(e => e.AssessmentId);
             entity.HasIndex(e => e.ControlFamily);
             entity.HasIndex(e => new { e.AssessmentId, e.Severity });
+            entity.HasIndex(e => e.ImportRecordId).HasDatabaseName("IX_ComplianceFinding_ImportRecordId");
         });
 
         // ─── NistControl ────────────────────────────────────────────────────────
@@ -1196,6 +1213,98 @@ public class AtoCopilotContext : DbContext
         modelBuilder.Entity<RemediationTask>(entity =>
         {
             entity.HasIndex(e => e.PoamItemId).HasDatabaseName("IX_RemediationTask_PoamItemId");
+        });
+
+        // ─── ScanImportRecord (Feature 017 — SCAP/STIG Import) ──────────────
+        modelBuilder.Entity<ScanImportRecord>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(100);
+
+            // Required strings
+            entity.Property(e => e.RegisteredSystemId).HasMaxLength(100);
+            entity.Property(e => e.AssessmentId).HasMaxLength(100);
+            entity.Property(e => e.FileName).HasMaxLength(500);
+            entity.Property(e => e.FileHash).HasMaxLength(128);
+            entity.Property(e => e.ImportedBy).HasMaxLength(200);
+
+            // Optional strings
+            entity.Property(e => e.BenchmarkId).HasMaxLength(200);
+            entity.Property(e => e.BenchmarkVersion).HasMaxLength(50);
+            entity.Property(e => e.BenchmarkTitle).HasMaxLength(500);
+            entity.Property(e => e.TargetHostName).HasMaxLength(200);
+            entity.Property(e => e.TargetIpAddress).HasMaxLength(50);
+            entity.Property(e => e.ErrorMessage).HasMaxLength(4000);
+
+            // Enum → string conversion
+            entity.Property(e => e.ImportType).HasConversion<string>().HasMaxLength(10);
+            entity.Property(e => e.ImportStatus).HasConversion<string>().HasMaxLength(30);
+            entity.Property(e => e.ConflictResolution).HasConversion<string>().HasMaxLength(20);
+
+            // JSON column — Warnings
+            entity.Property(e => e.Warnings).HasConversion(stringListConverter);
+
+            // Relationships
+            entity.HasOne<RegisteredSystem>()
+                .WithMany()
+                .HasForeignKey(e => e.RegisteredSystemId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne<ComplianceAssessment>()
+                .WithMany()
+                .HasForeignKey(e => e.AssessmentId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Indexes
+            entity.HasIndex(e => e.RegisteredSystemId).HasDatabaseName("IX_ScanImportRecord_RegisteredSystemId");
+            entity.HasIndex(e => new { e.RegisteredSystemId, e.BenchmarkId }).HasDatabaseName("IX_ScanImportRecord_System_Benchmark");
+            entity.HasIndex(e => new { e.RegisteredSystemId, e.FileHash }).HasDatabaseName("IX_ScanImportRecord_System_FileHash");
+        });
+
+        // ─── ScanImportFinding (Feature 017 — SCAP/STIG Import) ─────────────
+        modelBuilder.Entity<ScanImportFinding>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(100);
+
+            // Required strings
+            entity.Property(e => e.ScanImportRecordId).HasMaxLength(100);
+            entity.Property(e => e.VulnId).HasMaxLength(20);
+            entity.Property(e => e.RawStatus).HasMaxLength(50);
+            entity.Property(e => e.RawSeverity).HasMaxLength(20);
+
+            // Optional strings
+            entity.Property(e => e.RuleId).HasMaxLength(100);
+            entity.Property(e => e.StigVersion).HasMaxLength(50);
+            entity.Property(e => e.FindingDetails).HasMaxLength(8000);
+            entity.Property(e => e.Comments).HasMaxLength(8000);
+            entity.Property(e => e.SeverityOverride).HasMaxLength(20);
+            entity.Property(e => e.SeverityJustification).HasMaxLength(4000);
+            entity.Property(e => e.ResolvedStigControlId).HasMaxLength(20);
+            entity.Property(e => e.ComplianceFindingId).HasMaxLength(100);
+
+            // Enum → string conversion
+            entity.Property(e => e.MappedSeverity).HasConversion<string>().HasMaxLength(10);
+            entity.Property(e => e.ImportAction).HasConversion<string>().HasMaxLength(20);
+
+            // JSON columns
+            entity.Property(e => e.ResolvedNistControlIds).HasConversion(stringListConverter);
+            entity.Property(e => e.ResolvedCciRefs).HasConversion(stringListConverter);
+
+            // Relationships
+            entity.HasOne<ScanImportRecord>()
+                .WithMany()
+                .HasForeignKey(e => e.ScanImportRecordId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne<ComplianceFinding>()
+                .WithMany()
+                .HasForeignKey(e => e.ComplianceFindingId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            // Indexes
+            entity.HasIndex(e => e.ScanImportRecordId).HasDatabaseName("IX_ScanImportFinding_ImportRecordId");
+            entity.HasIndex(e => new { e.ScanImportRecordId, e.VulnId }).HasDatabaseName("IX_ScanImportFinding_Import_VulnId");
         });
     }
 

--- a/src/Ato.Copilot.Core/Interfaces/Compliance/IComplianceInterfaces.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Compliance/IComplianceInterfaces.cs
@@ -1020,6 +1020,24 @@ public interface IStigKnowledgeService
     Task<List<CciMapping>> GetCciMappingsAsync(
         string controlId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get a STIG control by its Rule ID (e.g., "SV-254239r849090_rule").
+    /// Used by scan import for XCCDF rule-result resolution and CKL fallback matching.
+    /// </summary>
+    /// <param name="ruleId">STIG Rule ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching STIG control, or null if not found.</returns>
+    Task<StigControl?> GetStigControlByRuleIdAsync(string ruleId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all STIG controls belonging to a specific benchmark.
+    /// Used by CKL export to enumerate the full STIG checklist.
+    /// </summary>
+    /// <param name="benchmarkId">Benchmark identifier (e.g., "Windows_Server_2022_STIG").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of STIG controls for the benchmark (empty if none found).</returns>
+    Task<List<StigControl>> GetStigControlsByBenchmarkAsync(string benchmarkId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Ato.Copilot.Core/Interfaces/Compliance/IScanImportService.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Compliance/IScanImportService.cs
@@ -1,0 +1,99 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: Service Interface
+// See specs/017-scap-stig-import/contracts/mcp-tools.md for tool contracts.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Core.Interfaces.Compliance;
+
+/// <summary>
+/// Service for importing SCAP/STIG scan results, exporting CKL checklists,
+/// and managing import history. Service receives raw bytes (tool layer decodes base64).
+/// </summary>
+public interface IScanImportService
+{
+    /// <summary>
+    /// Import a DISA STIG Viewer CKL file. Creates ComplianceFindings, ControlEffectiveness,
+    /// and ComplianceEvidence records from parsed CKL data.
+    /// </summary>
+    /// <param name="systemId">Registered system ID.</param>
+    /// <param name="assessmentId">Assessment context for findings (optional — auto-resolved if null).</param>
+    /// <param name="fileContent">Raw CKL file bytes (UTF-8 XML).</param>
+    /// <param name="fileName">Original file name.</param>
+    /// <param name="resolution">Conflict resolution strategy for duplicate findings.</param>
+    /// <param name="dryRun">If true, parse and report without persisting.</param>
+    /// <param name="importedBy">Identity of the importing user.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Import result with counts, warnings, and unmatched rules.</returns>
+    Task<ImportResult> ImportCklAsync(
+        string systemId,
+        string? assessmentId,
+        byte[] fileContent,
+        string fileName,
+        ImportConflictResolution resolution,
+        bool dryRun,
+        string importedBy,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Import a SCAP Compliance Checker XCCDF results file. Same downstream pipeline as CKL.
+    /// </summary>
+    Task<ImportResult> ImportXccdfAsync(
+        string systemId,
+        string? assessmentId,
+        byte[] fileContent,
+        string fileName,
+        ImportConflictResolution resolution,
+        bool dryRun,
+        string importedBy,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Export a CKL checklist for a system and benchmark, with current assessment status.
+    /// </summary>
+    /// <param name="systemId">Registered system ID.</param>
+    /// <param name="benchmarkId">STIG benchmark ID (e.g., "Windows_Server_2022_STIG").</param>
+    /// <param name="assessmentId">Optional assessment context (uses latest if null).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Base64-encoded CKL XML content.</returns>
+    Task<string> ExportCklAsync(
+        string systemId,
+        string benchmarkId,
+        string? assessmentId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// List import history for a system with pagination and filtering.
+    /// </summary>
+    /// <param name="systemId">Registered system ID.</param>
+    /// <param name="page">Page number (1-based).</param>
+    /// <param name="pageSize">Items per page (default 20, max 100).</param>
+    /// <param name="benchmarkId">Optional benchmark filter.</param>
+    /// <param name="importType">Optional type filter ("Ckl" or "Xccdf").</param>
+    /// <param name="includeDryRuns">Whether to include dry-run records (default false).</param>
+    /// <param name="fromDate">Optional start date filter (UTC).</param>
+    /// <param name="toDate">Optional end date filter (UTC).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Paginated list of import records.</returns>
+    Task<(List<ScanImportRecord> Records, int TotalCount)> ListImportsAsync(
+        string systemId,
+        int page,
+        int pageSize,
+        string? benchmarkId,
+        string? importType,
+        bool includeDryRuns,
+        DateTime? fromDate,
+        DateTime? toDate,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Get detailed summary of a specific import operation.
+    /// </summary>
+    /// <param name="importId">Import record ID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Import record with all findings, or null if not found.</returns>
+    Task<(ScanImportRecord Record, List<ScanImportFinding> Findings)?> GetImportSummaryAsync(
+        string importId,
+        CancellationToken ct = default);
+}

--- a/src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs
@@ -961,6 +961,14 @@ public class ComplianceFinding
 
     /// <summary>DoD CAT severity level for this finding (CAT I, CAT II, or CAT III).</summary>
     public CatSeverity? CatSeverity { get; set; }
+
+    // ─── New Properties (Feature 017 — SCAP/STIG Viewer Import) ──────────
+
+    /// <summary>
+    /// FK to <see cref="ScanImportRecord"/> when this finding was created or updated via scan import.
+    /// Null for manually-created findings. See data-model.md §Modified Entities.
+    /// </summary>
+    public string? ImportRecordId { get; set; }
 }
 
 /// <summary>

--- a/src/Ato.Copilot.Core/Models/Compliance/ScanImportModels.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/ScanImportModels.cs
@@ -1,0 +1,430 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: Entities, Enums, and DTOs
+// See specs/017-scap-stig-import/data-model.md for full specification.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+// ─── Enums ───────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Type of scan import file. Determines which parser is used.
+/// </summary>
+public enum ScanImportType
+{
+    /// <summary>DISA STIG Viewer checklist (.ckl) — XML format with manual assessments.</summary>
+    Ckl,
+
+    /// <summary>SCAP Compliance Checker XCCDF results (.xml) — automated scan output.</summary>
+    Xccdf
+}
+
+/// <summary>
+/// Final status of a scan import operation.
+/// </summary>
+public enum ScanImportStatus
+{
+    /// <summary>All entries processed successfully with no warnings.</summary>
+    Completed,
+
+    /// <summary>Processed but with unmatched rules or baseline mismatches.</summary>
+    CompletedWithWarnings,
+
+    /// <summary>Fatal error — malformed XML, system not found, etc.</summary>
+    Failed
+}
+
+/// <summary>
+/// Strategy for handling duplicate findings during re-import.
+/// </summary>
+public enum ImportConflictResolution
+{
+    /// <summary>Keep existing findings, skip duplicates.</summary>
+    Skip,
+
+    /// <summary>Replace existing findings with imported data.</summary>
+    Overwrite,
+
+    /// <summary>Keep more-recent data, append details if different.</summary>
+    Merge
+}
+
+/// <summary>
+/// Action taken for each individual finding during import.
+/// Stored on <see cref="ScanImportFinding"/> for audit trail.
+/// </summary>
+public enum ImportFindingAction
+{
+    /// <summary>New <see cref="ComplianceFinding"/> created.</summary>
+    Created,
+
+    /// <summary>Existing finding updated via overwrite or merge.</summary>
+    Updated,
+
+    /// <summary>Duplicate skipped (skip conflict resolution).</summary>
+    Skipped,
+
+    /// <summary>STIG rule not found in curated library.</summary>
+    Unmatched,
+
+    /// <summary>CKL Not_Applicable or XCCDF notapplicable — no ComplianceFinding created.</summary>
+    NotApplicable,
+
+    /// <summary>CKL Not_Reviewed or XCCDF notchecked — ComplianceFinding created as Open.</summary>
+    NotReviewed,
+
+    /// <summary>XCCDF error/unknown result — flagged for manual review, no finding created.</summary>
+    Error
+}
+
+// ─── Entities ────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Tracks each file import operation. One record per imported file.
+/// See data-model.md §ScanImportRecord for field descriptions.
+/// </summary>
+public class ScanImportRecord
+{
+    /// <summary>Unique identifier (GUID).</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>FK to <see cref="RegisteredSystem"/> this import belongs to.</summary>
+    public string RegisteredSystemId { get; set; } = string.Empty;
+
+    /// <summary>FK to <see cref="ComplianceAssessment"/> providing context for findings.</summary>
+    public string AssessmentId { get; set; } = string.Empty;
+
+    /// <summary>Type of import file (CKL or XCCDF).</summary>
+    public ScanImportType ImportType { get; set; }
+
+    /// <summary>Original file name as uploaded.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>SHA-256 hash of raw file content (before base64 encoding).</summary>
+    public string FileHash { get; set; } = string.Empty;
+
+    /// <summary>File size in bytes before base64 encoding.</summary>
+    public long FileSizeBytes { get; set; }
+
+    /// <summary>STIG benchmark ID (e.g., <c>Windows_Server_2022_STIG</c>).</summary>
+    public string? BenchmarkId { get; set; }
+
+    /// <summary>STIG release version.</summary>
+    public string? BenchmarkVersion { get; set; }
+
+    /// <summary>STIG benchmark display title.</summary>
+    public string? BenchmarkTitle { get; set; }
+
+    /// <summary>Target system hostname from scan.</summary>
+    public string? TargetHostName { get; set; }
+
+    /// <summary>Target IP address.</summary>
+    public string? TargetIpAddress { get; set; }
+
+    /// <summary>
+    /// When the scan was performed (UTC).
+    /// XCCDF: from <c>start-time</c> attribute.
+    /// CKL: <c>null</c> (CKL format has no scan timestamp; STIG_INFO releaseinfo is the benchmark release date).
+    /// </summary>
+    public DateTime? ScanTimestamp { get; set; }
+
+    /// <summary>Total rules/VULNs in the file.</summary>
+    public int TotalEntries { get; set; }
+
+    /// <summary>Findings with status Open/Fail.</summary>
+    public int OpenCount { get; set; }
+
+    /// <summary>Findings with status NotAFinding/Pass.</summary>
+    public int PassCount { get; set; }
+
+    /// <summary>Findings with status Not_Applicable.</summary>
+    public int NotApplicableCount { get; set; }
+
+    /// <summary>Findings not evaluated (CKL Not_Reviewed / XCCDF notchecked).</summary>
+    public int NotReviewedCount { get; set; }
+
+    /// <summary>XCCDF error/unknown results.</summary>
+    public int ErrorCount { get; set; }
+
+    /// <summary>Entries skipped due to conflict resolution.</summary>
+    public int SkippedCount { get; set; }
+
+    /// <summary>STIG rules not found in curated library.</summary>
+    public int UnmatchedCount { get; set; }
+
+    /// <summary>New <see cref="ComplianceFinding"/> records created.</summary>
+    public int FindingsCreated { get; set; }
+
+    /// <summary>Existing findings updated (overwrite/merge).</summary>
+    public int FindingsUpdated { get; set; }
+
+    /// <summary>New <see cref="ControlEffectiveness"/> records created.</summary>
+    public int EffectivenessRecordsCreated { get; set; }
+
+    /// <summary>Existing effectiveness records updated.</summary>
+    public int EffectivenessRecordsUpdated { get; set; }
+
+    /// <summary>Unique NIST 800-53 controls touched by this import.</summary>
+    public int NistControlsAffected { get; set; }
+
+    /// <summary>Conflict resolution strategy applied during this import.</summary>
+    public ImportConflictResolution ConflictResolution { get; set; }
+
+    /// <summary>Whether this was a preview-only import (no DB writes).</summary>
+    public bool IsDryRun { get; set; }
+
+    /// <summary>XCCDF compliance score (null for CKL imports).</summary>
+    public decimal? XccdfScore { get; set; }
+
+    /// <summary>Final import status.</summary>
+    public ScanImportStatus ImportStatus { get; set; }
+
+    /// <summary>Error details if import failed.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Non-fatal warnings (unmatched rules, baseline mismatches). Stored as JSON column.</summary>
+    public List<string> Warnings { get; set; } = new();
+
+    /// <summary>Identity of the user who performed the import.</summary>
+    public string ImportedBy { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the import was performed.</summary>
+    public DateTime ImportedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Per-finding audit trail for each import. Links the raw parsed data
+/// to the resulting <see cref="ComplianceFinding"/>.
+/// See data-model.md §ScanImportFinding for field descriptions.
+/// </summary>
+public class ScanImportFinding
+{
+    /// <summary>Unique identifier (GUID).</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>FK to parent <see cref="ScanImportRecord"/>.</summary>
+    public string ScanImportRecordId { get; set; } = string.Empty;
+
+    /// <summary>STIG Vulnerability ID (e.g., <c>V-254239</c>).</summary>
+    public string VulnId { get; set; } = string.Empty;
+
+    /// <summary>STIG Rule ID (e.g., <c>SV-254239r849090_rule</c>).</summary>
+    public string? RuleId { get; set; }
+
+    /// <summary>Rule version (e.g., <c>WN22-AU-000010</c>).</summary>
+    public string? StigVersion { get; set; }
+
+    /// <summary>Original CKL STATUS or XCCDF result value.</summary>
+    public string RawStatus { get; set; } = string.Empty;
+
+    /// <summary>Original severity text (<c>high</c>/<c>medium</c>/<c>low</c>).</summary>
+    public string RawSeverity { get; set; } = string.Empty;
+
+    /// <summary>Resolved CAT severity (null if severity could not be mapped).</summary>
+    public CatSeverity? MappedSeverity { get; set; }
+
+    /// <summary>CKL FINDING_DETAILS or XCCDF message.</summary>
+    public string? FindingDetails { get; set; }
+
+    /// <summary>CKL COMMENTS field.</summary>
+    public string? Comments { get; set; }
+
+    /// <summary>CKL SEVERITY_OVERRIDE value.</summary>
+    public string? SeverityOverride { get; set; }
+
+    /// <summary>CKL SEVERITY_JUSTIFICATION value.</summary>
+    public string? SeverityJustification { get; set; }
+
+    /// <summary>Matched <c>StigControl.StigId</c> (null if unmatched).</summary>
+    public string? ResolvedStigControlId { get; set; }
+
+    /// <summary>NIST 800-53 control IDs resolved via CCI chain. Stored as JSON column.</summary>
+    public List<string> ResolvedNistControlIds { get; set; } = new();
+
+    /// <summary>CCI references from the CKL/XCCDF entry. Stored as JSON column.</summary>
+    public List<string> ResolvedCciRefs { get; set; } = new();
+
+    /// <summary>Action taken for this finding during import.</summary>
+    public ImportFindingAction ImportAction { get; set; }
+
+    /// <summary>FK to created/updated <see cref="ComplianceFinding"/> (null if skipped/unmatched).</summary>
+    public string? ComplianceFindingId { get; set; }
+}
+
+// ─── DTOs (Not Persisted) ────────────────────────────────────────────────────
+
+/// <summary>
+/// Intermediate DTO from CKL parser — a single VULN entry.
+/// Not stored in database.
+/// </summary>
+/// <param name="VulnId">STIG Vulnerability ID (e.g., <c>V-254239</c>).</param>
+/// <param name="RuleId">STIG Rule ID (e.g., <c>SV-254239r849090_rule</c>).</param>
+/// <param name="StigVersion">Rule version (e.g., <c>WN22-AU-000010</c>).</param>
+/// <param name="RuleTitle">Descriptive title of the STIG rule.</param>
+/// <param name="Severity">Severity string: <c>high</c>, <c>medium</c>, or <c>low</c>.</param>
+/// <param name="Status">CKL status: <c>Open</c>, <c>NotAFinding</c>, <c>Not_Applicable</c>, <c>Not_Reviewed</c>.</param>
+/// <param name="FindingDetails">CKL FINDING_DETAILS field.</param>
+/// <param name="Comments">CKL COMMENTS field.</param>
+/// <param name="SeverityOverride">CKL SEVERITY_OVERRIDE value.</param>
+/// <param name="SeverityJustification">CKL SEVERITY_JUSTIFICATION value.</param>
+/// <param name="CciRefs">CCI references from the CKL entry.</param>
+/// <param name="GroupTitle">SRG reference (group title).</param>
+public record ParsedCklEntry(
+    string VulnId,
+    string? RuleId,
+    string? StigVersion,
+    string? RuleTitle,
+    string Severity,
+    string Status,
+    string? FindingDetails,
+    string? Comments,
+    string? SeverityOverride,
+    string? SeverityJustification,
+    List<string> CciRefs,
+    string? GroupTitle);
+
+/// <summary>
+/// Top-level CKL parse result containing asset info, STIG metadata, and all VULN entries.
+/// </summary>
+/// <param name="Asset">Parsed ASSET section.</param>
+/// <param name="StigInfo">Parsed STIG_INFO section.</param>
+/// <param name="Entries">All parsed VULN entries.</param>
+public record ParsedCklFile(
+    CklAssetInfo Asset,
+    CklStigInfo StigInfo,
+    List<ParsedCklEntry> Entries);
+
+/// <summary>
+/// CKL ASSET section — target system identification.
+/// </summary>
+/// <param name="HostName">Target hostname.</param>
+/// <param name="HostIp">Target IP address.</param>
+/// <param name="HostFqdn">Fully-qualified domain name.</param>
+/// <param name="HostMac">MAC address.</param>
+/// <param name="AssetType">Asset type (e.g., <c>Computing</c>).</param>
+/// <param name="TargetKey">DISA target key.</param>
+public record CklAssetInfo(
+    string? HostName,
+    string? HostIp,
+    string? HostFqdn,
+    string? HostMac,
+    string? AssetType,
+    string? TargetKey);
+
+/// <summary>
+/// CKL STIG_INFO section — benchmark metadata.
+/// </summary>
+/// <param name="StigId">Benchmark ID (e.g., <c>Windows_Server_2022_STIG</c>).</param>
+/// <param name="Version">STIG release version.</param>
+/// <param name="ReleaseInfo">Release info string (benchmark release date, not scan date).</param>
+/// <param name="Title">Benchmark display title.</param>
+public record CklStigInfo(
+    string? StigId,
+    string? Version,
+    string? ReleaseInfo,
+    string? Title);
+
+/// <summary>
+/// Intermediate DTO from XCCDF parser — a single rule-result.
+/// Not stored in database.
+/// </summary>
+/// <param name="RuleIdRef">Full XCCDF idref string.</param>
+/// <param name="ExtractedRuleId">Extracted <c>SV-XXXXX</c> portion from the XCCDF idref.</param>
+/// <param name="Result">XCCDF result: <c>pass</c>, <c>fail</c>, <c>error</c>, <c>notapplicable</c>, <c>notchecked</c>, etc.</param>
+/// <param name="Severity">Severity string from the rule-result.</param>
+/// <param name="Weight">Rule weight.</param>
+/// <param name="Timestamp">Result timestamp (if available).</param>
+/// <param name="Message">XCCDF message element content.</param>
+/// <param name="CheckRef">OVAL check reference.</param>
+public record ParsedXccdfResult(
+    string RuleIdRef,
+    string ExtractedRuleId,
+    string Result,
+    string Severity,
+    decimal Weight,
+    DateTime? Timestamp,
+    string? Message,
+    string? CheckRef);
+
+/// <summary>
+/// Top-level XCCDF parse result containing benchmark/target info, scores, and all rule-results.
+/// </summary>
+/// <param name="BenchmarkHref">Benchmark reference URI.</param>
+/// <param name="Title">Test result title.</param>
+/// <param name="Target">Target system identifier.</param>
+/// <param name="TargetAddress">Target IP or hostname.</param>
+/// <param name="StartTime">Scan start time (UTC).</param>
+/// <param name="EndTime">Scan end time (UTC).</param>
+/// <param name="Score">Achieved compliance score.</param>
+/// <param name="MaxScore">Maximum possible score.</param>
+/// <param name="TargetFacts">Additional target facts (OS, FQDN, etc.).</param>
+/// <param name="Results">All parsed rule-results.</param>
+public record ParsedXccdfFile(
+    string? BenchmarkHref,
+    string? Title,
+    string? Target,
+    string? TargetAddress,
+    DateTime? StartTime,
+    DateTime? EndTime,
+    decimal? Score,
+    decimal? MaxScore,
+    Dictionary<string, string> TargetFacts,
+    List<ParsedXccdfResult> Results);
+
+/// <summary>
+/// Return value from import operations. Contains all counts, warnings, and unmatched rule details.
+/// </summary>
+/// <param name="ImportRecordId">ID of the created <see cref="ScanImportRecord"/>.</param>
+/// <param name="Status">Final import status.</param>
+/// <param name="BenchmarkId">Detected benchmark ID.</param>
+/// <param name="BenchmarkTitle">Detected benchmark title.</param>
+/// <param name="TotalEntries">Total rules/VULNs in the file.</param>
+/// <param name="OpenCount">Findings with status Open/Fail.</param>
+/// <param name="PassCount">Findings with status NotAFinding/Pass.</param>
+/// <param name="NotApplicableCount">Findings marked Not_Applicable.</param>
+/// <param name="NotReviewedCount">Findings not evaluated.</param>
+/// <param name="ErrorCount">XCCDF error/unknown results.</param>
+/// <param name="SkippedCount">Entries skipped due to conflict resolution.</param>
+/// <param name="UnmatchedCount">STIG rules not found in curated library.</param>
+/// <param name="FindingsCreated">New ComplianceFinding records created.</param>
+/// <param name="FindingsUpdated">Existing findings updated.</param>
+/// <param name="EffectivenessRecordsCreated">New ControlEffectiveness records created.</param>
+/// <param name="EffectivenessRecordsUpdated">Existing effectiveness records updated.</param>
+/// <param name="NistControlsAffected">Unique NIST controls touched.</param>
+/// <param name="Warnings">Non-fatal warning messages.</param>
+/// <param name="UnmatchedRules">Details of unmatched STIG rules.</param>
+/// <param name="ErrorMessage">Error details if import failed.</param>
+public record ImportResult(
+    string ImportRecordId,
+    ScanImportStatus Status,
+    string BenchmarkId,
+    string? BenchmarkTitle,
+    int TotalEntries,
+    int OpenCount,
+    int PassCount,
+    int NotApplicableCount,
+    int NotReviewedCount,
+    int ErrorCount,
+    int SkippedCount,
+    int UnmatchedCount,
+    int FindingsCreated,
+    int FindingsUpdated,
+    int EffectivenessRecordsCreated,
+    int EffectivenessRecordsUpdated,
+    int NistControlsAffected,
+    List<string> Warnings,
+    List<UnmatchedRuleInfo> UnmatchedRules,
+    string? ErrorMessage);
+
+/// <summary>
+/// Details of a STIG rule that could not be matched to the curated library.
+/// </summary>
+/// <param name="VulnId">STIG Vulnerability ID.</param>
+/// <param name="RuleId">STIG Rule ID (if available).</param>
+/// <param name="RuleTitle">Rule title (if available).</param>
+/// <param name="Severity">Severity string from the source file.</param>
+public record UnmatchedRuleInfo(
+    string VulnId,
+    string? RuleId,
+    string? RuleTitle,
+    string Severity);

--- a/src/Ato.Copilot.Mcp/Tools/ComplianceMcpTools.cs
+++ b/src/Ato.Copilot.Mcp/Tools/ComplianceMcpTools.cs
@@ -187,6 +187,13 @@ public class ComplianceMcpTools
     private readonly UpdateTemplateTool _updateTemplateTool;
     private readonly DeleteTemplateTool _deleteTemplateTool;
 
+    // ─── Feature 017: SCAP/STIG Import tools ──────────────────────────────
+    private readonly ImportCklTool _importCklTool;
+    private readonly ImportXccdfTool _importXccdfTool;
+    private readonly ExportCklTool _exportCklTool;
+    private readonly ListImportsTool _listImportsTool;
+    private readonly GetImportSummaryTool _getImportSummaryTool;
+
     public ComplianceMcpTools(
         ComplianceAssessmentTool assessmentTool,
         ControlFamilyTool controlFamilyTool,
@@ -311,7 +318,13 @@ public class ComplianceMcpTools
         UploadTemplateTool uploadTemplateTool,
         ListTemplatesTool listTemplatesTool,
         UpdateTemplateTool updateTemplateTool,
-        DeleteTemplateTool deleteTemplateTool)
+        DeleteTemplateTool deleteTemplateTool,
+        // Feature 017: SCAP/STIG Import tools
+        ImportCklTool importCklTool,
+        ImportXccdfTool importXccdfTool,
+        ExportCklTool exportCklTool,
+        ListImportsTool listImportsTool,
+        GetImportSummaryTool getImportSummaryTool)
     {
         _assessmentTool = assessmentTool;
         _controlFamilyTool = controlFamilyTool;
@@ -440,6 +453,13 @@ public class ComplianceMcpTools
         _listTemplatesTool = listTemplatesTool;
         _updateTemplateTool = updateTemplateTool;
         _deleteTemplateTool = deleteTemplateTool;
+
+        // Feature 017: SCAP/STIG Import
+        _importCklTool = importCklTool;
+        _importXccdfTool = importXccdfTool;
+        _exportCklTool = exportCklTool;
+        _listImportsTool = listImportsTool;
+        _getImportSummaryTool = getImportSummaryTool;
     }
 
     [Description("Run a NIST 800-53 compliance assessment. Scan types: quick, policy, full.")]
@@ -2256,5 +2276,101 @@ public class ComplianceMcpTools
             ["template_id"] = templateId
         };
         return await _deleteTemplateTool.ExecuteAsync(args, cancellationToken);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Feature 017: SCAP/STIG Viewer Import
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Description("Import a DISA STIG Viewer CKL checklist file. Creates compliance findings, control effectiveness records, and evidence. Accepts base64-encoded file content (max 5 MB).")]
+    public async Task<string> ImportCklAsync(
+        string systemId,
+        string fileContent,
+        string fileName,
+        string? conflictResolution = null,
+        bool dryRun = false,
+        string? assessmentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["file_content"] = fileContent,
+            ["file_name"] = fileName,
+            ["conflict_resolution"] = conflictResolution,
+            ["dry_run"] = dryRun,
+            ["assessment_id"] = assessmentId
+        };
+        return await _importCklTool.ExecuteAsync(args, cancellationToken);
+    }
+
+    [Description("Import a SCAP Compliance Checker XCCDF results file. Creates compliance findings and control effectiveness records from automated scan results.")]
+    public async Task<string> ImportXccdfAsync(
+        string systemId,
+        string fileContent,
+        string fileName,
+        string? conflictResolution = null,
+        bool dryRun = false,
+        string? assessmentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["file_content"] = fileContent,
+            ["file_name"] = fileName,
+            ["conflict_resolution"] = conflictResolution,
+            ["dry_run"] = dryRun,
+            ["assessment_id"] = assessmentId
+        };
+        return await _importXccdfTool.ExecuteAsync(args, cancellationToken);
+    }
+
+    [Description("Export a CKL checklist file for a system and STIG benchmark. Returns base64-encoded XML content suitable for DISA STIG Viewer or eMASS upload.")]
+    public async Task<string> ExportCklAsync(
+        string systemId,
+        string benchmarkId,
+        string? assessmentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["benchmark_id"] = benchmarkId,
+            ["assessment_id"] = assessmentId
+        };
+        return await _exportCklTool.ExecuteAsync(args, cancellationToken);
+    }
+
+    [Description("List import history for a registered system. Shows CKL and XCCDF imports with summary statistics.")]
+    public async Task<string> ListImportsAsync(
+        string systemId,
+        int page = 1,
+        int pageSize = 20,
+        string? benchmarkId = null,
+        bool includeDryRuns = false,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["page"] = page,
+            ["page_size"] = pageSize,
+            ["benchmark_id"] = benchmarkId,
+            ["include_dry_runs"] = includeDryRuns
+        };
+        return await _listImportsTool.ExecuteAsync(args, cancellationToken);
+    }
+
+    [Description("Get detailed summary of a specific import operation, including per-finding breakdown and unmatched rules.")]
+    public async Task<string> GetImportSummaryAsync(
+        string importId,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["import_id"] = importId
+        };
+        return await _getImportSummaryTool.ExecuteAsync(args, cancellationToken);
     }
 }

--- a/tests/Ato.Copilot.Tests.Integration/Tools/ScanImportIntegrationTests.cs
+++ b/tests/Ato.Copilot.Tests.Integration/Tools/ScanImportIntegrationTests.cs
@@ -1,0 +1,371 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — Phase 10 (T060): SCAP/STIG Import Integration Tests
+// End-to-end: register → categorize → select baseline → import CKL →
+// verify findings → export CKL → re-import with Skip → no duplicates.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Agents.Compliance.Tools;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Tests.Integration.Tools;
+
+/// <summary>
+/// Full integration test for Feature 017 — SCAP/STIG Viewer Import.
+/// Uses real services (in-memory EF Core) with mocked IStigKnowledgeService.
+/// Validates the complete import → export → re-import lifecycle.
+/// </summary>
+public class ScanImportIntegrationTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly RegisterSystemTool _registerTool;
+    private readonly CategorizeSystemTool _categorizeTool;
+    private readonly SelectBaselineTool _selectBaselineTool;
+    private readonly ImportCklTool _importCklTool;
+    private readonly ExportCklTool _exportCklTool;
+    private readonly ListImportsTool _listImportsTool;
+    private readonly GetImportSummaryTool _getImportSummaryTool;
+    private readonly Mock<IStigKnowledgeService> _stigServiceMock;
+
+    // Known STIG controls that our mock will return
+    private static readonly StigControl StigAC2 = new StigControl(
+        StigId: "V-254239", VulnId: "V-254239", RuleId: "SV-254239r1_rule",
+        Title: "Windows Server 2022 must have the number of allowed bad logon attempts configured to three or less.",
+        Description: "Test STIG rule for AC-2", Severity: StigSeverity.High,
+        Category: "CAT I", StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "AC-7" },
+        CciRefs: new List<string> { "CCI-000044" },
+        CheckText: "Verify the number of allowed bad logon attempts.",
+        FixText: "Configure the policy to limit the number of bad logon attempts.",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "OS", BenchmarkId: "Windows_Server_2022_STIG");
+
+    private static readonly StigControl StigCM6 = new StigControl(
+        StigId: "V-254240", VulnId: "V-254240", RuleId: "SV-254240r1_rule",
+        Title: "Windows Server 2022 must be configured to audit logon successes.",
+        Description: "Test STIG rule for CM-6", Severity: StigSeverity.Medium,
+        Category: "CAT II", StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "CM-6" },
+        CciRefs: new List<string> { "CCI-000366" },
+        CheckText: "Verify audit logon successes is enabled.",
+        FixText: "Enable audit logon successes.",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "OS", BenchmarkId: "Windows_Server_2022_STIG");
+
+    private static readonly StigControl StigSC28 = new StigControl(
+        StigId: "V-254241", VulnId: "V-254241", RuleId: "SV-254241r1_rule",
+        Title: "Windows Server 2022 must be configured to prevent the storage of passwords using reversible encryption.",
+        Description: "Test STIG rule for SC-28", Severity: StigSeverity.High,
+        Category: "CAT I", StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "SC-28" },
+        CciRefs: new List<string> { "CCI-002476" },
+        CheckText: "Verify reversible encryption is disabled.",
+        FixText: "Disable reversible encryption.",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "OS", BenchmarkId: "Windows_Server_2022_STIG");
+
+    private static readonly List<StigControl> AllControls = new() { StigAC2, StigCM6, StigSC28 };
+
+    public ScanImportIntegrationTests()
+    {
+        var dbName = $"ScanImportIntTest_{Guid.NewGuid()}";
+        var services = new ServiceCollection();
+        services.AddDbContext<AtoCopilotContext>(opts =>
+            opts.UseInMemoryDatabase(dbName), ServiceLifetime.Scoped);
+        services.AddLogging();
+
+        _serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        // Real services
+        var lifecycleSvc = new RmfLifecycleService(scopeFactory, Mock.Of<ILogger<RmfLifecycleService>>());
+        var categorizationSvc = new CategorizationService(scopeFactory, Mock.Of<ILogger<CategorizationService>>());
+        var referenceDataSvc = new ReferenceDataService(Mock.Of<ILogger<ReferenceDataService>>());
+        var baselineSvc = new BaselineService(scopeFactory, referenceDataSvc, Mock.Of<ILogger<BaselineService>>());
+        var artifactSvc = new AssessmentArtifactService(scopeFactory, Mock.Of<ILogger<AssessmentArtifactService>>());
+
+        // Mock STIG knowledge service
+        _stigServiceMock = new Mock<IStigKnowledgeService>();
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254239", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StigAC2);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254240", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StigCM6);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254241", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StigSC28);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync(It.Is<string>(id =>
+                id != "V-254239" && id != "V-254240" && id != "V-254241"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlsByBenchmarkAsync("Windows_Server_2022_STIG", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AllControls);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+
+        // Real parsers & generator
+        var cklParser = new CklParser(Mock.Of<ILogger<CklParser>>());
+        var xccdfParser = new XccdfParser(Mock.Of<ILogger<XccdfParser>>());
+        var cklGenerator = new CklGenerator(Mock.Of<ILogger<CklGenerator>>());
+
+        var importSvc = new ScanImportService(
+            scopeFactory, _stigServiceMock.Object, baselineSvc, lifecycleSvc,
+            artifactSvc, cklParser, xccdfParser, cklGenerator,
+            Mock.Of<ILogger<ScanImportService>>());
+
+        // Tools
+        _registerTool = new RegisterSystemTool(lifecycleSvc, Mock.Of<ILogger<RegisterSystemTool>>());
+        _categorizeTool = new CategorizeSystemTool(categorizationSvc, Mock.Of<ILogger<CategorizeSystemTool>>());
+        _selectBaselineTool = new SelectBaselineTool(baselineSvc, Mock.Of<ILogger<SelectBaselineTool>>());
+        _importCklTool = new ImportCklTool(importSvc, scopeFactory, Mock.Of<ILogger<ImportCklTool>>());
+        _exportCklTool = new ExportCklTool(importSvc, Mock.Of<ILogger<ExportCklTool>>());
+        _listImportsTool = new ListImportsTool(importSvc, Mock.Of<ILogger<ListImportsTool>>());
+        _getImportSummaryTool = new GetImportSummaryTool(importSvc, Mock.Of<ILogger<GetImportSummaryTool>>());
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    /// <summary>
+    /// Full lifecycle: register → categorize → select baseline → import CKL →
+    /// verify findings → export CKL → re-import with Skip → verify no duplicates.
+    /// </summary>
+    [Fact]
+    public async Task FullScanImportLifecycle_CklImportExportReimport()
+    {
+        // ─── Step 1: Register system ──────────────────────────────────
+        var systemId = await RegisterSystem("STIG Import Test System", "MajorApplication");
+        systemId.Should().NotBeNullOrEmpty();
+
+        // ─── Step 2: Categorize as Moderate ───────────────────────────
+        await CategorizeSystem(systemId, "Moderate", "Moderate", "Low");
+
+        // ─── Step 3: Select baseline ──────────────────────────────────
+        var selectResult = await _selectBaselineTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["apply_overlay"] = true
+        });
+        var selectJson = JsonDocument.Parse(selectResult);
+        selectJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+
+        // ─── Step 4: Import CKL ──────────────────────────────────────
+        var cklXml = BuildTestCkl();
+        var cklBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(cklXml));
+
+        var importResult = await _importCklTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["file_content"] = cklBase64,
+            ["file_name"] = "windows_server_2022.ckl",
+            ["conflict_resolution"] = "Skip",
+            ["dry_run"] = false
+        });
+
+        var importJson = JsonDocument.Parse(importResult);
+        importJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+
+        var importData = importJson.RootElement.GetProperty("data");
+        var importRecordId = importData.GetProperty("import_record_id").GetString();
+        importRecordId.Should().NotBeNullOrEmpty();
+        importData.GetProperty("total_entries").GetInt32().Should().Be(3);
+
+        var summary = importData.GetProperty("summary");
+        summary.GetProperty("open").GetInt32().Should().Be(1);        // V-254239 is Open
+        summary.GetProperty("pass").GetInt32().Should().Be(1);        // V-254240 is NotAFinding
+        summary.GetProperty("not_applicable").GetInt32().Should().Be(1); // V-254241 is Not_Applicable
+
+        var changes = importData.GetProperty("changes");
+        changes.GetProperty("findings_created").GetInt32().Should().BeGreaterOrEqualTo(1);
+        changes.GetProperty("nist_controls_affected").GetInt32().Should().BeGreaterOrEqualTo(0);
+
+        // ─── Step 5: List imports ────────────────────────────────────
+        var listResult = await _listImportsTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId
+        });
+        var listJson = JsonDocument.Parse(listResult);
+        listJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+        listJson.RootElement.GetProperty("data").GetProperty("total_count").GetInt32().Should().Be(1);
+
+        // ─── Step 6: Get import summary ──────────────────────────────
+        var summaryResult = await _getImportSummaryTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["import_id"] = importRecordId
+        });
+        var summaryJson = JsonDocument.Parse(summaryResult);
+        summaryJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+        summaryJson.RootElement.GetProperty("data").GetProperty("file_name").GetString()
+            .Should().Be("windows_server_2022.ckl");
+
+        // ─── Step 7: Export CKL ──────────────────────────────────────
+        var exportResult = await _exportCklTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["benchmark_id"] = "Windows_Server_2022_STIG"
+        });
+        var exportJson = JsonDocument.Parse(exportResult);
+        exportJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+
+        var exportedBase64 = exportJson.RootElement.GetProperty("data")
+            .GetProperty("file_content").GetString();
+        exportedBase64.Should().NotBeNullOrEmpty();
+
+        // Verify exported CKL is valid XML with CHECKLIST root
+        var exportedXml = Encoding.UTF8.GetString(Convert.FromBase64String(exportedBase64!));
+        exportedXml.Should().Contain("<CHECKLIST>");
+        exportedXml.Should().Contain("V-254239");
+
+        // ─── Step 8: Re-import same CKL with Skip → no duplicates ───
+        var reimportResult = await _importCklTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["file_content"] = cklBase64,
+            ["file_name"] = "windows_server_2022_v2.ckl",
+            ["conflict_resolution"] = "Skip",
+            ["dry_run"] = false
+        });
+
+        var reimportJson = JsonDocument.Parse(reimportResult);
+        reimportJson.RootElement.GetProperty("status").GetString().Should().Be("success");
+
+        var reimportChanges = reimportJson.RootElement.GetProperty("data").GetProperty("changes");
+        // With Skip strategy, existing findings should be skipped (0 created)
+        reimportChanges.GetProperty("findings_created").GetInt32().Should().Be(0);
+
+        // ─── Step 9: Verify total import count is now 2 ─────────────
+        var finalListResult = await _listImportsTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId
+        });
+        var finalListJson = JsonDocument.Parse(finalListResult);
+        finalListJson.RootElement.GetProperty("data").GetProperty("total_count").GetInt32().Should().Be(2);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private async Task<string> RegisterSystem(string name, string type)
+    {
+        var result = await _registerTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["name"] = name,
+            ["system_type"] = type,
+            ["mission_criticality"] = "MissionCritical",
+            ["hosting_environment"] = "Government"
+        });
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        return json.RootElement.GetProperty("data").GetProperty("id").GetString()!;
+    }
+
+    private async Task CategorizeSystem(string systemId, string conf, string integ, string avail)
+    {
+        var result = await _categorizeTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = systemId,
+            ["information_types"] = new List<InformationTypeInput>
+            {
+                new()
+                {
+                    Sp80060Id = "C.3.5.8", Name = "Information Security",
+                    Category = "Management and Support",
+                    ConfidentialityImpact = conf, IntegrityImpact = integ, AvailabilityImpact = avail
+                }
+            },
+            ["justification"] = "Integration test categorization"
+        });
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    /// <summary>
+    /// Builds a minimal but valid CKL XML with 3 VULNs:
+    /// V-254239 (Open, high), V-254240 (NotAFinding, medium), V-254241 (Not_Applicable, high).
+    /// </summary>
+    private static string BuildTestCkl()
+    {
+        return @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <ASSET>
+    <ROLE>None</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>test-server-01</HOST_NAME>
+    <HOST_IP>10.0.1.100</HOST_IP>
+    <HOST_MAC>00:0A:95:9D:68:16</HOST_MAC>
+    <HOST_FQDN>test-server-01.example.mil</HOST_FQDN>
+    <TARGET_COMMENT></TARGET_COMMENT>
+    <TECH_AREA></TECH_AREA>
+    <TARGET_KEY>4089</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+    <WEB_DB_SITE></WEB_DB_SITE>
+    <WEB_DB_INSTANCE></WEB_DB_INSTANCE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA><SID_NAME>version</SID_NAME><SID_DATA>3</SID_DATA></SI_DATA>
+        <SI_DATA><SID_NAME>stigid</SID_NAME><SID_DATA>Windows_Server_2022_STIG</SID_DATA></SI_DATA>
+        <SI_DATA><SID_NAME>releaseinfo</SID_NAME><SID_DATA>Release: 1</SID_DATA></SI_DATA>
+        <SI_DATA><SID_NAME>title</SID_NAME><SID_DATA>Microsoft Windows Server 2022 STIG</SID_DATA></SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-254239</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE><ATTRIBUTE_DATA>high</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SRG-OS-000003</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SV-254239r1_rule</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Bad logon attempts</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE><ATTRIBUTE_DATA>WN22-AC-000010</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE><ATTRIBUTE_DATA>CCI-000044</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Verify logon attempts</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Configure logon attempts</ATTRIBUTE_DATA></STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>Found 10 allowed attempts</FINDING_DETAILS>
+        <COMMENTS>Needs remediation</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <VULN>
+        <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-254240</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE><ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SRG-OS-000037</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SV-254240r1_rule</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Audit logon successes</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE><ATTRIBUTE_DATA>WN22-AU-000010</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE><ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Verify audit settings</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Enable audit logon</ATTRIBUTE_DATA></STIG_DATA>
+        <STATUS>NotAFinding</STATUS>
+        <FINDING_DETAILS>Audit logon enabled</FINDING_DETAILS>
+        <COMMENTS>Verified</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <VULN>
+        <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-254241</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE><ATTRIBUTE_DATA>high</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SRG-OS-000405</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE><ATTRIBUTE_DATA>SV-254241r1_rule</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Reversible encryption</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE><ATTRIBUTE_DATA>WN22-SO-000010</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE><ATTRIBUTE_DATA>CCI-002476</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Verify encryption</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Disable reversible encryption</ATTRIBUTE_DATA></STIG_DATA>
+        <STATUS>Not_Applicable</STATUS>
+        <FINDING_DETAILS>N/A for this config</FINDING_DETAILS>
+        <COMMENTS>Not applicable</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>";
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Ato.Copilot.Tests.Unit.csproj
+++ b/tests/Ato.Copilot.Tests.Unit/Ato.Copilot.Tests.Unit.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\..\src\Ato.Copilot.Channels\Ato.Copilot.Channels.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="TestData\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Ato.Copilot.Tests.Unit/Models/ScanImportModelTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Models/ScanImportModelTests.cs
@@ -1,0 +1,410 @@
+using Xunit;
+using FluentAssertions;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Tests.Unit.Models;
+
+/// <summary>
+/// Unit tests for Feature 017 — SCAP/STIG Viewer Import entities, enums, and DTOs.
+/// Validates default values, enum members, and record immutability.
+/// </summary>
+public class ScanImportModelTests
+{
+    // ─── ScanImportType Enum ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ScanImportType_Should_Have_Ckl_And_Xccdf()
+    {
+        Enum.GetValues<ScanImportType>().Should().HaveCount(2);
+        Enum.IsDefined(ScanImportType.Ckl).Should().BeTrue();
+        Enum.IsDefined(ScanImportType.Xccdf).Should().BeTrue();
+    }
+
+    // ─── ScanImportStatus Enum ───────────────────────────────────────────────
+
+    [Fact]
+    public void ScanImportStatus_Should_Have_Three_Values()
+    {
+        Enum.GetValues<ScanImportStatus>().Should().HaveCount(3);
+        Enum.IsDefined(ScanImportStatus.Completed).Should().BeTrue();
+        Enum.IsDefined(ScanImportStatus.CompletedWithWarnings).Should().BeTrue();
+        Enum.IsDefined(ScanImportStatus.Failed).Should().BeTrue();
+    }
+
+    // ─── ImportConflictResolution Enum ───────────────────────────────────────
+
+    [Fact]
+    public void ImportConflictResolution_Should_Have_Three_Strategies()
+    {
+        Enum.GetValues<ImportConflictResolution>().Should().HaveCount(3);
+        Enum.IsDefined(ImportConflictResolution.Skip).Should().BeTrue();
+        Enum.IsDefined(ImportConflictResolution.Overwrite).Should().BeTrue();
+        Enum.IsDefined(ImportConflictResolution.Merge).Should().BeTrue();
+    }
+
+    // ─── ImportFindingAction Enum ────────────────────────────────────────────
+
+    [Fact]
+    public void ImportFindingAction_Should_Have_Seven_Values()
+    {
+        Enum.GetValues<ImportFindingAction>().Should().HaveCount(7);
+        Enum.IsDefined(ImportFindingAction.Created).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.Updated).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.Skipped).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.Unmatched).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.NotApplicable).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.NotReviewed).Should().BeTrue();
+        Enum.IsDefined(ImportFindingAction.Error).Should().BeTrue();
+    }
+
+    // ─── ScanImportRecord Entity ─────────────────────────────────────────────
+
+    [Fact]
+    public void ScanImportRecord_Should_Have_Generated_Id()
+    {
+        var record = new ScanImportRecord();
+        record.Id.Should().NotBeNullOrEmpty();
+        Guid.TryParse(record.Id, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ScanImportRecord_Should_Have_Default_Values()
+    {
+        var record = new ScanImportRecord();
+
+        record.RegisteredSystemId.Should().Be(string.Empty);
+        record.AssessmentId.Should().Be(string.Empty);
+        record.FileName.Should().Be(string.Empty);
+        record.FileHash.Should().Be(string.Empty);
+        record.FileSizeBytes.Should().Be(0);
+        record.IsDryRun.Should().BeFalse();
+        record.ImportedBy.Should().Be(string.Empty);
+        record.Warnings.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void ScanImportRecord_Should_Have_Nullable_Optional_Fields()
+    {
+        var record = new ScanImportRecord();
+
+        record.BenchmarkId.Should().BeNull();
+        record.BenchmarkVersion.Should().BeNull();
+        record.BenchmarkTitle.Should().BeNull();
+        record.TargetHostName.Should().BeNull();
+        record.TargetIpAddress.Should().BeNull();
+        record.ScanTimestamp.Should().BeNull();
+        record.XccdfScore.Should().BeNull();
+        record.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void ScanImportRecord_Should_Default_Counts_To_Zero()
+    {
+        var record = new ScanImportRecord();
+
+        record.TotalEntries.Should().Be(0);
+        record.OpenCount.Should().Be(0);
+        record.PassCount.Should().Be(0);
+        record.NotApplicableCount.Should().Be(0);
+        record.NotReviewedCount.Should().Be(0);
+        record.ErrorCount.Should().Be(0);
+        record.SkippedCount.Should().Be(0);
+        record.UnmatchedCount.Should().Be(0);
+        record.FindingsCreated.Should().Be(0);
+        record.FindingsUpdated.Should().Be(0);
+        record.EffectivenessRecordsCreated.Should().Be(0);
+        record.EffectivenessRecordsUpdated.Should().Be(0);
+        record.NistControlsAffected.Should().Be(0);
+    }
+
+    [Fact]
+    public void ScanImportRecord_Two_Instances_Should_Have_Unique_Ids()
+    {
+        var record1 = new ScanImportRecord();
+        var record2 = new ScanImportRecord();
+        record1.Id.Should().NotBe(record2.Id);
+    }
+
+    [Fact]
+    public void ScanImportRecord_ImportedAt_Should_Be_Close_To_UtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var record = new ScanImportRecord();
+        var after = DateTime.UtcNow;
+
+        record.ImportedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    // ─── ScanImportFinding Entity ────────────────────────────────────────────
+
+    [Fact]
+    public void ScanImportFinding_Should_Have_Generated_Id()
+    {
+        var finding = new ScanImportFinding();
+        finding.Id.Should().NotBeNullOrEmpty();
+        Guid.TryParse(finding.Id, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ScanImportFinding_Should_Have_Default_Values()
+    {
+        var finding = new ScanImportFinding();
+
+        finding.ScanImportRecordId.Should().Be(string.Empty);
+        finding.VulnId.Should().Be(string.Empty);
+        finding.RawStatus.Should().Be(string.Empty);
+        finding.RawSeverity.Should().Be(string.Empty);
+        finding.ResolvedNistControlIds.Should().NotBeNull().And.BeEmpty();
+        finding.ResolvedCciRefs.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void ScanImportFinding_Should_Have_Nullable_Optional_Fields()
+    {
+        var finding = new ScanImportFinding();
+
+        finding.RuleId.Should().BeNull();
+        finding.StigVersion.Should().BeNull();
+        finding.MappedSeverity.Should().BeNull();
+        finding.FindingDetails.Should().BeNull();
+        finding.Comments.Should().BeNull();
+        finding.SeverityOverride.Should().BeNull();
+        finding.SeverityJustification.Should().BeNull();
+        finding.ResolvedStigControlId.Should().BeNull();
+        finding.ComplianceFindingId.Should().BeNull();
+    }
+
+    // ─── ComplianceFinding.ImportRecordId FK ─────────────────────────────────
+
+    [Fact]
+    public void ComplianceFinding_ImportRecordId_Should_Be_Nullable()
+    {
+        var finding = new ComplianceFinding();
+        finding.ImportRecordId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ComplianceFinding_ImportRecordId_Should_Accept_Value()
+    {
+        var finding = new ComplianceFinding { ImportRecordId = "test-import-id" };
+        finding.ImportRecordId.Should().Be("test-import-id");
+    }
+
+    // ─── ParsedCklEntry DTO ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ParsedCklEntry_Should_Store_All_Fields()
+    {
+        var cciRefs = new List<string> { "CCI-000366", "CCI-001084" };
+        var entry = new ParsedCklEntry(
+            VulnId: "V-254239",
+            RuleId: "SV-254239r849090_rule",
+            StigVersion: "WN22-AU-000010",
+            RuleTitle: "Test Rule",
+            Severity: "high",
+            Status: "Open",
+            FindingDetails: "Finding details text",
+            Comments: "Assessor comments",
+            SeverityOverride: "medium",
+            SeverityJustification: "Override justification",
+            CciRefs: cciRefs,
+            GroupTitle: "SRG-OS-000037-GPOS-00015");
+
+        entry.VulnId.Should().Be("V-254239");
+        entry.RuleId.Should().Be("SV-254239r849090_rule");
+        entry.StigVersion.Should().Be("WN22-AU-000010");
+        entry.RuleTitle.Should().Be("Test Rule");
+        entry.Severity.Should().Be("high");
+        entry.Status.Should().Be("Open");
+        entry.FindingDetails.Should().Be("Finding details text");
+        entry.Comments.Should().Be("Assessor comments");
+        entry.SeverityOverride.Should().Be("medium");
+        entry.SeverityJustification.Should().Be("Override justification");
+        entry.CciRefs.Should().BeEquivalentTo(cciRefs);
+        entry.GroupTitle.Should().Be("SRG-OS-000037-GPOS-00015");
+    }
+
+    [Fact]
+    public void ParsedCklEntry_Should_Allow_Null_Optional_Fields()
+    {
+        var entry = new ParsedCklEntry(
+            VulnId: "V-100000",
+            RuleId: null,
+            StigVersion: null,
+            RuleTitle: null,
+            Severity: "low",
+            Status: "Not_Reviewed",
+            FindingDetails: null,
+            Comments: null,
+            SeverityOverride: null,
+            SeverityJustification: null,
+            CciRefs: new List<string>(),
+            GroupTitle: null);
+
+        entry.RuleId.Should().BeNull();
+        entry.StigVersion.Should().BeNull();
+        entry.CciRefs.Should().BeEmpty();
+    }
+
+    // ─── ParsedCklFile DTO ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParsedCklFile_Should_Compose_Asset_StigInfo_Entries()
+    {
+        var asset = new CklAssetInfo("server01", "10.0.0.1", "server01.domain.com", "00:11:22:33:44:55", "Computing", "4000");
+        var stigInfo = new CklStigInfo("Windows_Server_2022_STIG", "V2R1", "Release: 1 Benchmark Date: 01 Jan 2026", "Windows Server 2022 STIG");
+        var entries = new List<ParsedCklEntry>();
+
+        var file = new ParsedCklFile(asset, stigInfo, entries);
+
+        file.Asset.HostName.Should().Be("server01");
+        file.StigInfo.StigId.Should().Be("Windows_Server_2022_STIG");
+        file.Entries.Should().BeEmpty();
+    }
+
+    // ─── CklAssetInfo DTO ────────────────────────────────────────────────────
+
+    [Fact]
+    public void CklAssetInfo_Should_Allow_All_Nulls()
+    {
+        var asset = new CklAssetInfo(null, null, null, null, null, null);
+        asset.HostName.Should().BeNull();
+        asset.HostIp.Should().BeNull();
+        asset.HostFqdn.Should().BeNull();
+        asset.HostMac.Should().BeNull();
+        asset.AssetType.Should().BeNull();
+        asset.TargetKey.Should().BeNull();
+    }
+
+    // ─── CklStigInfo DTO ────────────────────────────────────────────────────
+
+    [Fact]
+    public void CklStigInfo_Should_Allow_All_Nulls()
+    {
+        var info = new CklStigInfo(null, null, null, null);
+        info.StigId.Should().BeNull();
+        info.Version.Should().BeNull();
+        info.ReleaseInfo.Should().BeNull();
+        info.Title.Should().BeNull();
+    }
+
+    // ─── ParsedXccdfResult DTO ───────────────────────────────────────────────
+
+    [Fact]
+    public void ParsedXccdfResult_Should_Store_All_Fields()
+    {
+        var result = new ParsedXccdfResult(
+            RuleIdRef: "xccdf_mil.disa.stig_rule_SV-254239r849090_rule",
+            ExtractedRuleId: "SV-254239r849090_rule",
+            Result: "fail",
+            Severity: "high",
+            Weight: 10.0m,
+            Timestamp: new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc),
+            Message: "Check failed: audit policy not configured",
+            CheckRef: "oval:mil.disa.stig.windows_server_2022:def:254239");
+
+        result.RuleIdRef.Should().Contain("xccdf_mil.disa.stig_rule_");
+        result.ExtractedRuleId.Should().Be("SV-254239r849090_rule");
+        result.Result.Should().Be("fail");
+        result.Severity.Should().Be("high");
+        result.Weight.Should().Be(10.0m);
+        result.Timestamp.Should().NotBeNull();
+        result.Message.Should().NotBeNullOrEmpty();
+        result.CheckRef.Should().Contain("oval:");
+    }
+
+    // ─── ParsedXccdfFile DTO ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParsedXccdfFile_Should_Compose_Results_And_Facts()
+    {
+        var facts = new Dictionary<string, string>
+        {
+            ["urn:xccdf:fact:asset:identifier:fqdn"] = "server01.domain.com",
+            ["urn:xccdf:fact:asset:identifier:os_name"] = "Windows Server 2022"
+        };
+
+        var file = new ParsedXccdfFile(
+            BenchmarkHref: "Windows_Server_2022_STIG",
+            Title: "XCCDF Result for Windows Server 2022",
+            Target: "server01",
+            TargetAddress: "10.0.0.1",
+            StartTime: DateTime.UtcNow.AddMinutes(-5),
+            EndTime: DateTime.UtcNow,
+            Score: 85.5m,
+            MaxScore: 100.0m,
+            TargetFacts: facts,
+            Results: new List<ParsedXccdfResult>());
+
+        file.BenchmarkHref.Should().NotBeNullOrEmpty();
+        file.Score.Should().Be(85.5m);
+        file.MaxScore.Should().Be(100.0m);
+        file.TargetFacts.Should().HaveCount(2);
+        file.Results.Should().BeEmpty();
+    }
+
+    // ─── ImportResult DTO ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ImportResult_Should_Store_All_Counts_And_Warnings()
+    {
+        var warnings = new List<string> { "Unmatched rule: V-999999" };
+        var unmatched = new List<UnmatchedRuleInfo>
+        {
+            new("V-999999", "SV-999999r1_rule", "Unknown Rule", "high")
+        };
+
+        var result = new ImportResult(
+            ImportRecordId: "import-001",
+            Status: ScanImportStatus.CompletedWithWarnings,
+            BenchmarkId: "Windows_Server_2022_STIG",
+            BenchmarkTitle: "Windows Server 2022 STIG",
+            TotalEntries: 100,
+            OpenCount: 10,
+            PassCount: 80,
+            NotApplicableCount: 5,
+            NotReviewedCount: 3,
+            ErrorCount: 0,
+            SkippedCount: 1,
+            UnmatchedCount: 1,
+            FindingsCreated: 13,
+            FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 8,
+            EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 8,
+            Warnings: warnings,
+            UnmatchedRules: unmatched,
+            ErrorMessage: null);
+
+        result.ImportRecordId.Should().Be("import-001");
+        result.Status.Should().Be(ScanImportStatus.CompletedWithWarnings);
+        result.TotalEntries.Should().Be(100);
+        result.OpenCount.Should().Be(10);
+        result.PassCount.Should().Be(80);
+        result.UnmatchedCount.Should().Be(1);
+        result.Warnings.Should().HaveCount(1);
+        result.UnmatchedRules.Should().HaveCount(1);
+        result.UnmatchedRules[0].VulnId.Should().Be("V-999999");
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    // ─── UnmatchedRuleInfo DTO ───────────────────────────────────────────────
+
+    [Fact]
+    public void UnmatchedRuleInfo_Should_Store_All_Fields()
+    {
+        var info = new UnmatchedRuleInfo("V-254239", "SV-254239r849090_rule", "Audit Policy", "high");
+        info.VulnId.Should().Be("V-254239");
+        info.RuleId.Should().Be("SV-254239r849090_rule");
+        info.RuleTitle.Should().Be("Audit Policy");
+        info.Severity.Should().Be("high");
+    }
+
+    [Fact]
+    public void UnmatchedRuleInfo_Should_Allow_Null_Optional_Fields()
+    {
+        var info = new UnmatchedRuleInfo("V-100000", null, null, "low");
+        info.RuleId.Should().BeNull();
+        info.RuleTitle.Should().BeNull();
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Parsers/CklParserTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Parsers/CklParserTests.cs
@@ -1,0 +1,398 @@
+using Xunit;
+using FluentAssertions;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Tests.Unit.Parsers;
+
+/// <summary>
+/// Unit tests for <see cref="CklParser"/> — Feature 017 CKL XML parsing.
+/// Covers valid files, malformed XML, severity overrides, edge cases.
+/// </summary>
+public class CklParserTests
+{
+    private readonly CklParser _parser;
+
+    public CklParserTests()
+    {
+        _parser = new CklParser(Mock.Of<ILogger<CklParser>>());
+    }
+
+    /// <summary>Helper to load test data file from TestData directory.</summary>
+    private static byte[] LoadTestFile(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+        return File.ReadAllBytes(path);
+    }
+
+    /// <summary>Helper to create CKL XML bytes from a string.</summary>
+    private static byte[] CklBytes(string xml)
+    {
+        return System.Text.Encoding.UTF8.GetBytes(xml);
+    }
+
+    // ─── Valid CKL Parsing ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_CorrectEntryCount()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        result.Entries.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_CorrectStatuses()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        result.Entries.Count(e => e.Status == "Open").Should().Be(2);
+        result.Entries.Count(e => e.Status == "NotAFinding").Should().Be(2);
+        result.Entries.Count(e => e.Status == "Not_Applicable").Should().Be(1);
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_CorrectSeverities()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.Severity.Should().Be("high");
+
+        var v254240 = result.Entries.First(e => e.VulnId == "V-254240");
+        v254240.Severity.Should().Be("medium");
+
+        var v254242 = result.Entries.First(e => e.VulnId == "V-254242");
+        v254242.Severity.Should().Be("low");
+    }
+
+    // ─── ASSET Section ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_CorrectAssetInfo()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        result.Asset.HostName.Should().Be("web-server-01");
+        result.Asset.HostIp.Should().Be("10.0.1.100");
+        result.Asset.HostFqdn.Should().Be("web-server-01.example.mil");
+        result.Asset.HostMac.Should().Be("00:0A:95:9D:68:16");
+        result.Asset.AssetType.Should().Be("Computing");
+        result.Asset.TargetKey.Should().Be("4089");
+    }
+
+    // ─── STIG_INFO Section ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_CorrectStigInfo()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        result.StigInfo.StigId.Should().Be("Windows_Server_2022_STIG");
+        result.StigInfo.Version.Should().Be("3");
+        result.StigInfo.ReleaseInfo.Should().Contain("Release: 1");
+        result.StigInfo.Title.Should().Contain("Windows Server 2022");
+    }
+
+    // ─── CCI References ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_MultipleCciRefs()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.CciRefs.Should().HaveCount(2);
+        v254239.CciRefs.Should().Contain("CCI-000018");
+        v254239.CciRefs.Should().Contain("CCI-000172");
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_SingleCciRef()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254240 = result.Entries.First(e => e.VulnId == "V-254240");
+        v254240.CciRefs.Should().HaveCount(1);
+        v254240.CciRefs.Should().Contain("CCI-000067");
+    }
+
+    // ─── VULN Detail Fields ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_RuleIdAndVersion()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.RuleId.Should().Be("SV-254239r849090_rule");
+        v254239.StigVersion.Should().Be("WN22-AU-000010");
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_FindingDetails()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.FindingDetails.Should().Contain("Audit policy not configured");
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_Comments()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.Comments.Should().Contain("Sprint 42");
+    }
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_GroupTitle()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.GroupTitle.Should().Be("SRG-OS-000003-GPOS-00004");
+    }
+
+    // ─── Severity Override ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_SeverityOverrideCkl_Returns_OverrideValues()
+    {
+        var content = LoadTestFile("sample-severity-override.ckl");
+        var result = _parser.Parse(content, "sample-severity-override.ckl");
+
+        result.Entries.Should().HaveCount(1);
+        var entry = result.Entries[0];
+
+        entry.VulnId.Should().Be("V-254250");
+        entry.Severity.Should().Be("medium"); // Original severity
+        entry.SeverityOverride.Should().Be("high");
+        entry.SeverityJustification.Should().Contain("public-facing network segment");
+    }
+
+    // ─── Malformed XML ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MalformedXml_Throws_CklParseException()
+    {
+        var content = LoadTestFile("sample-malformed.ckl");
+
+        var act = () => _parser.Parse(content, "sample-malformed.ckl");
+
+        act.Should().Throw<CklParseException>()
+            .Which.FileName.Should().Be("sample-malformed.ckl");
+    }
+
+    [Fact]
+    public void Parse_MalformedXml_Exception_Contains_DescriptiveMessage()
+    {
+        var content = LoadTestFile("sample-malformed.ckl");
+
+        var act = () => _parser.Parse(content, "sample-malformed.ckl");
+
+        act.Should().Throw<CklParseException>()
+            .WithMessage("*Malformed XML*");
+    }
+
+    // ─── Empty VULN List ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_EmptyVulnList_Returns_EmptyEntries()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <ASSET><HOST_NAME>empty-server</HOST_NAME></ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA><SID_NAME>stigid</SID_NAME><SID_DATA>Empty_STIG</SID_DATA></SI_DATA>
+      </STIG_INFO>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>";
+
+        var result = _parser.Parse(CklBytes(xml), "empty.ckl");
+
+        result.Entries.Should().BeEmpty();
+        result.StigInfo.StigId.Should().Be("Empty_STIG");
+        result.Asset.HostName.Should().Be("empty-server");
+    }
+
+    // ─── Not_Reviewed Status ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NotReviewedStatus_Returns_CorrectMapping()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <ASSET><HOST_NAME>test</HOST_NAME></ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA><SID_NAME>stigid</SID_NAME><SID_DATA>Test_STIG</SID_DATA></SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-100001</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE><ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA></STIG_DATA>
+        <STATUS>Not_Reviewed</STATUS>
+        <FINDING_DETAILS></FINDING_DETAILS>
+        <COMMENTS></COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>";
+
+        var result = _parser.Parse(CklBytes(xml), "not-reviewed.ckl");
+
+        result.Entries.Should().HaveCount(1);
+        result.Entries[0].Status.Should().Be("Not_Reviewed");
+        result.Entries[0].VulnId.Should().Be("V-100001");
+    }
+
+    // ─── Missing Optional Fields ─────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MissingOptionalFields_Returns_NullValues()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <ASSET><HOST_NAME>minimal</HOST_NAME></ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA><SID_NAME>stigid</SID_NAME><SID_DATA>Minimal_STIG</SID_DATA></SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-100002</ATTRIBUTE_DATA></STIG_DATA>
+        <STIG_DATA><VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE><ATTRIBUTE_DATA>low</ATTRIBUTE_DATA></STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS></FINDING_DETAILS>
+        <COMMENTS></COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>";
+
+        var result = _parser.Parse(CklBytes(xml), "minimal.ckl");
+
+        var entry = result.Entries[0];
+        entry.RuleId.Should().BeNull();
+        entry.StigVersion.Should().BeNull();
+        entry.RuleTitle.Should().BeNull();
+        entry.FindingDetails.Should().BeNull();
+        entry.Comments.Should().BeNull();
+        entry.SeverityOverride.Should().BeNull();
+        entry.SeverityJustification.Should().BeNull();
+        entry.GroupTitle.Should().BeNull();
+        entry.CciRefs.Should().BeEmpty();
+    }
+
+    // ─── Missing CHECKLIST Root ──────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MissingChecklistRoot_Throws_CklParseException()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<NOTACHECKLIST>
+  <STIGS><iSTIG><STIG_INFO></STIG_INFO></iSTIG></STIGS>
+</NOTACHECKLIST>";
+
+        var act = () => _parser.Parse(CklBytes(xml), "bad-root.ckl");
+
+        act.Should().Throw<CklParseException>()
+            .WithMessage("*Missing root*CHECKLIST*");
+    }
+
+    // ─── Missing STIGS/iSTIG ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MissingISTIG_Throws_CklParseException()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <ASSET><HOST_NAME>test</HOST_NAME></ASSET>
+</CHECKLIST>";
+
+        var act = () => _parser.Parse(CklBytes(xml), "no-stigs.ckl");
+
+        act.Should().Throw<CklParseException>()
+            .WithMessage("*Missing*iSTIG*");
+    }
+
+    // ─── Missing ASSET ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MissingAsset_Returns_NullAssetFields()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<CHECKLIST>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA><SID_NAME>stigid</SID_NAME><SID_DATA>NoAsset_STIG</SID_DATA></SI_DATA>
+      </STIG_INFO>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>";
+
+        var result = _parser.Parse(CklBytes(xml), "no-asset.ckl");
+
+        result.Asset.HostName.Should().BeNull();
+        result.Asset.HostIp.Should().BeNull();
+    }
+
+    // ─── Empty File ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_EmptyBytes_Throws_CklParseException()
+    {
+        var act = () => _parser.Parse(Array.Empty<byte>(), "empty.ckl");
+
+        act.Should().Throw<CklParseException>();
+    }
+
+    // ─── RuleTitle Parsing ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_Returns_RuleTitle()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        var v254239 = result.Entries.First(e => e.VulnId == "V-254239");
+        v254239.RuleTitle.Should().Contain("audit Account Management");
+    }
+
+    // ─── Empty Comments/FindingDetails Become Null ───────────────────────────
+
+    [Fact]
+    public void Parse_ValidCkl_EmptyComments_BecomesNull()
+    {
+        var content = LoadTestFile("sample-valid.ckl");
+        var result = _parser.Parse(content, "sample-valid.ckl");
+
+        // V-254240 has empty COMMENTS
+        var v254240 = result.Entries.First(e => e.VulnId == "V-254240");
+        v254240.Comments.Should().BeNull();
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Parsers/XccdfParserTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Parsers/XccdfParserTests.cs
@@ -1,0 +1,410 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Import: XCCDF Parser Tests (T041)
+// Covers valid parsing, namespace handling, rule ID extraction,
+// score parsing, target info, malformed XML, edge cases.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using Xunit;
+using FluentAssertions;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Core.Models.Compliance;
+using System.Text;
+
+namespace Ato.Copilot.Tests.Unit.Parsers;
+
+/// <summary>
+/// Unit tests for <see cref="XccdfParser"/> — Feature 017 XCCDF XML parsing.
+/// </summary>
+public class XccdfParserTests
+{
+    private readonly XccdfParser _parser;
+
+    public XccdfParserTests()
+    {
+        _parser = new XccdfParser(Mock.Of<ILogger<XccdfParser>>());
+    }
+
+    /// <summary>Helper to load test data file from TestData directory.</summary>
+    private static byte[] LoadTestFile(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+        return File.ReadAllBytes(path);
+    }
+
+    /// <summary>Helper to create XCCDF XML bytes from a string.</summary>
+    private static byte[] XccdfBytes(string xml) => Encoding.UTF8.GetBytes(xml);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Valid XCCDF Parsing (sample-valid.xccdf)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectResultCount()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Results.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectResultBreakdown()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Results.Count(r => r.Result == "fail").Should().Be(2);
+        result.Results.Count(r => r.Result == "pass").Should().Be(2);
+        result.Results.Count(r => r.Result == "notapplicable").Should().Be(1);
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectTarget()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Target.Should().Be("web-server-01");
+        result.TargetAddress.Should().Be("10.0.1.100");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectScore()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Score.Should().Be(72.5m);
+        result.MaxScore.Should().Be(100m);
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectBenchmarkHref()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.BenchmarkHref.Should().Be("xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectTitle()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Title.Should().Be("SCAP SCC Scan Results - Windows Server 2022");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_TargetFacts()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.TargetFacts.Should().ContainKey("urn:scap:fact:asset:identifier:host_name");
+        result.TargetFacts["urn:scap:fact:asset:identifier:host_name"].Should().Be("web-server-01");
+        result.TargetFacts.Should().ContainKey("urn:scap:fact:asset:identifier:os_name");
+        result.TargetFacts["urn:scap:fact:asset:identifier:os_name"].Should().Be("Microsoft Windows Server 2022");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_Returns_CorrectTimestamps()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.StartTime.Should().NotBeNull();
+        result.EndTime.Should().NotBeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Rule-Result Detail Parsing
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_ValidXccdf_ExtractsRuleIdsCorrectly()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        var firstResult = result.Results[0];
+        firstResult.RuleIdRef.Should().Be("xccdf_mil.disa.stig_rule_SV-254239r849090_rule");
+        firstResult.ExtractedRuleId.Should().Be("SV-254239r849090_rule");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_CapsSeverityToLowerCase()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        // Severities in test data: high, medium, medium, low, medium
+        result.Results[0].Severity.Should().Be("high");
+        result.Results[1].Severity.Should().Be("medium");
+        result.Results[3].Severity.Should().Be("low");
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_ParsesWeight()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Results.Should().OnlyContain(r => r.Weight == 10.0m);
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_ParsesMessage()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Results[0].Message.Should().Be("Registry value not configured as expected.");
+        result.Results[1].Message.Should().Be("Audit policy not properly configured.");
+        // Pass results have no message
+        result.Results[2].Message.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_ParsesCheckRef()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        // Only rule 1 has a check element
+        result.Results[0].CheckRef.Should().Be("oval:mil.disa.stig.windows_server_2022:def:254239");
+        result.Results[1].CheckRef.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_ValidXccdf_ParsesPerRuleTimestamp()
+    {
+        var content = LoadTestFile("sample-valid.xccdf");
+        var result = _parser.Parse(content, "sample-valid.xccdf");
+
+        result.Results[0].Timestamp.Should().NotBeNull();
+        result.Results[2].Timestamp.Should().NotBeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Rule ID Extraction (ExtractRuleId)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("xccdf_mil.disa.stig_rule_SV-254239r849090_rule", "SV-254239r849090_rule")]
+    [InlineData("SV-254239r849090_rule", "SV-254239r849090_rule")]
+    [InlineData("custom_rule_id", "custom_rule_id")]
+    [InlineData("", "")]
+    public void ExtractRuleId_ReturnsExpected(string input, string expected)
+    {
+        var result = XccdfParser.ExtractRuleId(input);
+        result.Should().Be(expected);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // XCCDF 1.1 Namespace Support
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_Xccdf11Namespace_ParsesSuccessfully()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult xmlns=""http://checklists.nist.gov/xccdf/1.1""
+            id=""test_result_1"">
+  <target>test-host</target>
+  <rule-result idref=""SV-100001r111111_rule"" severity=""high"" weight=""10.0"">
+    <result>fail</result>
+  </rule-result>
+  <score system=""urn:xccdf:scoring:default"" maximum=""100"">50.0</score>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "test-1.1.xccdf");
+
+        result.Target.Should().Be("test-host");
+        result.Results.Should().HaveCount(1);
+        result.Results[0].Result.Should().Be("fail");
+        result.Score.Should().Be(50.0m);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Benchmark-Wrapped TestResult
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_BenchmarkWrappedTestResult_ParsesSuccessfully()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Benchmark xmlns=""http://checklists.nist.gov/xccdf/1.2""
+           id=""xccdf_mil.disa.stig_benchmark_Test"">
+  <TestResult id=""test_result_1"">
+    <target>benchmark-host</target>
+    <rule-result idref=""xccdf_mil.disa.stig_rule_SV-200001r222222_rule"" severity=""medium"" weight=""10.0"">
+      <result>pass</result>
+    </rule-result>
+    <score system=""urn:xccdf:scoring:default"" maximum=""100"">100.0</score>
+  </TestResult>
+</Benchmark>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "benchmark.xccdf");
+
+        result.Target.Should().Be("benchmark-host");
+        result.Results.Should().HaveCount(1);
+        result.Results[0].ExtractedRuleId.Should().Be("SV-200001r222222_rule");
+        result.Results[0].Result.Should().Be("pass");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // No-Namespace Support
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_NoNamespace_ParsesSuccessfully()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult id=""test_result_1"">
+  <target>no-ns-host</target>
+  <rule-result idref=""SV-300001r333333_rule"" severity=""low"" weight=""5.0"">
+    <result>notapplicable</result>
+  </rule-result>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "no-ns.xccdf");
+
+        result.Target.Should().Be("no-ns-host");
+        result.Results.Should().HaveCount(1);
+        result.Results[0].Result.Should().Be("notapplicable");
+        result.Results[0].Weight.Should().Be(5.0m);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Error / Edge Cases
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_EmptyContent_Throws_XccdfParseException()
+    {
+        var act = () => _parser.Parse(Array.Empty<byte>(), "empty.xccdf");
+
+        act.Should().Throw<XccdfParseException>()
+            .Which.FileName.Should().Be("empty.xccdf");
+    }
+
+    [Fact]
+    public void Parse_NullContent_Throws_XccdfParseException()
+    {
+        var act = () => _parser.Parse(null!, "null.xccdf");
+
+        act.Should().Throw<XccdfParseException>()
+            .Which.FileName.Should().Be("null.xccdf");
+    }
+
+    [Fact]
+    public void Parse_MalformedXml_Throws_XccdfParseException()
+    {
+        var content = LoadTestFile("sample-malformed.xccdf");
+
+        var act = () => _parser.Parse(content, "sample-malformed.xccdf");
+
+        act.Should().Throw<XccdfParseException>()
+            .Which.Message.Should().Contain("Invalid XML");
+    }
+
+    [Fact]
+    public void Parse_NoTestResult_Throws_XccdfParseException()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Benchmark xmlns=""http://checklists.nist.gov/xccdf/1.2""
+           id=""xccdf_mil.disa.stig_benchmark_Test"">
+  <status>accepted</status>
+</Benchmark>";
+
+        var act = () => _parser.Parse(XccdfBytes(xml), "no-testresult.xccdf");
+
+        act.Should().Throw<XccdfParseException>()
+            .Which.Message.Should().Contain("TestResult");
+    }
+
+    [Fact]
+    public void Parse_EmptyRuleResults_Returns_EmptyList()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult xmlns=""http://checklists.nist.gov/xccdf/1.2""
+            id=""test_result_1"">
+  <target>empty-host</target>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "empty-rules.xccdf");
+
+        result.Results.Should().BeEmpty();
+        result.Target.Should().Be("empty-host");
+    }
+
+    [Theory]
+    [InlineData("error")]
+    [InlineData("unknown")]
+    [InlineData("notchecked")]
+    public void Parse_ErrorUnknownNotchecked_LowercasedCorrectly(string resultValue)
+    {
+        var xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult xmlns=""http://checklists.nist.gov/xccdf/1.2"" id=""tr_1"">
+  <target>host</target>
+  <rule-result idref=""SV-100001r111111_rule"" severity=""medium"" weight=""10.0"">
+    <result>{resultValue}</result>
+  </rule-result>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "test.xccdf");
+
+        result.Results[0].Result.Should().Be(resultValue.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Parse_NoScore_Returns_NullScores()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult xmlns=""http://checklists.nist.gov/xccdf/1.2"" id=""tr_1"">
+  <target>host</target>
+  <rule-result idref=""SV-100001r111111_rule"" severity=""medium"" weight=""10.0"">
+    <result>pass</result>
+  </rule-result>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "no-score.xccdf");
+
+        result.Score.Should().BeNull();
+        result.MaxScore.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_NoTargetFacts_Returns_EmptyDictionary()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TestResult xmlns=""http://checklists.nist.gov/xccdf/1.2"" id=""tr_1"">
+  <target>host</target>
+  <rule-result idref=""SV-100001r111111_rule"" severity=""medium"" weight=""10.0"">
+    <result>pass</result>
+  </rule-result>
+</TestResult>";
+
+        var result = _parser.Parse(XccdfBytes(xml), "no-facts.xccdf");
+
+        result.TargetFacts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_UnrecognizedNamespace_Throws_XccdfParseException()
+    {
+        var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<SomeRoot xmlns=""http://example.com/unknown"">
+  <child>text</child>
+</SomeRoot>";
+
+        var act = () => _parser.Parse(XccdfBytes(xml), "unknown-ns.xccdf");
+
+        act.Should().Throw<XccdfParseException>()
+            .Which.Message.Should().Contain("namespace");
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Performance/ScanImportPerformanceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Performance/ScanImportPerformanceTests.cs
@@ -1,0 +1,260 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — Phase 10 (T062): Performance Benchmark Tests
+// Generates large CKL (500 VULNs) and XCCDF (500 rule-results) payloads
+// programmatically and asserts import completes within wall-clock limits.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Diagnostics;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ato.Copilot.Tests.Unit.Performance;
+
+/// <summary>
+/// Performance benchmark tests for SCAP/STIG import operations.
+/// Validates that large payloads complete within acceptable wall-clock limits.
+/// </summary>
+public class ScanImportPerformanceTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly ScanImportService _service;
+    private readonly Mock<ICklParser> _cklParserMock;
+    private readonly Mock<IXccdfParser> _xccdfParserMock;
+
+    private const string TestSystemId = "sys-perf-001";
+    private const string TestAssessmentId = "assess-perf-001";
+
+    private readonly RegisteredSystem _testSystem = new()
+    {
+        Id = TestSystemId,
+        Name = "Performance Test System",
+        CurrentRmfStep = RmfPhase.Assess,
+        HostingEnvironment = "Azure Government",
+        CreatedBy = "admin"
+    };
+
+    private readonly ControlBaseline _testBaseline = new()
+    {
+        Id = "bl-perf-001",
+        RegisteredSystemId = TestSystemId,
+        BaselineLevel = "Moderate",
+        ControlIds = Enumerable.Range(1, 50).Select(i => $"AC-{i}").ToList(),
+        CreatedBy = "admin"
+    };
+
+    public ScanImportPerformanceTests(ITestOutputHelper output)
+    {
+        _output = output;
+
+        var services = new ServiceCollection();
+        var dbName = $"PerfTests_{Guid.NewGuid()}";
+        services.AddDbContext<AtoCopilotContext>(options =>
+            options.UseInMemoryDatabase(dbName));
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        // Seed data
+        using var initScope = _serviceProvider.CreateScope();
+        var initCtx = initScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        initCtx.Database.EnsureCreated();
+        initCtx.Assessments.Add(new ComplianceAssessment
+        {
+            Id = TestAssessmentId,
+            RegisteredSystemId = TestSystemId,
+            Framework = "NIST80053",
+            Status = AssessmentStatus.InProgress,
+            InitiatedBy = "perf-tester"
+        });
+        initCtx.SaveChanges();
+
+        // Mocks
+        var stigServiceMock = new Mock<IStigKnowledgeService>();
+        var baselineServiceMock = new Mock<IBaselineService>();
+        var rmfServiceMock = new Mock<IRmfLifecycleService>();
+        var artifactServiceMock = new Mock<IAssessmentArtifactService>();
+        _cklParserMock = new Mock<ICklParser>();
+        _xccdfParserMock = new Mock<IXccdfParser>();
+        var cklGeneratorMock = new Mock<ICklGenerator>();
+
+        rmfServiceMock.Setup(s => s.GetSystemAsync(TestSystemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testSystem);
+        baselineServiceMock.Setup(s => s.GetBaselineAsync(TestSystemId, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testBaseline);
+
+        // Setup STIG resolution: all 500 VulnIds will resolve to a STIG control
+        stigServiceMock.Setup(s => s.GetStigControlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((id, _) => Task.FromResult<StigControl?>(
+                new StigControl(
+                    StigId: id, VulnId: id,
+                    RuleId: $"SV-{id[2..]}r1_rule",
+                    Title: $"Test Rule {id}",
+                    Description: "Performance test STIG control",
+                    Severity: StigSeverity.Medium,
+                    Category: "CAT II",
+                    StigFamily: "Performance Test",
+                    NistControls: new List<string> { $"AC-{Math.Abs(id.GetHashCode()) % 50 + 1}" },
+                    CciRefs: new List<string> { $"CCI-{Math.Abs(id.GetHashCode()) % 9999:D6}" },
+                    CheckText: "Check",
+                    FixText: "Fix",
+                    AzureImplementation: new Dictionary<string, string>(),
+                    ServiceType: "Test",
+                    BenchmarkId: "Perf_Test_STIG")));
+
+        stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((ruleId, _) =>
+            {
+                var vulnNum = ruleId.Replace("SV-", "").Split('r')[0];
+                var vulnId = $"V-{vulnNum}";
+                return Task.FromResult<StigControl?>(
+                    new StigControl(
+                        StigId: vulnId, VulnId: vulnId,
+                        RuleId: ruleId,
+                        Title: $"Test Rule {vulnId}",
+                        Description: "Performance test STIG control",
+                        Severity: StigSeverity.Medium,
+                        Category: "CAT II",
+                        StigFamily: "Performance Test",
+                        NistControls: new List<string> { $"AC-{Math.Abs(vulnId.GetHashCode()) % 50 + 1}" },
+                        CciRefs: new List<string> { $"CCI-{Math.Abs(vulnId.GetHashCode()) % 9999:D6}" },
+                        CheckText: "Check",
+                        FixText: "Fix",
+                        AzureImplementation: new Dictionary<string, string>(),
+                        ServiceType: "Test",
+                        BenchmarkId: "Perf_Test_STIG"));
+            });
+
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        _service = new ScanImportService(
+            scopeFactory,
+            stigServiceMock.Object,
+            baselineServiceMock.Object,
+            rmfServiceMock.Object,
+            artifactServiceMock.Object,
+            _cklParserMock.Object,
+            _xccdfParserMock.Object,
+            cklGeneratorMock.Object,
+            NullLogger<ScanImportService>.Instance);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    // ═════════════════════════════════════════════════════════════════════
+    // CKL Performance: 500 VULNs < 10 seconds
+    // ═════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_500Vulns_CompletesWithin10Seconds()
+    {
+        // Arrange: Generate 500 CKL entries
+        var entries = Enumerable.Range(100000, 500).Select(i =>
+        {
+            var vulnId = $"V-{i}";
+            var statuses = new[] { "Open", "NotAFinding", "Not_Applicable", "Not_Reviewed" };
+            var status = statuses[i % 4];
+            var severity = (i % 3) switch { 0 => "high", 1 => "medium", _ => "low" };
+            return new ParsedCklEntry(
+                VulnId: vulnId,
+                RuleId: $"SV-{i}r1_rule",
+                StigVersion: $"WN22-TEST-{i:D6}",
+                RuleTitle: $"Test Rule {vulnId}",
+                Severity: severity,
+                Status: status,
+                FindingDetails: $"Details for {vulnId}",
+                Comments: null,
+                SeverityOverride: null,
+                SeverityJustification: null,
+                CciRefs: new List<string> { $"CCI-{i % 9999:D6}" },
+                GroupTitle: "SRG-OS-000003-GPOS-00004");
+        }).ToList();
+
+        var parsed = new ParsedCklFile(
+            Asset: new CklAssetInfo("perf-server", "10.0.1.1", "perf.example.mil", "AA:BB:CC:DD:EE:FF", "Computing", "9999"),
+            StigInfo: new CklStigInfo("Perf_Test_STIG", "1", "Release: 1", "Performance Test STIG"),
+            Entries: entries);
+
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var sw = Stopwatch.StartNew();
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId,
+            "perf-ckl-content"u8.ToArray(), "perf_500.ckl",
+            ImportConflictResolution.Skip, false, "perf-user");
+        sw.Stop();
+
+        // Assert
+        _output.WriteLine($"CKL 500 VULNs import completed in {sw.ElapsedMilliseconds}ms");
+        result.Status.Should().NotBe(ScanImportStatus.Failed,
+            $"Import failed with: {result.ErrorMessage}");
+        result.TotalEntries.Should().Be(500);
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10),
+            $"Import took {sw.ElapsedMilliseconds}ms, expected < 10000ms");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // XCCDF Performance: 500 rule-results < 5 seconds
+    // ═════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportXccdf_500RuleResults_CompletesWithin5Seconds()
+    {
+        // Arrange: Generate 500 XCCDF results
+        var results = Enumerable.Range(200000, 500).Select(i =>
+        {
+            var ruleId = $"xccdf_mil.disa.stig_rule_SV-{i}r1_rule";
+            var outcomes = new[] { "pass", "fail", "notapplicable", "error" };
+            var outcome = outcomes[i % 4];
+            var severity = (i % 3) switch { 0 => "high", 1 => "medium", _ => "low" };
+            return new ParsedXccdfResult(
+                RuleIdRef: ruleId,
+                ExtractedRuleId: $"SV-{i}r1_rule",
+                Result: outcome,
+                Severity: severity,
+                Weight: 10.0m,
+                Timestamp: DateTime.UtcNow,
+                Message: null,
+                CheckRef: null);
+        }).ToList();
+
+        var parsedXccdf = new ParsedXccdfFile(
+            BenchmarkHref: "xccdf_mil.disa.stig_benchmark_Perf_Test_STIG",
+            Title: "Performance Test STIG",
+            Target: "perf-server",
+            TargetAddress: "10.0.1.1",
+            StartTime: DateTime.UtcNow.AddMinutes(-5),
+            EndTime: DateTime.UtcNow,
+            Score: 75.0m,
+            MaxScore: 100.0m,
+            TargetFacts: new Dictionary<string, string> { ["os"] = "Windows" },
+            Results: results);
+
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsedXccdf);
+
+        // Act
+        var sw = Stopwatch.StartNew();
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId,
+            "perf-xccdf-content"u8.ToArray(), "perf_500.xccdf",
+            ImportConflictResolution.Skip, false, "perf-user");
+        sw.Stop();
+
+        // Assert
+        _output.WriteLine($"XCCDF 500 rule-results import completed in {sw.ElapsedMilliseconds}ms");
+        result.Status.Should().NotBe(ScanImportStatus.Failed,
+            $"Import failed with: {result.ErrorMessage}");
+        result.TotalEntries.Should().Be(500);
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5),
+            $"Import took {sw.ElapsedMilliseconds}ms, expected < 5000ms");
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Server/McpServerAiIntegrationTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Server/McpServerAiIntegrationTests.cs
@@ -453,7 +453,13 @@ public class McpServerAiIntegrationTests
             new UploadTemplateTool(Mock.Of<IDocumentTemplateService>(), Mock.Of<ILogger<UploadTemplateTool>>()),
             new ListTemplatesTool(Mock.Of<IDocumentTemplateService>(), Mock.Of<ILogger<ListTemplatesTool>>()),
             new UpdateTemplateTool(Mock.Of<IDocumentTemplateService>(), Mock.Of<ILogger<UpdateTemplateTool>>()),
-            new DeleteTemplateTool(Mock.Of<IDocumentTemplateService>(), Mock.Of<ILogger<DeleteTemplateTool>>()));
+            new DeleteTemplateTool(Mock.Of<IDocumentTemplateService>(), Mock.Of<ILogger<DeleteTemplateTool>>()),
+            // Feature 017: SCAP/STIG Import tools
+            new ImportCklTool(Mock.Of<IScanImportService>(), sf, Mock.Of<ILogger<ImportCklTool>>()),
+            new ImportXccdfTool(Mock.Of<IScanImportService>(), Mock.Of<ILogger<ImportXccdfTool>>()),
+            new ExportCklTool(Mock.Of<IScanImportService>(), Mock.Of<ILogger<ExportCklTool>>()),
+            new ListImportsTool(Mock.Of<IScanImportService>(), Mock.Of<ILogger<ListImportsTool>>()),
+            new GetImportSummaryTool(Mock.Of<IScanImportService>(), Mock.Of<ILogger<GetImportSummaryTool>>()));
     }
 
     private KnowledgeBaseMcpTools CreateKnowledgeBaseMcpTools()

--- a/tests/Ato.Copilot.Tests.Unit/Services/CklExportTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/CklExportTests.cs
@@ -1,0 +1,525 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Import: CKL Generator & Export Tests (T047)
+// Covers CklGenerator XML output, STATUS mapping, CCI_REF inclusion,
+// round-trip parsing, no-findings behavior, partial assessments,
+// and ExportCklAsync service integration.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Xml.Linq;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="CklGenerator"/> and <see cref="ScanImportService.ExportCklAsync"/>.
+/// </summary>
+public class CklExportTests : IDisposable
+{
+    private readonly CklGenerator _generator;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly Mock<IStigKnowledgeService> _stigServiceMock;
+    private readonly Mock<IBaselineService> _baselineServiceMock;
+    private readonly Mock<IRmfLifecycleService> _rmfServiceMock;
+    private readonly Mock<IAssessmentArtifactService> _artifactServiceMock;
+    private readonly Mock<ICklParser> _cklParserMock;
+    private readonly Mock<IXccdfParser> _xccdfParserMock;
+    private readonly Mock<ICklGenerator> _cklGeneratorMock;
+    private readonly ScanImportService _service;
+
+    private const string TestSystemId = "sys-export-001";
+    private const string TestAssessmentId = "assess-export-001";
+    private const string TestBenchmarkId = "Windows_Server_2022_STIG";
+
+    private readonly RegisteredSystem _testSystem = new()
+    {
+        Id = TestSystemId,
+        Name = "Export Test System",
+        CurrentRmfStep = RmfPhase.Assess,
+        HostingEnvironment = "Azure Government",
+        CreatedBy = "admin"
+    };
+
+    // Reusable STIG controls
+    private readonly StigControl _stig1 = new(
+        StigId: "V-254239", VulnId: "V-254239",
+        RuleId: "SV-254239r849090_rule",
+        Title: "Audit account management",
+        Description: "Test desc",
+        Severity: StigSeverity.High,
+        Category: "CAT I",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "AC-2" },
+        CciRefs: new List<string> { "CCI-000018", "CCI-000172" },
+        CheckText: "Check", FixText: "Fix",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-AU-000010",
+        BenchmarkId: TestBenchmarkId);
+
+    private readonly StigControl _stig2 = new(
+        StigId: "V-254240", VulnId: "V-254240",
+        RuleId: "SV-254240r849093_rule",
+        Title: "Password complexity",
+        Description: "Test desc",
+        Severity: StigSeverity.Medium,
+        Category: "CAT II",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "IA-5" },
+        CciRefs: new List<string> { "CCI-000192" },
+        CheckText: "Check", FixText: "Fix",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-SO-000060",
+        BenchmarkId: TestBenchmarkId);
+
+    private readonly StigControl _stig3 = new(
+        StigId: "V-254241", VulnId: "V-254241",
+        RuleId: "SV-254241r849096_rule",
+        Title: "Remote connections",
+        Description: "Test desc",
+        Severity: StigSeverity.Low,
+        Category: "CAT III",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "SC-7" },
+        CciRefs: new List<string> { "CCI-001097" },
+        CheckText: "Check", FixText: "Fix",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-CC-000010",
+        BenchmarkId: TestBenchmarkId);
+
+    public CklExportTests()
+    {
+        _generator = new CklGenerator(NullLogger<CklGenerator>.Instance);
+
+        // Service setup for ExportCklAsync tests
+        var services = new ServiceCollection();
+        var dbName = $"CklExportTests_{Guid.NewGuid()}";
+        services.AddDbContext<AtoCopilotContext>(options =>
+            options.UseInMemoryDatabase(dbName));
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var initScope = _serviceProvider.CreateScope();
+        var initCtx = initScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        initCtx.Database.EnsureCreated();
+
+        // Seed assessment
+        initCtx.Assessments.Add(new ComplianceAssessment
+        {
+            Id = TestAssessmentId,
+            RegisteredSystemId = TestSystemId,
+            Framework = "NIST80053",
+            Status = AssessmentStatus.InProgress,
+            InitiatedBy = "test-user"
+        });
+        initCtx.SaveChanges();
+
+        _stigServiceMock = new Mock<IStigKnowledgeService>();
+        _baselineServiceMock = new Mock<IBaselineService>();
+        _rmfServiceMock = new Mock<IRmfLifecycleService>();
+        _artifactServiceMock = new Mock<IAssessmentArtifactService>();
+        _cklParserMock = new Mock<ICklParser>();
+        _xccdfParserMock = new Mock<IXccdfParser>();
+        _cklGeneratorMock = new Mock<ICklGenerator>();
+
+        _rmfServiceMock.Setup(s => s.GetSystemAsync(TestSystemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testSystem);
+
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        _service = new ScanImportService(
+            scopeFactory,
+            _stigServiceMock.Object,
+            _baselineServiceMock.Object,
+            _rmfServiceMock.Object,
+            _artifactServiceMock.Object,
+            _cklParserMock.Object,
+            _xccdfParserMock.Object,
+            _cklGeneratorMock.Object,
+            NullLogger<ScanImportService>.Instance);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // CklGenerator Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Generate_ProducesWellFormedXml()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "Windows Server 2022 STIG");
+
+        // Should parse without error
+        var doc = XDocument.Parse(xml);
+        doc.Root.Should().NotBeNull();
+        doc.Root!.Name.LocalName.Should().Be("CHECKLIST");
+    }
+
+    [Fact]
+    public void Generate_AssetSection_ContainsSystemMetadata()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "Windows Server 2022 STIG");
+
+        var doc = XDocument.Parse(xml);
+        var asset = doc.Root!.Element("ASSET")!;
+        asset.Element("HOST_NAME")!.Value.Should().Be("Export Test System");
+    }
+
+    [Fact]
+    public void Generate_StigInfo_ContainsBenchmarkData()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "Windows Server 2022 STIG");
+
+        var doc = XDocument.Parse(xml);
+        var stigInfo = doc.Root!.Descendants("STIG_INFO").First();
+        var siDataValues = stigInfo.Elements("SI_DATA")
+            .ToDictionary(
+                e => e.Element("SID_NAME")!.Value,
+                e => e.Element("SID_DATA")!.Value);
+
+        siDataValues["stigid"].Should().Be(TestBenchmarkId);
+        siDataValues["version"].Should().Be("3");
+        siDataValues["title"].Should().Be("Windows Server 2022 STIG");
+    }
+
+    [Fact]
+    public void Generate_VulnEntries_HaveCorrectCount()
+    {
+        var controls = new List<StigControl> { _stig1, _stig2, _stig3 };
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var vulns = doc.Root!.Descendants("VULN").ToList();
+        vulns.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Generate_OpenFinding_MapsToOpenStatus()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new()
+            {
+                StigId = "V-254239",
+                Status = FindingStatus.Open,
+                Description = "Audit not configured"
+            }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var status = doc.Root!.Descendants("VULN").First().Element("STATUS")!.Value;
+        status.Should().Be("Open");
+    }
+
+    [Fact]
+    public void Generate_RemediatedFinding_MapsToNotAFinding()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new()
+            {
+                StigId = "V-254239",
+                Status = FindingStatus.Remediated,
+                Description = "Fixed"
+            }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var status = doc.Root!.Descendants("VULN").First().Element("STATUS")!.Value;
+        status.Should().Be("NotAFinding");
+    }
+
+    [Fact]
+    public void Generate_AcceptedFinding_MapsToNotApplicable()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new()
+            {
+                StigId = "V-254239",
+                Status = FindingStatus.Accepted,
+                Description = "Risk accepted"
+            }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var status = doc.Root!.Descendants("VULN").First().Element("STATUS")!.Value;
+        status.Should().Be("Not_Applicable");
+    }
+
+    [Fact]
+    public void Generate_NoFinding_DefaultsToNotReviewed()
+    {
+        var controls = new List<StigControl> { _stig1, _stig2 };
+        var findings = new Dictionary<string, ComplianceFinding>(); // No findings
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var statuses = doc.Root!.Descendants("VULN")
+            .Select(v => v.Element("STATUS")!.Value)
+            .ToList();
+
+        statuses.Should().OnlyContain(s => s == "Not_Reviewed");
+    }
+
+    [Fact]
+    public void Generate_CciRefElements_Included()
+    {
+        var controls = new List<StigControl> { _stig1 }; // Has CCI-000018, CCI-000172
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var vuln = doc.Root!.Descendants("VULN").First();
+        var cciRefs = vuln.Elements("STIG_DATA")
+            .Where(sd => sd.Element("VULN_ATTRIBUTE")!.Value == "CCI_REF")
+            .Select(sd => sd.Element("ATTRIBUTE_DATA")!.Value)
+            .ToList();
+
+        cciRefs.Should().Contain("CCI-000018");
+        cciRefs.Should().Contain("CCI-000172");
+    }
+
+    [Fact]
+    public void Generate_CorrectSeverityMapping()
+    {
+        var controls = new List<StigControl> { _stig1, _stig2, _stig3 };
+        var findings = new Dictionary<string, ComplianceFinding>();
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var vulns = doc.Root!.Descendants("VULN").ToList();
+        var severities = vulns.Select(v =>
+            v.Elements("STIG_DATA")
+                .First(sd => sd.Element("VULN_ATTRIBUTE")!.Value == "Severity")
+                .Element("ATTRIBUTE_DATA")!.Value)
+            .ToList();
+
+        severities[0].Should().Be("high");
+        severities[1].Should().Be("medium");
+        severities[2].Should().Be("low");
+    }
+
+    [Fact]
+    public void Generate_RoundTrip_CklParserCanReparse()
+    {
+        // Generate CKL with known findings
+        var controls = new List<StigControl> { _stig1, _stig2, _stig3 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new() { StigId = "V-254239", Status = FindingStatus.Open, Description = "Open finding" },
+            ["V-254240"] = new() { StigId = "V-254240", Status = FindingStatus.Remediated, Description = "Fixed" }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "Windows Server 2022 STIG");
+
+        // Parse it back using the real CklParser
+        var parser = new CklParser(NullLogger<CklParser>.Instance);
+        var content = System.Text.Encoding.UTF8.GetBytes(xml);
+        var parsed = parser.Parse(content, "round-trip.ckl");
+
+        // Verify round-trip integrity
+        parsed.Entries.Should().HaveCount(3);
+        parsed.Entries.Count(e => e.Status == "Open").Should().Be(1);
+        parsed.Entries.Count(e => e.Status == "NotAFinding").Should().Be(1);
+        parsed.Entries.Count(e => e.Status == "Not_Reviewed").Should().Be(1);
+        parsed.StigInfo.StigId.Should().Be(TestBenchmarkId);
+        parsed.Asset.HostName.Should().Be("Export Test System");
+    }
+
+    [Fact]
+    public void Generate_PartialAssessment_UnassessedDefaultToNotReviewed()
+    {
+        // 3 controls, only 1 has a finding
+        var controls = new List<StigControl> { _stig1, _stig2, _stig3 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new() { StigId = "V-254239", Status = FindingStatus.Open, Description = "Open" }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var statuses = doc.Root!.Descendants("VULN")
+            .Select(v => v.Element("STATUS")!.Value)
+            .ToList();
+
+        statuses.Count(s => s == "Open").Should().Be(1);
+        statuses.Count(s => s == "Not_Reviewed").Should().Be(2);
+    }
+
+    [Fact]
+    public void Generate_InProgressFinding_MapsToOpen()
+    {
+        var controls = new List<StigControl> { _stig1 };
+        var findings = new Dictionary<string, ComplianceFinding>
+        {
+            ["V-254239"] = new()
+            {
+                StigId = "V-254239",
+                Status = FindingStatus.InProgress,
+                Description = "Being remediated"
+            }
+        };
+
+        var xml = _generator.Generate(_testSystem, controls, findings,
+            TestBenchmarkId, "3", "STIG");
+
+        var doc = XDocument.Parse(xml);
+        var status = doc.Root!.Descendants("VULN").First().Element("STATUS")!.Value;
+        status.Should().Be("Open");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ExportCklAsync Service Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ExportCkl_InvalidSystem_ThrowsInvalidOperation()
+    {
+        _rmfServiceMock.Setup(s => s.GetSystemAsync("bad-sys", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RegisteredSystem?)null);
+
+        var act = () => _service.ExportCklAsync("bad-sys", TestBenchmarkId, TestAssessmentId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*bad-sys*");
+    }
+
+    [Fact]
+    public async Task ExportCkl_NoBenchmarkControls_ThrowsInvalidOperation()
+    {
+        _stigServiceMock.Setup(s => s.GetStigControlsByBenchmarkAsync("NonExistent_STIG", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StigControl>());
+
+        var act = () => _service.ExportCklAsync(TestSystemId, "NonExistent_STIG", TestAssessmentId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*NonExistent_STIG*");
+    }
+
+    [Fact]
+    public async Task ExportCkl_ValidRequest_CallsCklGenerator()
+    {
+        _stigServiceMock.Setup(s => s.GetStigControlsByBenchmarkAsync(TestBenchmarkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StigControl> { _stig1, _stig2 });
+
+        _cklGeneratorMock.Setup(g => g.Generate(
+                It.IsAny<RegisteredSystem>(),
+                It.IsAny<List<StigControl>>(),
+                It.IsAny<Dictionary<string, ComplianceFinding>>(),
+                TestBenchmarkId,
+                It.IsAny<string?>(),
+                It.IsAny<string?>()))
+            .Returns("<CHECKLIST></CHECKLIST>");
+
+        var result = await _service.ExportCklAsync(TestSystemId, TestBenchmarkId, TestAssessmentId);
+
+        result.Should().NotBeNullOrEmpty();
+        // Result should be valid base64
+        var decoded = Convert.FromBase64String(result);
+        var xml = System.Text.Encoding.UTF8.GetString(decoded);
+        xml.Should().Contain("CHECKLIST");
+
+        _cklGeneratorMock.Verify(g => g.Generate(
+            It.Is<RegisteredSystem>(s => s.Id == TestSystemId),
+            It.Is<List<StigControl>>(l => l.Count == 2),
+            It.IsAny<Dictionary<string, ComplianceFinding>>(),
+            TestBenchmarkId,
+            It.IsAny<string?>(),
+            It.IsAny<string?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExportCkl_WithFindings_PassesFindingsToGenerator()
+    {
+        // Seed a finding
+        using (var seedScope = _serviceProvider.CreateScope())
+        {
+            var seedCtx = seedScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+            seedCtx.Findings.Add(new ComplianceFinding
+            {
+                AssessmentId = TestAssessmentId,
+                StigFinding = true,
+                StigId = "V-254239",
+                Status = FindingStatus.Open,
+                ControlId = "AC-2",
+                ControlFamily = "AC",
+                Title = "Test",
+                Description = "Open finding",
+                Severity = FindingSeverity.High,
+                Source = "CKL Import"
+            });
+            await seedCtx.SaveChangesAsync();
+        }
+
+        _stigServiceMock.Setup(s => s.GetStigControlsByBenchmarkAsync(TestBenchmarkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StigControl> { _stig1, _stig2 });
+
+        _cklGeneratorMock.Setup(g => g.Generate(
+                It.IsAny<RegisteredSystem>(),
+                It.IsAny<List<StigControl>>(),
+                It.IsAny<Dictionary<string, ComplianceFinding>>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>()))
+            .Returns("<CHECKLIST></CHECKLIST>");
+
+        await _service.ExportCklAsync(TestSystemId, TestBenchmarkId, TestAssessmentId);
+
+        // Verify that the findings dictionary passed to Generator contains the seeded finding
+        _cklGeneratorMock.Verify(g => g.Generate(
+            It.IsAny<RegisteredSystem>(),
+            It.IsAny<List<StigControl>>(),
+            It.Is<Dictionary<string, ComplianceFinding>>(d => d.ContainsKey("V-254239")),
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>()), Times.Once);
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Services/ScanImportServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/ScanImportServiceTests.cs
@@ -1,0 +1,1738 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Viewer Import: ScanImportService Tests
+// Covers T018 (STIG resolution), T022-T024 (finding/effectiveness/evidence),
+// T028-T029 (conflict resolution, dry-run).
+// ═══════════════════════════════════════════════════════════════════════════
+
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ScanImportService"/>.
+/// Uses EF Core InMemory provider for DbContext, mocked services for external dependencies.
+/// </summary>
+public class ScanImportServiceTests : IDisposable
+{
+    // ── Shared test infrastructure ───────────────────────────────────────
+
+    private readonly ServiceProvider _serviceProvider;
+    private readonly Mock<IStigKnowledgeService> _stigServiceMock;
+    private readonly Mock<IBaselineService> _baselineServiceMock;
+    private readonly Mock<IRmfLifecycleService> _rmfServiceMock;
+    private readonly Mock<IAssessmentArtifactService> _artifactServiceMock;
+    private readonly Mock<ICklParser> _cklParserMock;
+    private readonly Mock<IXccdfParser> _xccdfParserMock;
+    private readonly Mock<ICklGenerator> _cklGeneratorMock;
+    private readonly ScanImportService _service;
+
+    // Standard test system
+    private const string TestSystemId = "sys-001";
+    private const string TestAssessmentId = "assess-001";
+    private const string TestImporter = "test-user";
+
+    private readonly RegisteredSystem _testSystem = new()
+    {
+        Id = TestSystemId,
+        Name = "Test System",
+        CurrentRmfStep = RmfPhase.Assess,
+        HostingEnvironment = "Azure Government",
+        CreatedBy = "admin"
+    };
+
+    private readonly ControlBaseline _testBaseline = new()
+    {
+        Id = "bl-001",
+        RegisteredSystemId = TestSystemId,
+        BaselineLevel = "Moderate",
+        ControlIds = new List<string> { "AC-2", "AC-7", "IA-5", "SC-7", "AU-3" },
+        CreatedBy = "admin"
+    };
+
+    // Standard STIG controls for resolution tests
+    private readonly StigControl _stigAc2 = new(
+        StigId: "V-254239",
+        VulnId: "V-254239",
+        RuleId: "SV-254239r849090_rule",
+        Title: "Windows Server 2022 must be configured to audit account management.",
+        Description: "Audit account management",
+        Severity: StigSeverity.High,
+        Category: "CAT I",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "AC-2" },
+        CciRefs: new List<string> { "CCI-000018", "CCI-000172" },
+        CheckText: "Check audit policy",
+        FixText: "Configure audit policy",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-AU-000010",
+        BenchmarkId: "Windows_Server_2022_STIG");
+
+    private readonly StigControl _stigIa5 = new(
+        StigId: "V-254240",
+        VulnId: "V-254240",
+        RuleId: "SV-254240r849093_rule",
+        Title: "Windows Server 2022 must enforce password complexity.",
+        Description: "Password complexity",
+        Severity: StigSeverity.Medium,
+        Category: "CAT II",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "IA-5" },
+        CciRefs: new List<string> { "CCI-000192" },
+        CheckText: "Check password policy",
+        FixText: "Configure password policy",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-SO-000060",
+        BenchmarkId: "Windows_Server_2022_STIG");
+
+    private readonly StigControl _stigSc7 = new(
+        StigId: "V-254241",
+        VulnId: "V-254241",
+        RuleId: "SV-254241r849096_rule",
+        Title: "Windows Server 2022 must restrict remote connections.",
+        Description: "Remote connections",
+        Severity: StigSeverity.Low,
+        Category: "CAT III",
+        StigFamily: "Windows Server 2022",
+        NistControls: new List<string> { "SC-7" },
+        CciRefs: new List<string> { "CCI-001097" },
+        CheckText: "Check remote settings",
+        FixText: "Configure remote settings",
+        AzureImplementation: new Dictionary<string, string>(),
+        ServiceType: "Windows",
+        StigVersion: "WN22-CC-000010",
+        BenchmarkId: "Windows_Server_2022_STIG");
+
+    public ScanImportServiceTests()
+    {
+        // Set up in-memory SQLite
+        var services = new ServiceCollection();
+        var dbName = $"ScanImportTests_{Guid.NewGuid()}";
+        services.AddDbContext<AtoCopilotContext>(options =>
+            options.UseInMemoryDatabase(dbName));
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        // Initialize DB
+        using var initScope = _serviceProvider.CreateScope();
+        var initCtx = initScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        initCtx.Database.EnsureCreated();
+
+        // Seed assessment
+        initCtx.Assessments.Add(new ComplianceAssessment
+        {
+            Id = TestAssessmentId,
+            RegisteredSystemId = TestSystemId,
+            Framework = "NIST80053",
+            Status = AssessmentStatus.InProgress,
+            InitiatedBy = TestImporter
+        });
+        initCtx.SaveChanges();
+
+        // Set up mocks
+        _stigServiceMock = new Mock<IStigKnowledgeService>();
+        _baselineServiceMock = new Mock<IBaselineService>();
+        _rmfServiceMock = new Mock<IRmfLifecycleService>();
+        _artifactServiceMock = new Mock<IAssessmentArtifactService>();
+        _cklParserMock = new Mock<ICklParser>();
+        _xccdfParserMock = new Mock<IXccdfParser>();
+        _cklGeneratorMock = new Mock<ICklGenerator>();
+
+        // Default setup: system exists, baseline exists
+        _rmfServiceMock.Setup(s => s.GetSystemAsync(TestSystemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testSystem);
+        _baselineServiceMock.Setup(s => s.GetBaselineAsync(TestSystemId, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testBaseline);
+
+        // Default STIG resolution
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254239", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigAc2);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254240", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigIa5);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254241", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigSc7);
+
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = NullLogger<ScanImportService>.Instance;
+
+        _service = new ScanImportService(
+            scopeFactory,
+            _stigServiceMock.Object,
+            _baselineServiceMock.Object,
+            _rmfServiceMock.Object,
+            _artifactServiceMock.Object,
+            _cklParserMock.Object,
+            _xccdfParserMock.Object,
+            _cklGeneratorMock.Object,
+            logger);
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+    }
+
+    // ── Helper: Build standard ParsedCklFile ─────────────────────────────
+
+    private static ParsedCklFile BuildParsedCkl(params ParsedCklEntry[] entries)
+    {
+        return new ParsedCklFile(
+            Asset: new CklAssetInfo("web-server-01", "10.0.1.100", "web-server-01.example.mil", "00:0A:95:9D:68:16", "Computing", "4089"),
+            StigInfo: new CklStigInfo("Windows_Server_2022_STIG", "3", "Release: 1 Benchmark Date: 23 Mar 2023", "Microsoft Windows Server 2022 STIG"),
+            Entries: entries.ToList());
+    }
+
+    private static ParsedCklEntry BuildEntry(
+        string vulnId, string status, string severity = "high",
+        string? ruleId = null, string? stigVersion = null,
+        string? findingDetails = null, string? comments = null,
+        string? severityOverride = null, string? severityJustification = null,
+        List<string>? cciRefs = null)
+    {
+        return new ParsedCklEntry(
+            VulnId: vulnId,
+            RuleId: ruleId ?? $"SV-{vulnId[2..]}r849090_rule",
+            StigVersion: stigVersion ?? "WN22-AU-000010",
+            RuleTitle: $"Test Rule {vulnId}",
+            Severity: severity,
+            Status: status,
+            FindingDetails: findingDetails,
+            Comments: comments,
+            SeverityOverride: severityOverride,
+            SeverityJustification: severityJustification,
+            CciRefs: cciRefs ?? new List<string> { "CCI-000018" },
+            GroupTitle: "SRG-OS-000003-GPOS-00004");
+    }
+
+    private byte[] DummyFileContent => "dummy-ckl-content"u8.ToArray();
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T018: STIG Resolution Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_VulnIdMatch_ReturnsCorrectStigControl()
+    {
+        // Arrange
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.FindingsCreated.Should().Be(1);
+        result.UnmatchedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportCkl_VulnIdMiss_FallbackToRuleId()
+    {
+        // Arrange: VulnId "V-999999" not found, but RuleId matches
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-999999", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync("SV-999999r123456_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigAc2);
+
+        var entry = BuildEntry("V-999999", "Open", ruleId: "SV-999999r123456_rule");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.UnmatchedCount.Should().Be(0);
+        result.FindingsCreated.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportCkl_BothMiss_TrackedAsUnmatched()
+    {
+        // Arrange: Neither VulnId nor RuleId match
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-888888", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+
+        var entry = BuildEntry("V-888888", "Open", ruleId: "SV-888888r000000_rule", stigVersion: "WN22-XX-000099");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.UnmatchedCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(0);
+        result.UnmatchedRules.Should().HaveCount(1);
+        result.UnmatchedRules[0].VulnId.Should().Be("V-888888");
+    }
+
+    [Fact]
+    public async Task ImportCkl_CciResolution_ReturnsCorrectNistControls()
+    {
+        // Arrange: STIG maps to AC-2 (in baseline)
+        var entry = BuildEntry("V-254239", "Open", cciRefs: new List<string> { "CCI-000018", "CCI-000172" });
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.NistControlsAffected.Should().BeGreaterThanOrEqualTo(1);
+        result.EffectivenessRecordsCreated.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task ImportCkl_NistControlNotInBaseline_WarningLogged()
+    {
+        // Arrange: STIG maps to "ZZ-99" which is NOT in baseline
+        var outOfBaselineStig = new StigControl(
+            StigId: "V-777777", VulnId: "V-777777", RuleId: "SV-777777r111_rule",
+            Title: "Test", Description: "Test", Severity: StigSeverity.Medium,
+            Category: "CAT II", StigFamily: "Test",
+            NistControls: new List<string> { "ZZ-99" },
+            CciRefs: new List<string> { "CCI-999999" },
+            CheckText: "Check", FixText: "Fix",
+            AzureImplementation: new Dictionary<string, string>(),
+            ServiceType: "Test");
+
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-777777", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outOfBaselineStig);
+
+        var entry = BuildEntry("V-777777", "Open", severity: "medium");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Finding created (audit trail) but no effectiveness (out of baseline)
+        result.FindingsCreated.Should().Be(1);
+        result.EffectivenessRecordsCreated.Should().Be(0);
+        result.Warnings.Should().Contain(w => w.Contains("not in system baseline"));
+    }
+
+    [Fact]
+    public async Task ImportCkl_MultipleCciRefs_AllNistControlsResolved()
+    {
+        // Arrange: STIG maps to multiple NIST controls
+        var multiControlStig = new StigControl(
+            StigId: "V-254239", VulnId: "V-254239", RuleId: "SV-254239r849090_rule",
+            Title: "Test", Description: "Test", Severity: StigSeverity.High,
+            Category: "CAT I", StigFamily: "Test",
+            NistControls: new List<string> { "AC-2", "AU-3" },
+            CciRefs: new List<string> { "CCI-000018", "CCI-000172" },
+            CheckText: "", FixText: "",
+            AzureImplementation: new Dictionary<string, string>(),
+            ServiceType: "Test");
+
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-254239", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(multiControlStig);
+
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Both AC-2 and AU-3 should be affected
+        result.NistControlsAffected.Should().Be(2);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T022: Finding Creation Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_OpenEntry_CreatesOpenFinding()
+    {
+        // Arrange
+        var entry = BuildEntry("V-254239", "Open", findingDetails: "Audit policy not configured.");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(1);
+        result.OpenCount.Should().Be(1);
+
+        // Verify the actual finding in DB
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings
+            .Where(f => f.StigId == "V-254239")
+            .FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Open);
+        finding.StigFinding.Should().BeTrue();
+        finding.Source.Should().Be("CKL Import");
+        finding.Description.Should().Contain("Audit policy not configured.");
+    }
+
+    [Fact]
+    public async Task ImportCkl_NotAFinding_CreatesRemediatedFinding()
+    {
+        // Arrange
+        var entry = BuildEntry("V-254240", "NotAFinding", severity: "medium");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(1);
+        result.PassCount.Should().Be(1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254240").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Remediated);
+    }
+
+    [Fact]
+    public async Task ImportCkl_NotApplicable_NoFindingCreated()
+    {
+        // Arrange
+        var entry = BuildEntry("V-254241", "Not_Applicable", severity: "low");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(0);
+        result.NotApplicableCount.Should().Be(1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var findings = await ctx.Findings.Where(f => f.StigId == "V-254241").ToListAsync();
+        findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ImportCkl_NotReviewed_CreatesOpenFindingWithNote()
+    {
+        // Arrange
+        var entry = BuildEntry("V-254239", "Not_Reviewed");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(1);
+        result.NotReviewedCount.Should().Be(1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254239").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Open);
+        finding.Description.Should().Contain("Not yet reviewed");
+    }
+
+    [Fact]
+    public async Task ImportCkl_SeverityMapping_HighToCatI()
+    {
+        var entry = BuildEntry("V-254239", "Open", severity: "high");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254239").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Severity.Should().Be(FindingSeverity.High);
+        finding.CatSeverity.Should().Be(CatSeverity.CatI);
+    }
+
+    [Theory]
+    [InlineData("medium", FindingSeverity.Medium, CatSeverity.CatII)]
+    [InlineData("low", FindingSeverity.Low, CatSeverity.CatIII)]
+    public async Task ImportCkl_SeverityMapping_MediumAndLow(
+        string rawSeverity, FindingSeverity expectedSeverity, CatSeverity expectedCat)
+    {
+        var entry = BuildEntry("V-254240", "Open", severity: rawSeverity);
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254240").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Severity.Should().Be(expectedSeverity);
+        finding.CatSeverity.Should().Be(expectedCat);
+    }
+
+    [Fact]
+    public async Task ImportCkl_SeverityOverride_AppliedOverDefault()
+    {
+        // Arrange: Default severity = medium, override = high
+        var entry = BuildEntry("V-254240", "Open", severity: "medium",
+            severityOverride: "high", severityJustification: "Escalated per ISSM review.");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254240").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Severity.Should().Be(FindingSeverity.High);
+        finding.CatSeverity.Should().Be(CatSeverity.CatI);
+    }
+
+    [Fact]
+    public async Task ImportCkl_OutOfBaselineNistControl_FindingCreated_NoEffectiveness()
+    {
+        // Arrange: STIG maps to "ZZ-99" which is NOT in baseline
+        var outOfBaselineStig = new StigControl(
+            StigId: "V-666666", VulnId: "V-666666", RuleId: "SV-666666r111_rule",
+            Title: "Out-of-baseline rule", Description: "Test", Severity: StigSeverity.Medium,
+            Category: "CAT II", StigFamily: "Test",
+            NistControls: new List<string> { "ZZ-99" },
+            CciRefs: new List<string> { "CCI-999999" },
+            CheckText: "", FixText: "",
+            AzureImplementation: new Dictionary<string, string>(), ServiceType: "Test");
+
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-666666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outOfBaselineStig);
+
+        var entry = BuildEntry("V-666666", "Open", severity: "medium");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Finding created but no effectiveness for out-of-baseline
+        result.FindingsCreated.Should().Be(1);
+        result.EffectivenessRecordsCreated.Should().Be(0);
+        result.Warnings.Should().Contain(w => w.Contains("not in system baseline"));
+    }
+
+    [Fact]
+    public async Task ImportCkl_SystemNotInAssessStep_WarningEmitted()
+    {
+        // Arrange: System in "Implement" step (before Assess)
+        var implementSystem = new RegisteredSystem
+        {
+            Id = TestSystemId,
+            Name = "Test System",
+            CurrentRmfStep = RmfPhase.Implement,
+            HostingEnvironment = "Azure Government",
+            CreatedBy = "admin"
+        };
+        _rmfServiceMock.Setup(s => s.GetSystemAsync(TestSystemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(implementSystem);
+
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Warning emitted but import proceeds
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.Warnings.Should().Contain(w => w.Contains("Implement") && w.Contains("expected Assess"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T023: Effectiveness Upsert Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_AllRulesPass_EffectivenessSatisfied()
+    {
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "NotAFinding"),
+            BuildEntry("V-254240", "NotAFinding", severity: "medium")
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.EffectivenessRecordsCreated.Should().BeGreaterThanOrEqualTo(1);
+
+        // Verify effectiveness in DB
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var effRecords = await ctx.ControlEffectivenessRecords
+            .Where(e => e.AssessmentId == TestAssessmentId)
+            .ToListAsync();
+
+        effRecords.Should().NotBeEmpty();
+        effRecords.Should().OnlyContain(e => e.Determination == EffectivenessDetermination.Satisfied);
+        effRecords.Should().OnlyContain(e => e.AssessmentMethod == "Test");
+    }
+
+    [Fact]
+    public async Task ImportCkl_OneRuleFails_EffectivenessOtherThanSatisfied()
+    {
+        // AC-2 maps to V-254239 (Open) → OtherThanSatisfied
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "Open"), // AC-2 → Open
+            BuildEntry("V-254240", "NotAFinding", severity: "medium") // IA-5 → pass
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var ac2Eff = await ctx.ControlEffectivenessRecords
+            .Where(e => e.ControlId == "AC-2" && e.AssessmentId == TestAssessmentId)
+            .FirstOrDefaultAsync();
+        var ia5Eff = await ctx.ControlEffectivenessRecords
+            .Where(e => e.ControlId == "IA-5" && e.AssessmentId == TestAssessmentId)
+            .FirstOrDefaultAsync();
+
+        ac2Eff.Should().NotBeNull();
+        ac2Eff!.Determination.Should().Be(EffectivenessDetermination.OtherThanSatisfied);
+
+        ia5Eff.Should().NotBeNull();
+        ia5Eff!.Determination.Should().Be(EffectivenessDetermination.Satisfied);
+    }
+
+    [Fact]
+    public async Task ImportCkl_EffectivenessMethodIsTest()
+    {
+        var entry = BuildEntry("V-254239", "NotAFinding");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var eff = await ctx.ControlEffectivenessRecords
+            .Where(e => e.AssessmentId == TestAssessmentId)
+            .FirstOrDefaultAsync();
+
+        eff.Should().NotBeNull();
+        eff!.AssessmentMethod.Should().Be("Test");
+    }
+
+    [Fact]
+    public async Task ImportCkl_ReimportAggregateReeval_FlipsToSatisfied()
+    {
+        // First import: V-254239 is Open → OtherThanSatisfied for AC-2
+        var firstEntry = BuildEntry("V-254239", "Open");
+        var firstParsed = BuildParsedCkl(firstEntry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(firstParsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "first.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import: V-254239 is now NotAFinding → re-evaluate should flip AC-2 to Satisfied
+        var secondEntry = BuildEntry("V-254239", "NotAFinding");
+        var secondParsed = BuildParsedCkl(secondEntry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(secondParsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "second.ckl",
+            ImportConflictResolution.Overwrite, false, TestImporter);
+
+        // Assert: Effectiveness for AC-2 should now be Satisfied
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var ac2Eff = await ctx.ControlEffectivenessRecords
+            .Where(e => e.ControlId == "AC-2" && e.AssessmentId == TestAssessmentId)
+            .FirstOrDefaultAsync();
+
+        ac2Eff.Should().NotBeNull();
+        ac2Eff!.Determination.Should().Be(EffectivenessDetermination.Satisfied);
+    }
+
+    [Fact]
+    public async Task ImportCkl_OutOfBaselineControl_NoEffectivenessCreated()
+    {
+        var outOfBaselineStig = new StigControl(
+            StigId: "V-555555", VulnId: "V-555555", RuleId: "SV-555555r111_rule",
+            Title: "OOB Test", Description: "Test", Severity: StigSeverity.High,
+            Category: "CAT I", StigFamily: "Test",
+            NistControls: new List<string> { "XX-1" },
+            CciRefs: new List<string>(), CheckText: "", FixText: "",
+            AzureImplementation: new Dictionary<string, string>(), ServiceType: "Test");
+
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-555555", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outOfBaselineStig);
+
+        var entry = BuildEntry("V-555555", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.EffectivenessRecordsCreated.Should().Be(0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T024: Evidence Creation Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_EvidenceCreated_WithSha256Hash()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var fileBytes = DummyFileContent;
+        var expectedHash = ScanImportService.ComputeSha256(fileBytes);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, fileBytes, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var evidences = await ctx.Evidence
+            .Where(e => e.AssessmentId == TestAssessmentId && e.EvidenceType == "StigChecklist")
+            .ToListAsync();
+
+        evidences.Should().HaveCount(1);
+        evidences[0].ContentHash.Should().Be(expectedHash);
+        evidences[0].EvidenceCategory.Should().Be(EvidenceCategory.Configuration);
+        evidences[0].CollectionMethod.Should().Be("Manual");
+    }
+
+    [Fact]
+    public async Task ImportCkl_EvidenceType_IsStigChecklist()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var evidence = await ctx.Evidence
+            .Where(e => e.EvidenceType == "StigChecklist")
+            .FirstOrDefaultAsync();
+
+        evidence.Should().NotBeNull();
+        evidence!.EvidenceType.Should().Be("StigChecklist");
+    }
+
+    [Fact]
+    public async Task ImportCkl_EvidenceContent_ContainsSummaryJson()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var evidence = await ctx.Evidence
+            .Where(e => e.EvidenceType == "StigChecklist")
+            .FirstOrDefaultAsync();
+
+        evidence.Should().NotBeNull();
+        evidence!.Content.Should().Contain("CKL");
+        evidence.Content.Should().Contain("OpenCount");
+    }
+
+    [Fact]
+    public async Task ImportCkl_EvidenceLinkedToEffectiveness()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var effRecords = await ctx.ControlEffectivenessRecords
+            .Where(e => e.AssessmentId == TestAssessmentId)
+            .ToListAsync();
+
+        effRecords.Should().NotBeEmpty();
+        effRecords.Should().OnlyContain(e => e.EvidenceIds.Count > 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T028: Conflict Resolution Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_Skip_ExistingFindingUnchanged()
+    {
+        // First import
+        var entry1 = BuildEntry("V-254239", "Open", findingDetails: "Original details");
+        var parsed1 = BuildParsedCkl(entry1);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed1);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "first.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import with Skip resolution
+        var entry2 = BuildEntry("V-254239", "NotAFinding", findingDetails: "Updated details");
+        var parsed2 = BuildParsedCkl(entry2);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed2);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "second.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Finding not updated
+        result.SkippedCount.Should().Be(1);
+        result.FindingsUpdated.Should().Be(0);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254239").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Open); // Original status
+        finding.Description.Should().Contain("Original details");
+    }
+
+    [Fact]
+    public async Task ImportCkl_Overwrite_FindingUpdatedWithImportedData()
+    {
+        // First import
+        var entry1 = BuildEntry("V-254239", "Open", findingDetails: "Original details");
+        var parsed1 = BuildParsedCkl(entry1);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed1);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "first.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import with Overwrite
+        var entry2 = BuildEntry("V-254239", "NotAFinding", findingDetails: "Now remediated");
+        var parsed2 = BuildParsedCkl(entry2);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed2);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "second.ckl",
+            ImportConflictResolution.Overwrite, false, TestImporter);
+
+        result.FindingsUpdated.Should().Be(1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254239").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Remediated);
+        finding.Description.Should().Contain("Now remediated");
+    }
+
+    [Fact]
+    public async Task ImportCkl_Merge_SeverityTakesHigherValue()
+    {
+        // First import: medium severity
+        var entry1 = BuildEntry("V-254240", "Open", severity: "medium");
+        var parsed1 = BuildParsedCkl(entry1);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed1);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "first.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import with Merge: high severity (should upgrade)
+        var entry2 = BuildEntry("V-254240", "Open", severity: "high");
+        var parsed2 = BuildParsedCkl(entry2);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed2);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "second.ckl",
+            ImportConflictResolution.Merge, false, TestImporter);
+
+        result.FindingsUpdated.Should().Be(1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254240").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Severity.Should().Be(FindingSeverity.High);
+        finding.CatSeverity.Should().Be(CatSeverity.CatI);
+    }
+
+    [Fact]
+    public async Task ImportCkl_Merge_DetailsAppendedIfDifferent()
+    {
+        // First import
+        var entry1 = BuildEntry("V-254239", "Open", findingDetails: "First observation.");
+        var parsed1 = BuildParsedCkl(entry1);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed1);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "first.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import with Merge: different details
+        var entry2 = BuildEntry("V-254239", "Open", findingDetails: "Second observation.");
+        var parsed2 = BuildParsedCkl(entry2);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed2);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "second.ckl",
+            ImportConflictResolution.Merge, false, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.Where(f => f.StigId == "V-254239").FirstOrDefaultAsync();
+
+        finding.Should().NotBeNull();
+        finding!.Description.Should().Contain("First observation");
+        finding.Description.Should().Contain("Second observation");
+    }
+
+    [Fact]
+    public async Task ImportCkl_NoConflict_NewFindingCreatedRegardlessly()
+    {
+        // Import two different VULNs — no conflict
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "Open"),
+            BuildEntry("V-254240", "NotAFinding", severity: "medium")
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.FindingsCreated.Should().Be(2);
+        result.SkippedCount.Should().Be(0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T029: Dry-Run Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_DryRun_ReturnsAccurateCounts()
+    {
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "Open"),
+            BuildEntry("V-254240", "NotAFinding", severity: "medium"),
+            BuildEntry("V-254241", "Not_Applicable", severity: "low")
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, true, TestImporter);
+
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.TotalEntries.Should().Be(3);
+        result.OpenCount.Should().Be(1);
+        result.PassCount.Should().Be(1);
+        result.NotApplicableCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(2); // Open + NotAFinding (Not_Applicable skipped)
+    }
+
+    [Fact]
+    public async Task ImportCkl_DryRun_CreatesNoDbRecords()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, true, TestImporter);
+
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // No findings created
+        var findings = await ctx.Findings.Where(f => f.StigId == "V-254239").ToListAsync();
+        findings.Should().BeEmpty();
+
+        // No import records created
+        var imports = await ctx.ScanImportRecords.ToListAsync();
+        imports.Should().BeEmpty();
+
+        // No evidence created
+        var evidence = await ctx.Evidence
+            .Where(e => e.EvidenceType == "StigChecklist")
+            .ToListAsync();
+        evidence.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ImportCkl_DryRun_ResultsMatchNonDryRun()
+    {
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "Open"),
+            BuildEntry("V-254240", "NotAFinding", severity: "medium")
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Dry run first
+        var dryResult = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, true, TestImporter);
+
+        // Actual run
+        var actualResult = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: Counts should match
+        dryResult.TotalEntries.Should().Be(actualResult.TotalEntries);
+        dryResult.OpenCount.Should().Be(actualResult.OpenCount);
+        dryResult.PassCount.Should().Be(actualResult.PassCount);
+        dryResult.FindingsCreated.Should().Be(actualResult.FindingsCreated);
+        dryResult.UnmatchedCount.Should().Be(actualResult.UnmatchedCount);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Error Handling & Edge Cases
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportCkl_SystemNotFound_ReturnsFailedResult()
+    {
+        _rmfServiceMock.Setup(s => s.GetSystemAsync("nonexistent", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RegisteredSystem?)null);
+
+        var result = await _service.ImportCklAsync(
+            "nonexistent", null, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Status.Should().Be(ScanImportStatus.Failed);
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ImportCkl_ParseError_ReturnsFailedResult()
+    {
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>()))
+            .Throws(new CklParseException("bad.ckl", "Truncated XML at position 256"));
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "bad.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Status.Should().Be(ScanImportStatus.Failed);
+        result.ErrorMessage.Should().Contain("Truncated XML");
+    }
+
+    [Fact]
+    public async Task ImportCkl_EmptyEntries_CompletesWithZeroCounts()
+    {
+        var parsed = BuildParsedCkl(); // No entries
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "empty.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.TotalEntries.Should().Be(0);
+        result.FindingsCreated.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportCkl_DuplicateFile_WarningEmitted()
+    {
+        // First import
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var fileBytes = DummyFileContent;
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, fileBytes, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Second import with same file content
+        var result = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, fileBytes, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Warnings.Should().Contain(w => w.Contains("previously imported"));
+    }
+
+    [Fact]
+    public async Task ImportCkl_AssessmentNotFound_ReturnsFailedResult()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var result = await _service.ImportCklAsync(
+            TestSystemId, "nonexistent-assessment", DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Status.Should().Be(ScanImportStatus.Failed);
+        result.ErrorMessage.Should().Contain("Assessment");
+    }
+
+    [Fact]
+    public async Task ImportCkl_NoAssessmentId_AutoCreatesAssessment()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Pass null assessmentId — should auto-create
+        var result = await _service.ImportCklAsync(
+            TestSystemId, null, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.FindingsCreated.Should().Be(1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Utility Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ComputeSha256_ReturnsConsistentHash()
+    {
+        var data = "Hello, World!"u8.ToArray();
+        var hash1 = ScanImportService.ComputeSha256(data);
+        var hash2 = ScanImportService.ComputeSha256(data);
+
+        hash1.Should().Be(hash2);
+        hash1.Should().HaveLength(64); // 32 bytes = 64 hex chars
+        hash1.Should().MatchRegex("^[a-f0-9]{64}$");
+    }
+
+    [Fact]
+    public void ComputeSha256_DifferentInput_DifferentHash()
+    {
+        var hash1 = ScanImportService.ComputeSha256("ABC"u8.ToArray());
+        var hash2 = ScanImportService.ComputeSha256("XYZ"u8.ToArray());
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Import Management Tests (T048-T049)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ListImports_BySysemId_ReturnsCorrectResults()
+    {
+        // Seed some import records
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test1.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act
+        var (records, total) = await _service.ListImportsAsync(
+            TestSystemId, 1, 20, null, null, false, null, null);
+
+        // Assert
+        total.Should().BeGreaterThanOrEqualTo(1);
+        records.Should().NotBeEmpty();
+        records.Should().OnlyContain(r => r.RegisteredSystemId == TestSystemId);
+    }
+
+    [Fact]
+    public async Task GetImportSummary_ExistingImport_ReturnsDetails()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var importResult = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "test.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act
+        var summary = await _service.GetImportSummaryAsync(importResult.ImportRecordId);
+
+        // Assert
+        summary.Should().NotBeNull();
+        summary!.Value.Record.FileName.Should().Be("test.ckl");
+        summary.Value.Findings.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetImportSummary_NonExistent_ReturnsNull()
+    {
+        var summary = await _service.GetImportSummaryAsync("nonexistent-id");
+        summary.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListImports_ExcludesDryRuns_ByDefault()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // One dry run
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "dry.ckl",
+            ImportConflictResolution.Skip, true, TestImporter);
+
+        // One real import
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "real.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act: exclude dry runs (default)
+        var (records, _) = await _service.ListImportsAsync(
+            TestSystemId, 1, 20, null, null, false, null, null);
+
+        // Assert: Only real import should appear
+        records.Should().OnlyContain(r => !r.IsDryRun);
+    }
+
+    [Fact]
+    public async Task ListImports_ByBenchmark_FiltersCorrectly()
+    {
+        // Arrange: create two imports with different benchmark IDs
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "win2022.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act: filter by benchmark
+        var (records, _) = await _service.ListImportsAsync(
+            TestSystemId, 1, 20, "Windows_Server_2022_STIG", null, false, null, null);
+
+        // Assert
+        records.Should().OnlyContain(r =>
+            r.BenchmarkId != null &&
+            r.BenchmarkId.Contains("Windows_Server_2022", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ListImports_SystemWithNoImports_ReturnsEmptyList()
+    {
+        // Act: query a system that has no imports
+        var (records, total) = await _service.ListImportsAsync(
+            "no-imports-system", 1, 20, null, null, false, null, null);
+
+        // Assert
+        records.Should().BeEmpty();
+        total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetImportSummary_IncludesUnmatchedRules()
+    {
+        // Arrange: import with an unmatched rule
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-999999", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync(It.Is<string>(r => r.StartsWith("SV-999999")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync(It.Is<string>(r => r.StartsWith("SV-999999")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+
+        var entries = new[]
+        {
+            BuildEntry("V-254239", "Open"),
+            BuildEntry("V-999999", "Open", ruleId: "SV-999999r000000_rule")
+        };
+        var parsed = BuildParsedCkl(entries);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var importResult = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "unmatched.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act
+        var summary = await _service.GetImportSummaryAsync(importResult.ImportRecordId);
+
+        // Assert
+        summary.Should().NotBeNull();
+        summary!.Value.Record.UnmatchedCount.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task GetImportSummary_IncludesFindingCounts()
+    {
+        var entry = BuildEntry("V-254239", "Open");
+        var parsed = BuildParsedCkl(entry);
+        _cklParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        var importResult = await _service.ImportCklAsync(
+            TestSystemId, TestAssessmentId, DummyFileContent, "counts.ckl",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Act
+        var summary = await _service.GetImportSummaryAsync(importResult.ImportRecordId);
+
+        // Assert
+        summary.Should().NotBeNull();
+        summary!.Value.Record.TotalEntries.Should().BeGreaterThanOrEqualTo(1);
+        summary.Value.Record.FindingsCreated.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // T042: XCCDF Import Tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>Helper to build a parsed XCCDF file with the given rule results.</summary>
+    private static ParsedXccdfFile BuildParsedXccdf(params ParsedXccdfResult[] results)
+    {
+        return new ParsedXccdfFile(
+            BenchmarkHref: "xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG",
+            Title: "SCAP SCC Scan - Windows Server 2022",
+            Target: "web-server-01",
+            TargetAddress: "10.0.1.100",
+            StartTime: DateTime.UtcNow.AddMinutes(-15),
+            EndTime: DateTime.UtcNow,
+            Score: 72.5m,
+            MaxScore: 100m,
+            TargetFacts: new Dictionary<string, string>
+            {
+                ["urn:scap:fact:asset:identifier:host_name"] = "web-server-01"
+            },
+            Results: results.ToList());
+    }
+
+    private static ParsedXccdfResult BuildXccdfResult(
+        string ruleId, string result, string severity = "high",
+        string? message = null)
+    {
+        return new ParsedXccdfResult(
+            RuleIdRef: $"xccdf_mil.disa.stig_rule_{ruleId}",
+            ExtractedRuleId: ruleId,
+            Result: result,
+            Severity: severity,
+            Weight: 10.0m,
+            Timestamp: DateTime.UtcNow,
+            Message: message,
+            CheckRef: null);
+    }
+
+    private byte[] DummyXccdfContent => "dummy-xccdf-content"u8.ToArray();
+
+    private void SetupXccdfRuleIdResolution()
+    {
+        // XCCDF uses ResolveStigControlByRuleIdAsync which first tries RuleId, then derives VulnId
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync("SV-254239r849090_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigAc2);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync("SV-254240r849093_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigIa5);
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync("SV-254241r849096_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_stigSc7);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_FailResult_CreatesOpenFinding_OtherThanSatisfied()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.Status.Should().NotBe(ScanImportStatus.Failed);
+        result.FindingsCreated.Should().Be(1);
+        result.OpenCount.Should().Be(1);
+        result.EffectivenessRecordsCreated.Should().BeGreaterThanOrEqualTo(1);
+
+        // Verify finding in DB
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.FirstOrDefaultAsync(f => f.StigId == "V-254239");
+        finding.Should().NotBeNull();
+        finding!.Status.Should().Be(FindingStatus.Open);
+        finding.Source.Should().Be("XCCDF Import");
+
+        // Verify effectiveness
+        var eff = await ctx.ControlEffectivenessRecords
+            .FirstOrDefaultAsync(e => e.ControlId == "AC-2");
+        eff.Should().NotBeNull();
+        eff!.Determination.Should().Be(EffectivenessDetermination.OtherThanSatisfied);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_PassResult_CreatesSatisfiedEffectiveness()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254241r849096_rule", "pass", "low");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(1);
+        result.PassCount.Should().Be(1);
+
+        // Verify effectiveness
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var eff = await ctx.ControlEffectivenessRecords
+            .FirstOrDefaultAsync(e => e.ControlId == "SC-7");
+        eff.Should().NotBeNull();
+        eff!.Determination.Should().Be(EffectivenessDetermination.Satisfied);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_NotApplicable_DoesNotCreateFinding()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254241r849096_rule", "notapplicable", "medium");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.NotApplicableCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_ErrorResult_FlaggedForReview()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "error", "high",
+            message: "OVAL evaluation error");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.ErrorCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(0);
+        result.Warnings.Should().Contain(w => w.Contains("flagged for manual review"));
+    }
+
+    [Fact]
+    public async Task ImportXccdf_UnknownResult_FlaggedForReview()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254240r849093_rule", "unknown", "medium");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.ErrorCount.Should().Be(1);
+        result.Warnings.Should().Contain(w => w.Contains("unknown"));
+    }
+
+    [Fact]
+    public async Task ImportXccdf_CapturesXccdfScore()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: verify import record captured the score
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var record = await ctx.ScanImportRecords.FirstOrDefaultAsync();
+        record.Should().NotBeNull();
+        record!.XccdfScore.Should().Be(72.5m);
+        record.ImportType.Should().Be(ScanImportType.Xccdf);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_CollectionMethod_IsAutomated()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert: evidence should use "Automated" collection method
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var evidence = await ctx.Evidence.FirstOrDefaultAsync(e => e.EvidenceType == "XccdfScanResult");
+        evidence.Should().NotBeNull();
+        evidence!.CollectionMethod.Should().Be("Automated");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_UnmatchedRule_TrackedCorrectly()
+    {
+        // Arrange: rule ID not found in STIG knowledge
+        _stigServiceMock.Setup(s => s.GetStigControlByRuleIdAsync("SV-999999r000000_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("V-999999", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+        _stigServiceMock.Setup(s => s.GetStigControlAsync("SV-999999r000000_rule", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StigControl?)null);
+
+        var xccdfResult = BuildXccdfResult("SV-999999r000000_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.UnmatchedCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(0);
+        result.UnmatchedRules.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_MultipleResults_CountsCorrectly()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var results = new[]
+        {
+            BuildXccdfResult("SV-254239r849090_rule", "fail", "high"),
+            BuildXccdfResult("SV-254240r849093_rule", "fail", "medium"),
+            BuildXccdfResult("SV-254241r849096_rule", "pass", "low")
+        };
+        var parsed = BuildParsedXccdf(results);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.TotalEntries.Should().Be(3);
+        result.OpenCount.Should().Be(2);
+        result.PassCount.Should().Be(1);
+        result.FindingsCreated.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_DryRun_DoesNotPersist()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, true, TestImporter);
+
+        // Assert
+        result.FindingsCreated.Should().Be(1);
+
+        // Nothing persisted
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var findings = await ctx.Findings.Where(f => f.Source == "XCCDF Import").ToListAsync();
+        findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ImportXccdf_InvalidSystem_ReturnsFailed()
+    {
+        // Arrange: system not found
+        _rmfServiceMock.Setup(s => s.GetSystemAsync("bad-sys", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RegisteredSystem?)null);
+
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            "bad-sys", TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.Status.Should().Be(ScanImportStatus.Failed);
+        result.ErrorMessage.Should().Contain("bad-sys");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_SeverityMapping_CatIForHigh()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "fail", "high");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        using var scope = _serviceProvider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        var finding = await ctx.Findings.FirstOrDefaultAsync(f => f.StigId == "V-254239");
+        finding.Should().NotBeNull();
+        finding!.CatSeverity.Should().Be(CatSeverity.CatI);
+    }
+
+    [Fact]
+    public async Task ImportXccdf_BenchmarkId_ExtractedCorrectly()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254239r849090_rule", "pass", "medium");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.BenchmarkId.Should().Be("Windows_Server_2022_STIG");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_NotcheckedResult_FlaggedAsError()
+    {
+        // Arrange
+        SetupXccdfRuleIdResolution();
+        var xccdfResult = BuildXccdfResult("SV-254240r849093_rule", "notchecked", "medium");
+        var parsed = BuildParsedXccdf(xccdfResult);
+        _xccdfParserMock.Setup(p => p.Parse(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(parsed);
+
+        // Act
+        var result = await _service.ImportXccdfAsync(
+            TestSystemId, TestAssessmentId, DummyXccdfContent, "scan.xccdf",
+            ImportConflictResolution.Skip, false, TestImporter);
+
+        // Assert
+        result.ErrorCount.Should().Be(1);
+        result.Warnings.Should().Contain(w => w.Contains("notchecked"));
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.ckl
+++ b/tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.ckl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.17-->
+<CHECKLIST>
+  <ASSET>
+    <HOST_NAME>broken-server</HOST_NAME>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>Broken_STIG</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-999999</ATTRIBUTE_DATA>
+        <!-- Missing closing tags to create malformed XML -->

--- a/tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.xccdf
+++ b/tests/Ato.Copilot.Tests.Unit/TestData/sample-malformed.xccdf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestResult xmlns="http://checklists.nist.gov/xccdf/1.2"
+            id="xccdf_mil.disa.stig_testresult_default">
+  <benchmark href="xccdf_mil.disa.stig_benchmark_BROKEN"/>
+  <target>broken-host</target>
+  <!-- Malformed: missing closing tags, truncated XML -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-999999r1_rule"
+               severity="high" weight="10.0">
+    <result>fail</result>

--- a/tests/Ato.Copilot.Tests.Unit/TestData/sample-severity-override.ckl
+++ b/tests/Ato.Copilot.Tests.Unit/TestData/sample-severity-override.ckl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.17-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>None</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>secure-server-01</HOST_NAME>
+    <HOST_IP>10.0.2.50</HOST_IP>
+    <HOST_MAC>AA:BB:CC:DD:EE:FF</HOST_MAC>
+    <HOST_FQDN>secure-server-01.example.mil</HOST_FQDN>
+    <TARGET_COMMENT></TARGET_COMMENT>
+    <TECH_AREA></TECH_AREA>
+    <TARGET_KEY>5001</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>Windows_Server_2022_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 2 Benchmark Date: 15 Jun 2025</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Microsoft Windows Server 2022 STIG</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <!-- VULN with severity override from medium to high -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254250</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000080-GPOS-00048</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254250r849120_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-SO-000010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must restrict unauthenticated RPC clients.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000213</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>RPC restrictions not applied per STIG guidance.</FINDING_DETAILS>
+        <COMMENTS>Override justified due to exposure on public-facing network segment.</COMMENTS>
+        <SEVERITY_OVERRIDE>high</SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION>This system is on a public-facing network segment. The risk of unauthenticated RPC access is elevated to CAT I per the site ISSM determination on 2026-01-15.</SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.ckl
+++ b/tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.ckl
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.17-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>None</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>web-server-01</HOST_NAME>
+    <HOST_IP>10.0.1.100</HOST_IP>
+    <HOST_MAC>00:0A:95:9D:68:16</HOST_MAC>
+    <HOST_FQDN>web-server-01.example.mil</HOST_FQDN>
+    <TARGET_COMMENT></TARGET_COMMENT>
+    <TECH_AREA></TECH_AREA>
+    <TARGET_KEY>4089</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+    <WEB_DB_SITE></WEB_DB_SITE>
+    <WEB_DB_INSTANCE></WEB_DB_INSTANCE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>3</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>Windows_Server_2022_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 1 Benchmark Date: 23 Mar 2023</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Microsoft Windows Server 2022 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <!-- VULN 1: Open, high severity -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254239</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000003-GPOS-00004</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254239r849090_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-AU-000010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must be configured to audit Account Management - User Account Management successes.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000018</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000172</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>Audit policy not configured for Account Management - User Account Management.</FINDING_DETAILS>
+        <COMMENTS>Remediation scheduled for Sprint 42.</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <!-- VULN 2: Open, medium severity -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254240</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000004-GPOS-00004</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254240r849093_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-AU-000020</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must be configured to audit Logon/Logoff - Logon successes.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000067</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>Logon audit policy not enabled.</FINDING_DETAILS>
+        <COMMENTS></COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <!-- VULN 3: NotAFinding -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254241</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000037-GPOS-00015</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254241r849096_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-AU-000030</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must be configured to audit System - Security State Change successes.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>NotAFinding</STATUS>
+        <FINDING_DETAILS>Verified: Security State Change auditing is enabled.</FINDING_DETAILS>
+        <COMMENTS>Confirmed by system administrator on 2026-02-20.</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <!-- VULN 4: NotAFinding -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254242</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>low</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000038-GPOS-00016</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254242r849099_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-AU-000040</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 must audit System - Security System Extension successes.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>NotAFinding</STATUS>
+        <FINDING_DETAILS>Verified: System Extension auditing is enabled.</FINDING_DETAILS>
+        <COMMENTS></COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+      <!-- VULN 5: Not_Applicable -->
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-254243</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000095-GPOS-00049</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-254243r849102_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>WN22-DC-000010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Windows Server 2022 domain controllers must have a PKI certificate for authentication.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Not_Applicable</STATUS>
+        <FINDING_DETAILS>This system is not a domain controller.</FINDING_DETAILS>
+        <COMMENTS>N/A - member server only.</COMMENTS>
+        <SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.xccdf
+++ b/tests/Ato.Copilot.Tests.Unit/TestData/sample-valid.xccdf
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestResult xmlns="http://checklists.nist.gov/xccdf/1.2"
+            id="xccdf_mil.disa.stig_testresult_default"
+            start-time="2026-02-15T14:30:00"
+            end-time="2026-02-15T14:45:22">
+  <benchmark href="xccdf_mil.disa.stig_benchmark_Windows_Server_2022_STIG"/>
+  <title>SCAP SCC Scan Results - Windows Server 2022</title>
+  <identity authenticated="true" privileged="true">SYSTEM</identity>
+  <target>web-server-01</target>
+  <target-address>10.0.1.100</target-address>
+  <target-facts>
+    <fact name="urn:scap:fact:asset:identifier:host_name" type="string">web-server-01</fact>
+    <fact name="urn:scap:fact:asset:identifier:os_name" type="string">Microsoft Windows Server 2022</fact>
+    <fact name="urn:scap:fact:asset:identifier:os_version" type="string">10.0.20348</fact>
+  </target-facts>
+
+  <!-- Rule 1: FAIL - high severity -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254239r849090_rule"
+               time="2026-02-15T14:32:11"
+               severity="high" weight="10.0">
+    <result>fail</result>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="scap_mil.disa.stig_comp_U_MS_Windows_Server_2022_STIG_V1R1-oval.xml"
+                         name="oval:mil.disa.stig.windows_server_2022:def:254239"/>
+    </check>
+    <message severity="info">Registry value not configured as expected.</message>
+  </rule-result>
+
+  <!-- Rule 2: FAIL - medium severity -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254240r849093_rule"
+               time="2026-02-15T14:32:15"
+               severity="medium" weight="10.0">
+    <result>fail</result>
+    <message severity="info">Audit policy not properly configured.</message>
+  </rule-result>
+
+  <!-- Rule 3: PASS - medium severity -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254241r849096_rule"
+               time="2026-02-15T14:33:01"
+               severity="medium" weight="10.0">
+    <result>pass</result>
+  </rule-result>
+
+  <!-- Rule 4: PASS - low severity -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254242r849099_rule"
+               time="2026-02-15T14:33:05"
+               severity="low" weight="10.0">
+    <result>pass</result>
+  </rule-result>
+
+  <!-- Rule 5: NOT APPLICABLE -->
+  <rule-result idref="xccdf_mil.disa.stig_rule_SV-254243r849102_rule"
+               time="2026-02-15T14:33:10"
+               severity="medium" weight="10.0">
+    <result>notapplicable</result>
+  </rule-result>
+
+  <score system="urn:xccdf:scoring:default" maximum="100">72.5</score>
+</TestResult>

--- a/tests/Ato.Copilot.Tests.Unit/Tools/ScanImportToolTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Tools/ScanImportToolTests.cs
@@ -1,0 +1,773 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature 017 — SCAP/STIG Import: MCP Tool Unit Tests
+// Tests for ImportCklTool, ImportXccdfTool, ExportCklTool,
+// ListImportsTool, and GetImportSummaryTool.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using System.Text;
+using System.Text.Json;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
+using Ato.Copilot.Agents.Compliance.Tools;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Tools;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportCklTool Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class ImportCklToolTests : IDisposable
+{
+    private readonly Mock<IScanImportService> _importServiceMock = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly ImportCklTool _tool;
+
+    public ImportCklToolTests()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<AtoCopilotContext>(o =>
+            o.UseInMemoryDatabase($"ImportCklToolTests-{Guid.NewGuid()}"));
+        _serviceProvider = services.BuildServiceProvider();
+
+        _tool = new ImportCklTool(
+            _importServiceMock.Object,
+            _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ImportCklTool>.Instance);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    [Fact]
+    public void Name_ReturnsCorrectToolName()
+    {
+        _tool.Name.Should().Be("compliance_import_ckl");
+    }
+
+    [Fact]
+    public void Parameters_ContainAllRequiredAndOptionalKeys()
+    {
+        _tool.Parameters.Should().ContainKey("system_id");
+        _tool.Parameters.Should().ContainKey("file_content");
+        _tool.Parameters.Should().ContainKey("file_name");
+        _tool.Parameters.Should().ContainKey("conflict_resolution");
+        _tool.Parameters.Should().ContainKey("dry_run");
+        _tool.Parameters.Should().ContainKey("assessment_id");
+
+        _tool.Parameters["system_id"].Required.Should().BeTrue();
+        _tool.Parameters["file_content"].Required.Should().BeTrue();
+        _tool.Parameters["file_name"].Required.Should().BeTrue();
+        _tool.Parameters["conflict_resolution"].Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ImportCkl_MissingSystemId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ImportCkl_MissingFileContent_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = "",
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ImportCkl_MissingFileName_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = ""
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ImportCkl_InvalidBase64_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = "not-valid-base64!!!",
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_BASE64");
+    }
+
+    [Fact]
+    public async Task ImportCkl_FileTooLarge_ReturnsError()
+    {
+        var largeContent = new byte[6 * 1024 * 1024]; // 6 MB
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(largeContent),
+            ["file_name"] = "huge.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("FILE_TOO_LARGE");
+    }
+
+    [Fact]
+    public async Task ImportCkl_ValidInput_CallsServiceAndReturnsSuccess()
+    {
+        var cklContent = "<CHECKLIST><STIGS></STIGS></CHECKLIST>";
+        var importResult = new ImportResult(
+            ImportRecordId: "imp-1",
+            Status: ScanImportStatus.Completed,
+            BenchmarkId: "Windows_Server_2022_STIG",
+            BenchmarkTitle: "Windows Server 2022 STIG",
+            TotalEntries: 10,
+            OpenCount: 3,
+            PassCount: 5,
+            NotApplicableCount: 1,
+            NotReviewedCount: 1,
+            ErrorCount: 0,
+            SkippedCount: 0,
+            UnmatchedCount: 0,
+            FindingsCreated: 8,
+            FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 6,
+            EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 6,
+            UnmatchedRules: new List<UnmatchedRuleInfo>(),
+            Warnings: new List<string>(),
+            ErrorMessage: null);
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                "sys-1", null, It.IsAny<byte[]>(), "test.ckl",
+                ImportConflictResolution.Skip, false, "mcp-user",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(cklContent)),
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("import_record_id").GetString().Should().Be("imp-1");
+        data.GetProperty("import_status").GetString().Should().Be("Completed");
+        data.GetProperty("benchmark").GetString().Should().Be("Windows_Server_2022_STIG");
+        data.GetProperty("total_entries").GetInt32().Should().Be(10);
+
+        var summary = data.GetProperty("summary");
+        summary.GetProperty("open").GetInt32().Should().Be(3);
+        summary.GetProperty("pass").GetInt32().Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ImportCkl_DryRun_PassesDryRunParameter()
+    {
+        var importResult = new ImportResult(
+            ImportRecordId: "dry-1", Status: ScanImportStatus.Completed,
+            BenchmarkId: "test", BenchmarkTitle: "Test", TotalEntries: 1,
+            OpenCount: 0, PassCount: 1, NotApplicableCount: 0,
+            NotReviewedCount: 0, ErrorCount: 0, SkippedCount: 0,
+            UnmatchedCount: 0, FindingsCreated: 0, FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 0, EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 0, UnmatchedRules: new(), Warnings: new(),
+            ErrorMessage: null);
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                "sys-1", null, It.IsAny<byte[]>(), "test.ckl",
+                ImportConflictResolution.Skip, true, "mcp-user",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl",
+            ["dry_run"] = true
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("dry_run").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ImportCkl_ConflictResolution_ParsesOverwrite()
+    {
+        var importResult = new ImportResult(
+            ImportRecordId: "ow-1", Status: ScanImportStatus.Completed,
+            BenchmarkId: "test", BenchmarkTitle: "Test", TotalEntries: 1,
+            OpenCount: 0, PassCount: 1, NotApplicableCount: 0,
+            NotReviewedCount: 0, ErrorCount: 0, SkippedCount: 0,
+            UnmatchedCount: 0, FindingsCreated: 0, FindingsUpdated: 1,
+            EffectivenessRecordsCreated: 0, EffectivenessRecordsUpdated: 1,
+            NistControlsAffected: 1, UnmatchedRules: new(), Warnings: new(),
+            ErrorMessage: null);
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                "sys-1", null, It.IsAny<byte[]>(), "test.ckl",
+                ImportConflictResolution.Overwrite, false, "mcp-user",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl",
+            ["conflict_resolution"] = "Overwrite"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    [Fact]
+    public async Task ImportCkl_ServiceThrows_ReturnsImportFailedError()
+    {
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<byte[]>(),
+                It.IsAny<string>(), It.IsAny<ImportConflictResolution>(),
+                It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("System not found"));
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-invalid",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("IMPORT_FAILED");
+        json.RootElement.GetProperty("message").GetString().Should().Contain("System not found");
+    }
+
+    [Fact]
+    public async Task ImportCkl_WithAssessmentId_PassesToService()
+    {
+        var importResult = new ImportResult(
+            ImportRecordId: "aid-1", Status: ScanImportStatus.Completed,
+            BenchmarkId: "test", BenchmarkTitle: "Test", TotalEntries: 1,
+            OpenCount: 0, PassCount: 1, NotApplicableCount: 0,
+            NotReviewedCount: 0, ErrorCount: 0, SkippedCount: 0,
+            UnmatchedCount: 0, FindingsCreated: 1, FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 1, EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 1, UnmatchedRules: new(), Warnings: new(),
+            ErrorMessage: null);
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                "sys-1", "assess-42", It.IsAny<byte[]>(), "test.ckl",
+                ImportConflictResolution.Skip, false, "mcp-user",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl",
+            ["assessment_id"] = "assess-42"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        _importServiceMock.Verify(s => s.ImportCklAsync(
+            "sys-1", "assess-42", It.IsAny<byte[]>(), "test.ckl",
+            ImportConflictResolution.Skip, false, "mcp-user",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportCkl_FailedResult_ReturnsErrorStatus()
+    {
+        var importResult = new ImportResult(
+            ImportRecordId: "fail-1", Status: ScanImportStatus.Failed,
+            BenchmarkId: null, BenchmarkTitle: null, TotalEntries: 0,
+            OpenCount: 0, PassCount: 0, NotApplicableCount: 0,
+            NotReviewedCount: 0, ErrorCount: 1, SkippedCount: 0,
+            UnmatchedCount: 0, FindingsCreated: 0, FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 0, EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 0, UnmatchedRules: new(), Warnings: new(),
+            ErrorMessage: "Invalid CKL structure");
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<byte[]>(),
+                It.IsAny<string>(), It.IsAny<ImportConflictResolution>(),
+                It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "bad.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("data").GetProperty("error_message").GetString().Should().Be("Invalid CKL structure");
+    }
+
+    [Fact]
+    public async Task ImportCkl_UnmatchedRules_AppearsInOutput()
+    {
+        var importResult = new ImportResult(
+            ImportRecordId: "um-1", Status: ScanImportStatus.CompletedWithWarnings,
+            BenchmarkId: "test", BenchmarkTitle: "Test", TotalEntries: 3,
+            OpenCount: 1, PassCount: 1, NotApplicableCount: 0,
+            NotReviewedCount: 0, ErrorCount: 0, SkippedCount: 0,
+            UnmatchedCount: 1, FindingsCreated: 2, FindingsUpdated: 0,
+            EffectivenessRecordsCreated: 2, EffectivenessRecordsUpdated: 0,
+            NistControlsAffected: 2,
+            UnmatchedRules: new List<UnmatchedRuleInfo>
+            {
+                new("V-999999", "SV-999999r1_rule", "Unknown Check", "high")
+            },
+            Warnings: new List<string> { "1 unmatched rule(s)" },
+            ErrorMessage: null);
+
+        _importServiceMock
+            .Setup(s => s.ImportCklAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<byte[]>(),
+                It.IsAny<string>(), It.IsAny<ImportConflictResolution>(),
+                It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(importResult);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "test.ckl"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("unmatched_rules").GetArrayLength().Should().Be(1);
+        data.GetProperty("warnings").GetArrayLength().Should().BeGreaterThan(0);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExportCklTool Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class ExportCklToolTests
+{
+    private readonly Mock<IScanImportService> _importServiceMock = new();
+    private readonly ExportCklTool _tool;
+
+    public ExportCklToolTests()
+    {
+        _tool = new ExportCklTool(
+            _importServiceMock.Object,
+            NullLogger<ExportCklTool>.Instance);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectToolName()
+    {
+        _tool.Name.Should().Be("compliance_export_ckl");
+    }
+
+    [Fact]
+    public async Task ExportCkl_MissingSystemId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "",
+            ["benchmark_id"] = "Windows_Server_2022_STIG"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ExportCkl_MissingBenchmarkId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["benchmark_id"] = ""
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ExportCkl_ValidInput_ReturnsBase64Content()
+    {
+        var expectedBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("<CHECKLIST/>"));
+
+        _importServiceMock
+            .Setup(s => s.ExportCklAsync("sys-1", "Windows_STIG", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedBase64);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["benchmark_id"] = "Windows_STIG"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("file_content").GetString().Should().Be(expectedBase64);
+        data.GetProperty("file_name").GetString().Should().Contain("Windows_STIG");
+    }
+
+    [Fact]
+    public async Task ExportCkl_ServiceThrows_ReturnsExportFailedError()
+    {
+        _importServiceMock
+            .Setup(s => s.ExportCklAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("No data"));
+
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["benchmark_id"] = "Windows_STIG"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("EXPORT_FAILED");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ListImportsTool Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class ListImportsToolTests
+{
+    private readonly Mock<IScanImportService> _importServiceMock = new();
+    private readonly ListImportsTool _tool;
+
+    public ListImportsToolTests()
+    {
+        _tool = new ListImportsTool(
+            _importServiceMock.Object,
+            NullLogger<ListImportsTool>.Instance);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectToolName()
+    {
+        _tool.Name.Should().Be("compliance_list_imports");
+    }
+
+    [Fact]
+    public async Task ListImports_MissingSystemId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?> { ["system_id"] = "" };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ListImports_ValidInput_ReturnsPagedResults()
+    {
+        var records = new List<ScanImportRecord>
+        {
+            new()
+            {
+                Id = "imp-1",
+                FileName = "test.ckl",
+                ImportType = ScanImportType.Ckl,
+                BenchmarkId = "Windows_STIG",
+                BenchmarkTitle = "Windows Server 2022 STIG",
+                ImportStatus = ScanImportStatus.Completed,
+                ImportedBy = "user1",
+                ImportedAt = DateTime.UtcNow.AddHours(-1),
+                TotalEntries = 10,
+                OpenCount = 3,
+                PassCount = 5,
+                FindingsCreated = 8,
+                FindingsUpdated = 0,
+                RegisteredSystemId = "sys-1"
+            }
+        };
+
+        _importServiceMock
+            .Setup(s => s.ListImportsAsync(
+                "sys-1", 1, 20, null, null, false, null, null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((records, 1));
+
+        var args = new Dictionary<string, object?> { ["system_id"] = "sys-1" };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("total_count").GetInt32().Should().Be(1);
+        data.GetProperty("imports").GetArrayLength().Should().Be(1);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetImportSummaryTool Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class GetImportSummaryToolTests
+{
+    private readonly Mock<IScanImportService> _importServiceMock = new();
+    private readonly GetImportSummaryTool _tool;
+
+    public GetImportSummaryToolTests()
+    {
+        _tool = new GetImportSummaryTool(
+            _importServiceMock.Object,
+            NullLogger<GetImportSummaryTool>.Instance);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectToolName()
+    {
+        _tool.Name.Should().Be("compliance_get_import_summary");
+    }
+
+    [Fact]
+    public async Task GetSummary_MissingImportId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?> { ["import_id"] = "" };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task GetSummary_NotFound_ReturnsNotFoundError()
+    {
+        _importServiceMock
+            .Setup(s => s.GetImportSummaryAsync("imp-999", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ValueTuple<ScanImportRecord, List<ScanImportFinding>>?)null);
+
+        var args = new Dictionary<string, object?> { ["import_id"] = "imp-999" };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task GetSummary_Found_ReturnsDetailedSummary()
+    {
+        var record = new ScanImportRecord
+        {
+            Id = "imp-1",
+            FileName = "windows.ckl",
+            FileHash = "abc123",
+            ImportType = ScanImportType.Ckl,
+            ImportStatus = ScanImportStatus.Completed,
+            BenchmarkId = "Windows_STIG",
+            BenchmarkTitle = "Windows Server 2022 STIG",
+            TargetHostName = "WEBSERVER01",
+            ImportedBy = "admin",
+            ImportedAt = DateTime.UtcNow,
+            TotalEntries = 5,
+            OpenCount = 2,
+            PassCount = 3,
+            FindingsCreated = 5,
+            NistControlsAffected = 4,
+            RegisteredSystemId = "sys-1"
+        };
+
+        var findings = new List<ScanImportFinding>
+        {
+            new()
+            {
+                Id = "f1",
+                ScanImportRecordId = "imp-1",
+                VulnId = "V-254239",
+                RuleId = "SV-254239r1_rule",
+                RawStatus = "Open",
+                MappedSeverity = CatSeverity.CatI,
+                ImportAction = ImportFindingAction.Created,
+                ResolvedStigControlId = "stig-1",
+                ResolvedNistControlIds = new List<string> { "AC-2" }
+            }
+        };
+
+        _importServiceMock
+            .Setup(s => s.GetImportSummaryAsync("imp-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((record, findings));
+
+        var args = new Dictionary<string, object?> { ["import_id"] = "imp-1" };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("id").GetString().Should().Be("imp-1");
+        data.GetProperty("target_host").GetString().Should().Be("WEBSERVER01");
+        data.GetProperty("findings").GetArrayLength().Should().Be(1);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportXccdfTool Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class ImportXccdfToolTests
+{
+    private readonly Mock<IScanImportService> _importServiceMock = new();
+    private readonly ImportXccdfTool _tool;
+
+    public ImportXccdfToolTests()
+    {
+        _tool = new ImportXccdfTool(
+            _importServiceMock.Object,
+            NullLogger<ImportXccdfTool>.Instance);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectToolName()
+    {
+        _tool.Name.Should().Be("compliance_import_xccdf");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_MissingSystemId_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "",
+            ["file_content"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("<xml/>")),
+            ["file_name"] = "results.xml"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_InvalidBase64_ReturnsError()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = "not-base64!!!",
+            ["file_name"] = "results.xml"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_BASE64");
+    }
+
+    [Fact]
+    public async Task ImportXccdf_FileTooLarge_ReturnsError()
+    {
+        var largeContent = new byte[6 * 1024 * 1024];
+        var args = new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_content"] = Convert.ToBase64String(largeContent),
+            ["file_name"] = "results.xml"
+        };
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result);
+
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("FILE_TOO_LARGE");
+    }
+}


### PR DESCRIPTION
This pull request introduces Feature 017: SCAP/STIG Viewer Import & Export, a major enhancement that enables ATO Copilot to import and export DISA STIG Viewer CKL checklists and SCAP Compliance Checker XCCDF results. The update provides new tools for automated compliance data ingestion, mapping, evidence capture, and export workflows, with detailed documentation and workflow guidance for ISSMs, SCAs, and engineers. The release also adds comprehensive documentation, workflow examples, and reference material for the new import/export capabilities.

**SCAP/STIG Import & Export Functionality:**

- Added tools for importing DISA STIG Viewer `.ckl` checklist files (`compliance_import_ckl`) and SCAP Compliance Checker XCCDF result files (`compliance_import_xccdf`), with automatic STIG rule resolution, NIST mapping, finding creation, and control effectiveness determination. Includes support for conflict resolution strategies (`Skip`, `Overwrite`, `Merge`), dry-run previews, and duplicate detection via SHA-256 hashing. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R37) [[2]](diffhunk://#diff-61f0b1f6e52ef55e32e0075cdb477df4de0315050060dc7cf00bcb84e20f6198R1725-R1949)
- Added export capability (`compliance_export_ckl`) to generate CKL files compatible with DISA STIG Viewer and eMASS upload, including proper mapping of finding statuses and benchmark metadata. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R37) [[2]](diffhunk://#diff-61f0b1f6e52ef55e32e0075cdb477df4de0315050060dc7cf00bcb84e20f6198R1725-R1949)
- Introduced import history (`compliance_list_imports`) and detailed import summaries (`compliance_get_import_summary`) with filtering, pagination, and per-finding breakdowns. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R37) [[2]](diffhunk://#diff-61f0b1f6e52ef55e32e0075cdb477df4de0315050060dc7cf00bcb84e20f6198R1725-R1949)

**Documentation & Workflow Guides:**

- Expanded documentation with step-by-step guides for ISSMs, SCAs, and engineers on using the new import/export tools, including workflow examples, chat command usage in VS Code, and integration with eMASS. [[1]](diffhunk://#diff-8cdfd1c8c23754154f45276278b594419aaf920f928e431155b2ea69d8dd3c88R301-R351) [[2]](diffhunk://#diff-1c8f5468999d09cd82269e3b574698fee55defb293f913df9a631aeceed43dd3R745-R829) [[3]](diffhunk://#diff-a6164e7bdaf3684c43a691e1cd4b02954afb4c5568cefad6a5c23df2666d2601R235-R287)
- Added reference material covering supported formats, import processing pipeline, status mapping tables, conflict resolution strategies, and duplicate detection mechanisms. [[1]](diffhunk://#diff-296fb785b0dab4c1ca2abdac237a8a8da8b7029a13dcc3b6457de7f04fa77869R146-R221) [[2]](diffhunk://#diff-61f0b1f6e52ef55e32e0075cdb477df4de0315050060dc7cf00bcb84e20f6198R1725-R1949)

**General Improvements and Highlights:**

- Updated the `README.md` to clarify ATO Copilot's unique value in automating control narrative writing, integrating with Azure, and supporting eMASS workflows.
- Documented new tools in the agent tool catalog, including parameters, response schemas, RBAC roles, and RMF step mapping. [[1]](diffhunk://#diff-61f0b1f6e52ef55e32e0075cdb477df4de0315050060dc7cf00bcb84e20f6198R1725-R1949) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R37)

These changes significantly expand ATO Copilot’s compliance automation capabilities, streamline STIG assessment workflows, and provide detailed documentation for end users and compliance teams.