### PR TITLE
feat(024-025): narrative governance + HW/SW inventory with docs

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -47,6 +47,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - Static markdown files in `docs/` directory, served via MkDocs (023-feature-docs-update)
 - C# 13 / .NET 9.0 + ASP.NET Core, EF Core 9.0.0, Serilog, DiffPlex (new — MIT, .NET Standard 2.0) (024-narrative-governance)
 - SQLite (dev) / SQL Server (prod) via EF Core dual-provider (024-narrative-governance)
+- C# 13 / .NET 9.0 + EF Core 9.0.0 (SQLite dev / SQL Server prod), ClosedXML (Excel I/O), System.Text.Json, FluentAssertions + xUnit + Moq (tests) (025-hw-sw-inventory)
+- EF Core — `AtoCopilotContext` with `DbSet<InventoryItem>`. SQLite for dev, SQL Server for prod. (025-hw-sw-inventory)
 
 - C# 13 / .NET 9.0 + Azure.Identity 1.13, Azure.ResourceManager 1.13, Microsoft.Extensions.AI 9.4-preview, Microsoft.EntityFrameworkCore 9.0, Serilog 4.2, xUnit 2.9, FluentAssertions 7.0, Moq 4.20 (001-core-compliance)
 
@@ -66,9 +68,9 @@ dotnet build Ato.Copilot.sln [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMAN
 C# .NET 9: Follow standard conventions
 
 ## Recent Changes
+- 025-hw-sw-inventory: Added C# 13 / .NET 9.0 + EF Core 9.0.0 (SQLite dev / SQL Server prod), ClosedXML (Excel I/O), System.Text.Json, FluentAssertions + xUnit + Moq (tests)
+- 025-hw-sw-inventory: Added C# 13 / .NET 9.0 + EF Core 9.0.0 (SQLite dev / SQL Server prod), ClosedXML (Excel I/O), System.Text.Json, FluentAssertions + xUnit + Moq (tests)
 - 024-narrative-governance: Added C# 13 / .NET 9.0 + ASP.NET Core, EF Core 9.0.0, Serilog, DiffPlex (new — MIT, .NET Standard 2.0)
-- 024-narrative-governance: Added [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
-- 023-feature-docs-update: Added Markdown (MkDocs Material theme) + MkDocs with Material theme, pymdownx extensions (admonition, superfences, tabbed, tasklist)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -927,6 +927,242 @@ Validate OSCAL SSP against NIST schema.
 
 ---
 
+## HW/SW Inventory (Feature 025)
+
+### `inventory_add_item`
+
+Register a hardware or software inventory item.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `item_name` | string | ✓ | Display name of the item |
+| `type` | string | ✓ | `hardware` or `software` |
+| `function` | string | ✓ | HW: `Server`, `Workstation`, `NetworkDevice`, `Storage`, `Other`; SW: `OperatingSystem`, `Database`, `Middleware`, `Application`, `SecurityTool`, `Other` |
+| `manufacturer` | string | | Manufacturer (required for hardware) |
+| `model` | string | | Hardware model |
+| `serial_number` | string | | Hardware serial number |
+| `ip_address` | string | | IP address (required for Server/NetworkDevice) |
+| `mac_address` | string | | MAC address |
+| `location` | string | | Physical location |
+| `vendor` | string | | Software vendor (required for software) |
+| `version` | string | | Software version (required for software) |
+| `patch_level` | string | | Current patch level |
+| `license_type` | string | | License type |
+| `parent_hardware_id` | string | | Parent hardware GUID (for software items) |
+
+**Response:** Created inventory item with generated GUID.
+
+### `inventory_update_item`
+
+Update fields on an existing inventory item. Only provided fields are changed.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | ✓ | Inventory item GUID |
+| `item_name` | string | | Updated display name |
+| `manufacturer` | string | | Updated manufacturer |
+| `model` | string | | Updated model |
+| `serial_number` | string | | Updated serial number |
+| `ip_address` | string | | Updated IP address |
+| `mac_address` | string | | Updated MAC address |
+| `location` | string | | Updated location |
+| `vendor` | string | | Updated vendor |
+| `version` | string | | Updated version |
+| `patch_level` | string | | Updated patch level |
+| `license_type` | string | | Updated license type |
+
+**Response:** Updated inventory item.
+
+### `inventory_decommission_item`
+
+Soft-delete an inventory item with a decommission rationale. Cascades to child software.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | ✓ | Inventory item GUID |
+| `rationale` | string | ✓ | Reason for decommissioning |
+
+**Response:** Decommissioned item with cascade count in metadata.
+
+### `inventory_list`
+
+List and filter inventory items with pagination.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `type` | string | | `hardware` or `software` |
+| `function` | string | | Function filter |
+| `vendor` | string | | Vendor/manufacturer filter |
+| `status` | string | | `active` (default) or `decommissioned` |
+| `search` | string | | Free-text search on item name |
+| `page_size` | integer | | Results per page (default 50) |
+| `page` | integer | | Page number (default 1) |
+
+**Response:** Paginated list of inventory items with count.
+
+### `inventory_get`
+
+Retrieve a single inventory item with installed software children.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | ✓ | Inventory item GUID |
+
+**Response:** Inventory item with installed software array for hardware items.
+
+### `inventory_export`
+
+Export inventory to an eMASS-compatible Excel workbook.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `export_type` | string | | `all` (default), `hardware`, or `software` |
+| `include_decommissioned` | boolean | | Include decommissioned items (default false) |
+
+**Response:** Base64-encoded Excel workbook with Hardware and Software worksheets.
+
+### `inventory_import`
+
+Import inventory from an eMASS-format Excel workbook.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `file_base64` | string | ✓ | Base64-encoded Excel file |
+| `dry_run` | boolean | | Preview import without persisting (default false) |
+
+**Response:** Import result with `hardware_created`, `software_created`, `rows_skipped`, and row-level errors.
+
+### `inventory_completeness`
+
+Check inventory completeness against boundary and field requirements.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+
+**Response:** Completeness report with `completeness_score`, `is_complete`, items with missing fields, unmatched boundary resources, and hardware without software.
+
+### `inventory_auto_seed`
+
+Auto-create hardware inventory items from authorization boundary resources.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+
+**Response:** List of created items with `created_count`. Idempotent — re-running skips existing items.
+
+---
+
+## Narrative Governance (Feature 024)
+
+**Service**: `INarrativeGovernanceService`
+
+### `compliance_narrative_history`
+
+Retrieve paginated version history for a control narrative (newest first).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `control_id` | string | ✓ | NIST 800-53 control ID (e.g., "AC-1") |
+| `page` | integer | | Page number (default: 1) |
+| `page_size` | integer | | Items per page (default: 50) |
+
+**Response:** Array of `versions` with `version_number`, `content`, `status`, `authored_by`, `authored_at`, `change_reason`. Includes `total_versions` count. Error codes: `SYSTEM_NOT_FOUND`, `CONTROL_NOT_FOUND`.
+
+### `compliance_narrative_diff`
+
+Compare two versions of a control narrative with line-level unified diff.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `control_id` | string | ✓ | NIST 800-53 control ID |
+| `from_version` | integer | ✓ | Base version number |
+| `to_version` | integer | ✓ | Target version number |
+
+**Response:** Unified diff text with `lines_added` and `lines_removed` counts. Error codes: `SYSTEM_NOT_FOUND`, `CONTROL_NOT_FOUND`, `VERSION_NOT_FOUND`.
+
+### `compliance_rollback_narrative`
+
+Roll back to a prior narrative version (copy-forward — creates new version with old content, resets to Draft).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `control_id` | string | ✓ | NIST 800-53 control ID |
+| `target_version` | integer | ✓ | Version number to roll back to |
+| `change_reason` | string | | Reason for rollback |
+
+**Response:** New version details with `new_version_number`, `rolled_back_to`, `status` (Draft). Error codes: `SYSTEM_NOT_FOUND`, `CONTROL_NOT_FOUND`, `VERSION_NOT_FOUND`, `UNDER_REVIEW`.
+
+### `compliance_submit_narrative`
+
+Submit a Draft narrative for ISSM review (transitions status to InReview).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `control_id` | string | ✓ | NIST 800-53 control ID |
+
+**Response:** Updated version with `previous_status`, `new_status` (InReview), `submitted_by`, `submitted_at`. Error codes: `SYSTEM_NOT_FOUND`, `CONTROL_NOT_FOUND`, `INVALID_STATUS`.
+
+### `compliance_review_narrative`
+
+Approve or request revision of a narrative under review. ISSM only.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `control_id` | string | ✓ | NIST 800-53 control ID |
+| `decision` | string | ✓ | `approve` or `request_revision` |
+| `comments` | string | | Reviewer comments (required for `request_revision`) |
+
+**Response:** Review result with `decision`, `new_status` (Approved or NeedsRevision), `reviewed_by`, `reviewed_at`. Error codes: `SYSTEM_NOT_FOUND`, `CONTROL_NOT_FOUND`, `INVALID_STATUS`, `COMMENTS_REQUIRED`.
+
+### `compliance_batch_review_narratives`
+
+Batch approve or request revision of narratives by family or control IDs. ISSM only.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `decision` | string | ✓ | `approve` or `request_revision` |
+| `comments` | string | | Reviewer comments (required for `request_revision`) |
+| `family_filter` | string | | Control family prefix (e.g., "AC"). Mutually exclusive with `control_ids` |
+| `control_ids` | string | | Comma-separated control IDs. Mutually exclusive with `family_filter` |
+
+**Response:** `reviewed_count`, `skipped_count`, `reviewed_controls`, `skipped_controls`. Error codes: `SYSTEM_NOT_FOUND`, `NO_REVIEWABLE_NARRATIVES`, `COMMENTS_REQUIRED`, `MUTUALLY_EXCLUSIVE_FILTERS`.
+
+### `compliance_narrative_approval_progress`
+
+Return aggregate approval status, per-family breakdown, review queue, and staleness warnings.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `family_filter` | string | | Control family prefix to filter results |
+
+**Response:** Overall counts (`total_controls`, `approved`, `draft`, `in_review`, `needs_revision`, `missing`, `approval_percentage`), `families` breakdown, `review_queue` (InReview control IDs), `staleness_warnings`. Error codes: `SYSTEM_NOT_FOUND`.
+
+### `compliance_batch_submit_narratives`
+
+Submit all Draft narratives for a control family (or all families) for ISSM review.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `family_filter` | string | | Control family prefix. If omitted, submits all Draft narratives |
+
+**Response:** `submitted_count`, `skipped_count`, `submitted_controls`, `skipped_controls`, `skipped_reason`. Error codes: `SYSTEM_NOT_FOUND`, `NO_DRAFT_NARRATIVES`.
+
+---
+
 ## Document Templates
 
 ### `compliance_upload_template`

--- a/docs/architecture/agent-tool-catalog.md
+++ b/docs/architecture/agent-tool-catalog.md
@@ -3062,3 +3062,130 @@ Submit all Draft narratives for a control family (or all families) for ISSM revi
   "resolution": "Verify INarrativeGovernanceService is registered and Feature024_NarrativeGovernance migration is applied."
 }
 ```
+
+---
+
+## HW/SW Inventory Tools (Feature 025)
+
+> **Feature 025**: HW/SW Inventory Management — Register, manage, import/export, and assess completeness of hardware and software inventory items.
+
+### `inventory_add_item`
+
+Register a hardware or software inventory item with function-based field validation.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM), Compliance.PlatformEngineer (Engineer)
+- **RMF Step**: Implement (Phase 3)
+- **Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | ✓ | System GUID, name, or acronym |
+| `item_name` | string | ✓ | Display name |
+| `type` | string | ✓ | `hardware` or `software` |
+| `function` | string | ✓ | HW: Server, Workstation, NetworkDevice, Storage, Other; SW: OperatingSystem, Database, Middleware, Application, SecurityTool, Other |
+| `manufacturer` | string | | Required for hardware |
+| `model` | string | | Hardware model |
+| `serial_number` | string | | Serial number |
+| `ip_address` | string | | Required for Server/NetworkDevice |
+| `mac_address` | string | | MAC address |
+| `location` | string | | Physical location |
+| `vendor` | string | | Required for software |
+| `version` | string | | Required for software |
+| `patch_level` | string | | Patch level |
+| `license_type` | string | | License type |
+| `parent_hardware_id` | string | | Parent HW GUID (for SW items) |
+
+- **Response**: Created item with `id`, `item_name`, `type`, `status`
+- **Errors**: `SYSTEM_NOT_FOUND`, `VALIDATION_FAILED`, `DUPLICATE_IP`, `INVALID_INPUT`
+
+### `inventory_update_item`
+
+Update fields on an existing inventory item (partial update — null fields unchanged).
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM), Compliance.PlatformEngineer (Engineer)
+- **RMF Step**: Implement (Phase 3)
+- **Parameters**: `item_id` (required), plus optional `item_name`, `manufacturer`, `model`, `serial_number`, `ip_address`, `mac_address`, `location`, `vendor`, `version`, `patch_level`, `license_type`
+- **Response**: Updated item
+- **Errors**: `ITEM_NOT_FOUND`, `DUPLICATE_IP`, `INVALID_INPUT`
+
+### `inventory_decommission_item`
+
+Soft-delete an inventory item. Cascades to child software items.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM)
+- **RMF Step**: Implement (Phase 3)
+- **Parameters**: `item_id` (required), `rationale` (required)
+- **Response**: Decommissioned item with cascaded child count in metadata
+- **Errors**: `ITEM_NOT_FOUND`, `ALREADY_DECOMMISSIONED`, `INVALID_INPUT`
+
+### `inventory_list`
+
+List and filter inventory items with pagination.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.Auditor (SCA), Compliance.PlatformEngineer (Engineer)
+- **RMF Step**: Implement (Phase 3), Assess (Phase 5)
+- **Parameters**: `system_id` (required), optional `type`, `function`, `vendor`, `status`, `search`, `page_size`, `page`
+- **Response**: `count`, `page`, `page_size`, `items[]`
+- **Errors**: `SYSTEM_NOT_FOUND`, `INVALID_INPUT`
+
+### `inventory_get`
+
+Retrieve a single inventory item with installed software children.
+
+- **RBAC**: All compliance roles
+- **RMF Step**: Any
+- **Parameters**: `item_id` (required)
+- **Response**: Item detail with `installed_software[]` for hardware items
+- **Errors**: `ITEM_NOT_FOUND`, `INVALID_INPUT`
+
+### `inventory_export`
+
+Export inventory to an eMASS-compatible Excel workbook with Hardware and Software worksheets.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM)
+- **RMF Step**: Implement (Phase 3), Authorize (Phase 6)
+- **Parameters**: `system_id` (required), optional `export_type` (`all`/`hardware`/`software`), `include_decommissioned`
+- **Response**: `file_base64` (base64-encoded .xlsx)
+- **Errors**: `SYSTEM_NOT_FOUND`, `NO_INVENTORY_DATA`
+
+### `inventory_import`
+
+Import inventory from an eMASS-format Excel workbook with dry-run support.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM)
+- **RMF Step**: Implement (Phase 3)
+- **Parameters**: `system_id` (required), `file_base64` (required), optional `dry_run`
+- **Response**: `hardware_created`, `software_created`, `rows_skipped`, `dry_run`, `errors[]`
+- **Errors**: `SYSTEM_NOT_FOUND`, `INVALID_BASE64`
+
+### `inventory_completeness`
+
+Check inventory completeness — missing fields, unmatched boundary resources, hardware without software.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.Auditor (SCA)
+- **RMF Step**: Implement (Phase 3), Assess (Phase 5)
+- **Parameters**: `system_id` (required)
+- **Response**: `completeness_score`, `is_complete`, `items_with_missing_fields[]`, `unmatched_boundary_resources[]`, `hardware_without_software[]`
+- **Errors**: `SYSTEM_NOT_FOUND`
+
+### `inventory_auto_seed`
+
+Auto-create hardware inventory items from authorization boundary resources. Idempotent via BoundaryResourceId FK.
+
+- **RBAC**: Compliance.Analyst (ISSO), Compliance.SecurityLead (ISSM)
+- **RMF Step**: Implement (Phase 3)
+- **Parameters**: `system_id` (required)
+- **Response**: `created_count`, `items[]`
+- **Errors**: `SYSTEM_NOT_FOUND`, `NO_BOUNDARY_DATA`
+
+### Troubleshooting — HW/SW Inventory Tools
+
+**"Tool not found" error**: Inventory tools require Feature 025 to be deployed with `IInventoryService` registered in DI. Verify the service is registered in `ServiceCollectionExtensions.cs`.
+
+```json
+{
+  "status": "error",
+  "error": "Tool 'inventory_add_item' not found. Feature 025 (HW/SW Inventory) may not be deployed in this environment.",
+  "resolution": "Verify IInventoryService is registered and database migration is applied."
+}
+```

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -791,6 +791,53 @@ ISCP reference for SSP §13 (Feature 022).
 
 ---
 
+## Inventory Entities
+
+### InventoryItem
+
+HW/SW inventory item linked to a registered system (Feature 025).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Id` | `string(36)` | Primary key (GUID) |
+| `RegisteredSystemId` | `string` | FK → RegisteredSystem |
+| `ItemName` | `string(200)` | Display name |
+| `Type` | `InventoryItemType` | `Hardware` or `Software` |
+| `HardwareFunction` | `HardwareFunction?` | Server, Workstation, NetworkDevice, Storage, Other |
+| `SoftwareFunction` | `SoftwareFunction?` | OperatingSystem, Database, Middleware, Application, SecurityTool, Other |
+| `Manufacturer` | `string?` | Hardware manufacturer |
+| `Model` | `string?` | Hardware model |
+| `SerialNumber` | `string?` | Hardware serial number |
+| `IpAddress` | `string?` | IP address (unique within system for active items) |
+| `MacAddress` | `string?` | MAC address |
+| `Location` | `string?` | Physical location |
+| `Vendor` | `string?` | Software vendor |
+| `Version` | `string?` | Software version |
+| `PatchLevel` | `string?` | Current patch level |
+| `LicenseType` | `string?` | License type |
+| `Status` | `InventoryItemStatus` | `Active` or `Decommissioned` |
+| `ParentHardwareId` | `string?` | Self-referencing FK for SW installed on HW |
+| `BoundaryResourceId` | `string?` | FK linking to AuthorizationBoundary resource |
+| `DecommissionDate` | `DateTime?` | When decommissioned |
+| `DecommissionRationale` | `string?` | Reason for decommissioning |
+| `CreatedBy` | `string` | Identity of creator |
+| `CreatedAt` | `DateTime` | Creation timestamp |
+| `ModifiedBy` | `string?` | Last modifier identity |
+| `ModifiedAt` | `DateTime?` | Last modification timestamp |
+
+**Relationships:**
+
+- Many InventoryItems → one RegisteredSystem
+- Self-referencing: Software → parent Hardware via `ParentHardwareId`
+- Optional link to AuthorizationBoundary via `BoundaryResourceId` (auto-seed)
+
+**Indexes:**
+
+- Composite: `RegisteredSystemId` + `Type`
+- Unique: `IpAddress` within system (for active items)
+
+---
+
 ## Core Compliance Entities
 
 | Entity | Purpose |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -82,6 +82,7 @@ ATO Copilot is a compliance-focused MCP (Model Context Protocol) agent server bu
 │  │  RmfLifecycle │ Categorization │ Baseline │ Ssp      │          │
 │  │  Assessment │ Authorization │ ConMon │ eMASS        │          │
 │  │  AtoCompliance │ Remediation │ KanbanService        │          │
+│  │  NarrativeGovernance │ InventoryService               │          │
 │  └───────────────────────────────────────────────────────┘          │
 │                                                                     │
 │  ┌───────────────────────────────────────────────────────┐          │
@@ -97,7 +98,7 @@ ATO Copilot is a compliance-focused MCP (Model Context Protocol) agent server bu
 │ Ato.Copilot  │  │ Ato.Copilot  │  │ Azure SDKs   │
 │ .Core        │  │ .State       │  │              │
 │ ├─ DbContext │  │ ├─ Agent     │  │ ├─ ARM       │
-│ │  (45+ sets)│  │ │  State     │  │ ├─ Resource  │
+│ │  (46+ sets)│  │ │  State     │  │ ├─ Resource  │
 │ ├─ Models    │  │ ├─ Conver-   │  │ │  Graph     │
 │ ├─ Config    │  │ │  sation    │  │ ├─ Policy    │
 │ ├─ Constants │  │ └─ State     │  │ ├─ Defender  │

--- a/docs/getting-started/engineer.md
+++ b/docs/getting-started/engineer.md
@@ -71,6 +71,8 @@ ATO Copilot integrates directly into your VS Code workflow:
 - **Quick Fix** — Lightbulb Code Actions to apply suggested fixes from STIG findings
 - **Hover Info** — Shows NIST control + STIG rule + CAT severity on hover
 - **`@ato` Chat Participant** — Ask compliance questions in natural language from the Copilot Chat panel
+- **Narrative Governance** — View narrative version history, compare changes, and submit narratives for ISSM review (`compliance_narrative_history`, `compliance_narrative_diff`, `compliance_submit_narrative`)
+- **HW/SW Inventory** — Register deployed software components and keep versions current (`inventory_add_item`, `inventory_update_item`)
 
 ## What's Next
 

--- a/docs/getting-started/isso.md
+++ b/docs/getting-started/isso.md
@@ -73,6 +73,8 @@ Beyond narrative authoring and Watch monitoring, ISSOs can also:
 - **Register interconnections** — Document system-to-system connections crossing the authorization boundary (`compliance_add_interconnection`)
 - **Author SSP sections** — Write NIST 800-18 SSP sections and submit them for ISSM review (`compliance_write_ssp_section`)
 - **Track SSP completeness** — Monitor overall SSP readiness percentage (`compliance_ssp_completeness`)
+- **Manage narrative governance** — View version history, diff changes, roll back edits, and submit narratives for ISSM approval (`compliance_narrative_history`, `compliance_narrative_diff`, `compliance_rollback_narrative`, `compliance_submit_narrative`, `compliance_batch_submit_narratives`)
+- **Manage HW/SW inventory** — Register hardware and software, auto-seed from boundary, check completeness, and export to eMASS Excel (`inventory_add_item`, `inventory_auto_seed`, `inventory_completeness`, `inventory_export`)
 
 ---
 

--- a/docs/guides/engineer-guide.md
+++ b/docs/guides/engineer-guide.md
@@ -536,6 +536,53 @@ Tool: `compliance_narrative_approval_progress` — shows per-family approval %, 
 
 ---
 
+## HW/SW Inventory — Component Registration
+
+> **Feature 025** — Engineers register the software components they deploy and keep version information current.
+
+### Registering a Software Component
+
+After deploying a new application or service, register it in the inventory:
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "{system-id}",
+  "item_name": "my-api-service",
+  "type": "software",
+  "function": "Application",
+  "vendor": "Internal",
+  "version": "1.2.0",
+  "parent_hardware_id": "{server-id}"
+}
+```
+
+### Updating Version After Deployment
+
+When you push a new version, update the inventory to keep it current:
+
+```
+Tool: inventory_update_item
+Parameters: {
+  "item_id": "{item-id}",
+  "version": "1.3.0",
+  "patch_level": "2024-01-15"
+}
+```
+
+### Checking Inventory Coverage
+
+```
+Tool: inventory_list
+Parameters: {
+  "system_id": "{system-id}",
+  "type": "software",
+  "search": "api"
+}
+```
+
+---
+
 ## See Also
 
 - [Engineer Getting Started](../getting-started/engineer.md) — First-time setup and first 3 commands

--- a/docs/guides/issm-guide.md
+++ b/docs/guides/issm-guide.md
@@ -1278,6 +1278,110 @@ Before submitting the authorization package, verify:
 
 ---
 
+## HW/SW Inventory Management
+
+> **Feature 025** — Register, manage, import/export, and verify completeness of hardware and software inventory items for eMASS and SSP §11.
+
+### Quick-Start: Auto-Seed from Boundary
+
+If the system already has an authorization boundary defined, auto-seed creates inventory items from boundary resources:
+
+```
+Tool: inventory_auto_seed
+Parameters: { "system_id": "{system-id}" }
+```
+
+The tool maps Azure resource types to hardware functions (VMs → Server, NSGs → NetworkDevice, Storage → Storage) and links each item back to its boundary resource for traceability.
+
+### Registering Inventory Items
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "{system-id}",
+  "item_name": "web-server-01",
+  "type": "hardware",
+  "function": "Server",
+  "manufacturer": "Dell",
+  "ip_address": "10.0.0.1"
+}
+```
+
+For software installed on hardware:
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "{system-id}",
+  "item_name": "RHEL 9.2",
+  "type": "software",
+  "function": "OperatingSystem",
+  "vendor": "Red Hat",
+  "version": "9.2",
+  "parent_hardware_id": "{hw-item-id}"
+}
+```
+
+### Completeness Check
+
+Before exporting to eMASS, verify inventory completeness:
+
+```
+Tool: inventory_completeness
+Parameters: { "system_id": "{system-id}" }
+```
+
+The tool checks three dimensions:
+1. **Missing required fields** — items lacking manufacturer, IP (for servers), vendor (for software)
+2. **Unmatched boundary resources** — boundary resources with no corresponding inventory entry
+3. **Hardware without software** — servers/workstations with no installed software registered
+
+### Export to eMASS Excel
+
+```
+Tool: inventory_export
+Parameters: { "system_id": "{system-id}" }
+```
+
+Produces an Excel workbook with separate Hardware and Software worksheets matching the eMASS format.
+
+### Import from Excel
+
+```
+Tool: inventory_import
+Parameters: {
+  "system_id": "{system-id}",
+  "file_base64": "{base64-encoded-xlsx}",
+  "dry_run": true
+}
+```
+
+Use `dry_run: true` to preview the import before persisting. Row-level errors are reported with worksheet name, row number, and error detail.
+
+### Decommissioning
+
+```
+Tool: inventory_decommission_item
+Parameters: {
+  "item_id": "{item-id}",
+  "rationale": "End of life — replaced by web-server-02"
+}
+```
+
+Decommissioning a hardware item automatically cascades to all installed software.
+
+### ISSM Inventory Workflow
+
+```
+1. inventory_auto_seed                ← Quick-start from boundary
+2. inventory_add_item (repeat)        ← Add items not in boundary
+3. inventory_completeness             ← Verify coverage
+4. inventory_export                   ← Export for eMASS
+5. compliance_generate_ssp            ← §11 includes HW/SW tables
+```
+
+---
+
 ## See Also
 
 - [ISSM Getting Started](../getting-started/issm.md) — First-time setup and first 3 commands

--- a/docs/guides/sca-guide.md
+++ b/docs/guides/sca-guide.md
@@ -459,6 +459,45 @@ Before generating the SAR, verify:
 
 ---
 
+## Inventory Verification
+
+> **Feature 025** — Before assessment, verify that the HW/SW inventory is complete and accurate.
+
+### Check Inventory Completeness
+
+```
+Tool: inventory_completeness
+Parameters: { "system_id": "{system-id}" }
+```
+
+Review the completeness report for:
+- Items with missing required fields
+- Boundary resources without corresponding inventory entries
+- Hardware items without any registered software
+
+### Review Inventory List
+
+```
+Tool: inventory_list
+Parameters: {
+  "system_id": "{system-id}",
+  "type": "hardware"
+}
+```
+
+Cross-reference against the authorization boundary to verify all in-scope resources are registered.
+
+### Pre-Assessment Inventory Checklist
+
+```
+1. inventory_completeness             ← Verify is_complete = true
+2. inventory_list (type=hardware)     ← Verify HW entries match boundary
+3. inventory_list (type=software)     ← Verify SW entries with versions
+4. inventory_export                   ← Archive inventory snapshot
+```
+
+---
+
 ## See Also
 
 - [SCA Getting Started](../getting-started/sca.md) — First-time setup and first 3 commands

--- a/docs/persona-test-cases/environment-checklist.md
+++ b/docs/persona-test-cases/environment-checklist.md
@@ -17,7 +17,7 @@ This checklist must be completed **before** any persona test case execution begi
 | 1.1 | Solution builds | `dotnet build Ato.Copilot.sln` | Build succeeded, 0 errors | ⬜ | |
 | 1.2 | MCP server starts | `dotnet run --project src/Ato.Copilot.Mcp` | Server listening on configured port | ⬜ | Port: ___ |
 | 1.3 | Health endpoint responds | `curl http://localhost:{port}/health` | 200 OK within 5s | ⬜ | |
-| 1.4 | Tool count ≥ 136 | Query `/tools/list` endpoint | Returns ≥ 136 registered tools | ⬜ | Actual: ___ |
+| 1.4 | Tool count ≥ 145 | Query `/tools/list` endpoint | Returns ≥ 145 registered tools | ⬜ | Actual: ___ |
 | 1.5 | All 106 spec tools present | Cross-reference `/tools/list` against research.md tool list | 0 missing tools | ⬜ | Missing: ___ |
 
 ### 106 Spec-Referenced Tools
@@ -182,6 +182,19 @@ Verify each tool is in the `/tools/list` response:
 - [ ] `jit_request_access`
 
 **Tool Count**: 106 tools | **Verified**: ___/106
+
+**HW/SW Inventory (9)** — F025
+- [ ] `inventory_add_item`
+- [ ] `inventory_update_item`
+- [ ] `inventory_decommission_item`
+- [ ] `inventory_list`
+- [ ] `inventory_get`
+- [ ] `inventory_export`
+- [ ] `inventory_import`
+- [ ] `inventory_completeness`
+- [ ] `inventory_auto_seed`
+
+**Inventory Tool Count**: 9 tools | **Verified**: ___/9
 
 </details>
 

--- a/docs/persona-test-cases/results-template.md
+++ b/docs/persona-test-cases/results-template.md
@@ -180,6 +180,18 @@
 
 **Checkpoint**: ⬜ ISSM complete — Eagle Eye fully provisioned through Monitor phase
 
+### ISSM Narrative Governance (ISSM-NGV-01 to ISSM-NGV-05)
+
+| TC-ID | Task | Status | Duration | Actual Output | Notes |
+|-------|------|--------|----------|---------------|-------|
+| ISSM-NGV-01 | View narrative approval progress | ⬜ | | | approval_percentage: |
+| ISSM-NGV-02 | Review & approve AC-1 narrative | ⬜ | | | new_status: Approved |
+| ISSM-NGV-03 | Review & request revision (with comments) | ⬜ | | | new_status: NeedsRevision |
+| ISSM-NGV-04 | Batch approve AC family narratives | ⬜ | | | reviewed_count: skipped_count: |
+| ISSM-NGV-05 | View narrative version history (audit trail) | ⬜ | | | total_versions: |
+
+**Subtotal**: ___/5 passed | Avg duration: ___s
+
 ---
 
 ## Phase 4: ISSO Persona (US2) — 24 Test Cases
@@ -237,6 +249,34 @@
 | Issues Found | |
 
 **Checkpoint**: ⬜ ISSO complete — SSP authored, scans imported, monitoring active
+
+### ISSO Inventory Management (ISSO-INV-01 to ISSO-INV-07)
+
+| TC-ID | Task | Status | Duration | Actual Output | Notes |
+|-------|------|--------|----------|---------------|-------|
+| ISSO-INV-01 | Auto-seed inventory from boundary | ⬜ | | | created_count: |
+| ISSO-INV-02 | Add hardware item (web-server-01) | ⬜ | | | item_id: |
+| ISSO-INV-03 | Add software item on hardware | ⬜ | | | item_id: |
+| ISSO-INV-04 | Update hardware location | ⬜ | | | |
+| ISSO-INV-05 | Check inventory completeness | ⬜ | | | is_complete: score: |
+| ISSO-INV-06 | Export inventory to eMASS Excel | ⬜ | | | file received: |
+| ISSO-INV-07 | Decommission hardware (cascade) | ⬜ | | | cascaded_count: |
+
+**Subtotal**: ___/7 passed | Avg duration: ___s
+
+### ISSO Narrative Governance (ISSO-NGV-01 to ISSO-NGV-07)
+
+| TC-ID | Task | Status | Duration | Actual Output | Notes |
+|-------|------|--------|----------|---------------|-------|
+| ISSO-NGV-01 | Write narrative for AC-1 (creates version 1) | ⬜ | | | version_number: |
+| ISSO-NGV-02 | Update narrative (creates version 2 with change_reason) | ⬜ | | | version_number: |
+| ISSO-NGV-03 | View narrative version history | ⬜ | | | total_versions: |
+| ISSO-NGV-04 | Diff versions 1 and 2 | ⬜ | | | lines_added: lines_removed: |
+| ISSO-NGV-05 | Roll back to version 1 (creates version 3) | ⬜ | | | new_version_number: |
+| ISSO-NGV-06 | Submit narrative for ISSM review | ⬜ | | | new_status: InReview |
+| ISSO-NGV-07 | Batch submit AC family narratives | ⬜ | | | submitted_count: skipped_count: |
+
+**Subtotal**: ___/7 passed | Avg duration: ___s
 
 ---
 
@@ -296,6 +336,16 @@
 | Issues Found | |
 
 **Checkpoint**: ⬜ SCA complete — assessment artifacts generated, RBAC enforced
+
+### SCA Narrative Governance (SCA-NGV-01 to SCA-NGV-03)
+
+| TC-ID | Task | Status | Duration | Actual Output | Notes |
+|-------|------|--------|----------|---------------|-------|
+| SCA-NGV-01 | View narrative approval progress | ⬜ | | | approval_percentage: |
+| SCA-NGV-02 | View narrative version history for assessed control | ⬜ | | | total_versions: |
+| SCA-NGV-03 | Review narrative (DENIED — SCA cannot review) | ⬜ | | | 403 expected |
+
+**Subtotal**: ___/3 passed | Avg duration: ___s
 
 ---
 
@@ -420,6 +470,16 @@
 | Issues Found | |
 
 **Checkpoint**: ⬜ Engineer complete — all 5 persona sections finished (131 test cases)
+
+### Engineer Narrative Governance (ENG-NGV-01 to ENG-NGV-03)
+
+| TC-ID | Task | Status | Duration | Actual Output | Notes |
+|-------|------|--------|----------|---------------|-------|
+| ENG-NGV-01 | View narrative history after writing | ⬜ | | | total_versions: |
+| ENG-NGV-02 | Diff narrative versions | ⬜ | | | lines_added: lines_removed: |
+| ENG-NGV-03 | Submit narrative for ISSM review | ⬜ | | | new_status: InReview |
+
+**Subtotal**: ___/3 passed | Avg duration: ___s
 
 ---
 

--- a/docs/persona-test-cases/scripts/cross-persona-test-script.md
+++ b/docs/persona-test-cases/scripts/cross-persona-test-script.md
@@ -1405,3 +1405,43 @@ Check privacy compliance status for Eagle Eye
 | 3 | | | | | |
 
 **Cross-Persona & Edge Cases Status**: ☐ PASS / ☐ FAIL | **Tester**: __________ | **Date**: __________
+
+---
+
+## Scenario 5: HW/SW Inventory Cross-Persona Flow
+
+**Goal**: Verify inventory lifecycle across personas — Engineer registers → ISSO completeness check → SCA verifies → ISSO exports.
+
+| Step | Persona | Action | Tool | Expected |
+|------|---------|--------|------|----------|
+| 1 | ISSO | Auto-seed inventory from boundary | `inventory_auto_seed` | created_count > 0 |
+| 2 | Engineer | Register software component | `inventory_add_item` (software) | Item created |
+| 3 | Engineer | Update software version | `inventory_update_item` | Version updated |
+| 4 | ISSO | Check inventory completeness | `inventory_completeness` | Report generated |
+| 5 | SCA | List hardware items | `inventory_list` (type=hardware) | Items match boundary |
+| 6 | SCA | List software items | `inventory_list` (type=software) | Includes Engineer's item |
+| 7 | ISSO | Export to eMASS Excel | `inventory_export` | Excel workbook generated |
+| 8 | ISSO | Import from Excel (dry run) | `inventory_import` (dry_run=true) | Preview without persistence |
+| 9 | ISSO | Decommission end-of-life HW | `inventory_decommission_item` | Cascades to child SW |
+| 10 | SCA | Verify completeness post-decommission | `inventory_completeness` | Score reflects change |
+
+---
+
+## Scenario 6: Narrative Governance Cross-Persona Flow
+
+**Goal**: Verify the narrative governance lifecycle across personas — Engineer writes → ISSO submits → ISSM reviews → SCA verifies approval progress.
+
+| Step | Persona | Action | Tool | Expected |
+|------|---------|--------|------|----------|
+| 1 | Engineer | Write narrative for SC-7 | `compliance_write_narrative` | version_number: 1, status: Draft |
+| 2 | Engineer | Update narrative with change_reason | `compliance_write_narrative` | version_number: 2, status: Draft |
+| 3 | ISSO | View narrative version history | `compliance_narrative_history` | total_versions: 2 |
+| 4 | ISSO | Diff versions 1 and 2 | `compliance_narrative_diff` | Unified diff with lines_added/removed |
+| 5 | ISSO | Submit narrative for ISSM review | `compliance_submit_narrative` | new_status: InReview |
+| 6 | ISSM | View approval progress | `compliance_narrative_approval_progress` | Shows SC-7 in review_queue |
+| 7 | ISSM | Request revision with comments | `compliance_review_narrative` (request_revision) | new_status: NeedsRevision |
+| 8 | Engineer | Update narrative per ISSM feedback | `compliance_write_narrative` | new version created, status: Draft |
+| 9 | ISSO | Re-submit narrative | `compliance_submit_narrative` | new_status: InReview |
+| 10 | ISSM | Approve narrative | `compliance_review_narrative` (approve) | new_status: Approved |
+| 11 | SCA | Verify approval progress | `compliance_narrative_approval_progress` | SC-7 now in approved count |
+| 12 | SCA | View narrative history (audit trail) | `compliance_narrative_history` | Full version history visible |

--- a/docs/persona-test-cases/scripts/engineer-test-script.md
+++ b/docs/persona-test-cases/scripts/engineer-test-script.md
@@ -752,3 +752,82 @@ All configurations are enforced via Bicep IaC templates.
 - [ ] Issues documented
 
 **Engineer Section Status**: ☐ PASS / ☐ FAIL | **Tester**: __________ | **Date**: __________
+
+---
+
+## HW/SW Inventory — Component Registration (ENG-INV-01 to ENG-INV-03)
+
+### ENG-INV-01: Register Software Component
+
+**Task**: Register a deployed application in the inventory
+
+```text
+@ato Add software "my-api-service" version 1.2.0 to Eagle Eye — vendor Internal, function Application, installed on web-server-01
+```
+
+**Expected Tool**: `inventory_add_item`
+**Expected Output**: Created software item linked to parent hardware
+
+### ENG-INV-02: Update Software Version
+
+**Task**: Update version after a deployment
+
+```text
+@ato Update my-api-service version to 1.3.0, patch level 2024-01-15
+```
+
+**Expected Tool**: `inventory_update_item`
+**Expected Output**: Updated item with new version and patch level
+
+### ENG-INV-03: List Software Components
+
+**Task**: List all software items for the system
+
+```text
+@ato List all software inventory items for Eagle Eye
+```
+
+**Expected Tool**: `inventory_list` with `type` = "software"
+**Expected Output**: Paginated list including newly registered component
+
+---
+
+## Narrative Governance (ENG-NGV-01 to ENG-NGV-03)
+
+> Feature 024: Engineers can view narrative version history, compare versions, and submit narratives for ISSM review.
+
+### ENG-NGV-01: View Narrative Version History
+
+**Task**: View the version history for a control narrative the engineer has written
+
+```text
+@ato Show the version history for the SC-7 narrative of Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_history`
+**Expected Output**: List of versions (newest first) with `total_versions`, each showing `version_number`, `authored_by`, `change_reason`
+**Record**: total_versions = ___
+
+### ENG-NGV-02: Diff Narrative Versions
+
+**Task**: Compare two versions of a control narrative
+
+```text
+@ato Show the diff between version 1 and version 2 of the SC-7 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_diff`
+**Expected Output**: Unified diff text with `lines_added` and `lines_removed`
+**Record**: lines_added = ___ | lines_removed = ___
+
+### ENG-NGV-03: Submit Narrative for ISSM Review
+
+**Task**: Submit a completed narrative for ISSM review
+
+```text
+@ato Submit the SC-7 narrative for Eagle Eye for ISSM review
+```
+
+**Expected Tool**: `compliance_submit_narrative`
+**Expected Output**: `previous_status: Draft`, `new_status: InReview`
+**Record**: new_status = ___

--- a/docs/persona-test-cases/scripts/issm-test-script.md
+++ b/docs/persona-test-cases/scripts/issm-test-script.md
@@ -1324,3 +1324,95 @@ Import the latest Prisma Cloud scan for Eagle Eye to verify remediation
 | Compliance Score | _______________ | ISSM-33 |
 
 **Checkpoint**: ⬜ ISSM (61 tests) complete. Eagle Eye fully provisioned through Monitor phase with privacy, interconnections, and SSP review. ISSO testing can begin.
+
+---
+
+## HW/SW Inventory Review (ISSM-INV-01 to ISSM-INV-02)
+
+### ISSM-INV-01: Review Portfolio Inventory Status
+
+**Task**: Check inventory completeness across systems in portfolio
+
+```text
+@ato Check inventory completeness for Eagle Eye
+```
+
+**Expected Tool**: `inventory_completeness`
+**Expected Output**: Completeness report with score and issue breakdown
+
+### ISSM-INV-02: Review Inventory Export
+
+**Task**: Review eMASS-ready inventory export before submission
+
+```text
+@ato Export the HW/SW inventory for Eagle Eye including decommissioned items
+```
+
+**Expected Tool**: `inventory_export` with `include_decommissioned` = true
+**Expected Output**: Excel workbook with all items including decommissioned
+
+---
+
+## Narrative Governance — Approval Workflow (ISSM-NGV-01 to ISSM-NGV-05)
+
+> Feature 024: ISSM reviews, approves, and requests revisions on submitted narratives. Batch operations and progress dashboard supported.
+
+### ISSM-NGV-01: View Narrative Approval Progress
+
+**Task**: Check overall narrative approval progress across all control families
+
+```text
+@ato Show the narrative approval progress for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_approval_progress`
+**Expected Output**: Overall counts (`total_controls`, `approved`, `draft`, `in_review`, `needs_revision`, `missing`), `approval_percentage`, per-family breakdown, `review_queue`, `staleness_warnings`
+**Record**: approval_percentage = ___
+
+### ISSM-NGV-02: Review & Approve Narrative
+
+**Task**: Approve a submitted narrative for AC-1
+
+```text
+@ato Approve the AC-1 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_review_narrative` with `decision` = "approve"
+**Expected Output**: `previous_status: InReview`, `new_status: Approved`, `reviewed_by`, `reviewed_at`
+**Record**: new_status = ___
+
+### ISSM-NGV-03: Review & Request Revision
+
+**Task**: Request revision of a submitted narrative with comments
+
+```text
+@ato Request revision of the AC-2 narrative for Eagle Eye — comments: "Please add specific Azure AD configuration details for account management"
+```
+
+**Expected Tool**: `compliance_review_narrative` with `decision` = "request_revision"
+**Expected Output**: `new_status: NeedsRevision`, `comments` recorded
+**Record**: new_status = ___
+
+### ISSM-NGV-04: Batch Approve AC Family Narratives
+
+**Task**: Batch approve all InReview narratives in the AC family
+
+```text
+@ato Batch approve all AC family narratives for Eagle Eye
+```
+
+**Expected Tool**: `compliance_batch_review_narratives` with `decision` = "approve", `family_filter` = "AC"
+**Expected Output**: `reviewed_count`, `skipped_count`, `reviewed_controls`, `skipped_controls`
+**Record**: reviewed_count = ___ | skipped_count = ___
+
+### ISSM-NGV-05: View Narrative Version History (Audit Trail)
+
+**Task**: Review the version history for AC-1 to verify audit trail
+
+```text
+@ato Show the full version history for the AC-1 narrative of Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_history`
+**Expected Output**: Complete version list with `authored_by`, `authored_at`, `change_reason`, `status` for each version
+**Record**: total_versions = ___

--- a/docs/persona-test-cases/scripts/isso-test-script.md
+++ b/docs/persona-test-cases/scripts/isso-test-script.md
@@ -771,3 +771,182 @@ CAC revocation within 24 hours of departure.
 | SSP Completion | ___% | ISSO-34 |
 
 **Checkpoint**: ⬜ ISSO (35 tests) complete. SSP sections authored, scans imported, CKL exported, privacy analyzed, interconnections registered, monitoring active. SCA testing can begin.
+
+---
+
+## HW/SW Inventory Management (ISSO-INV-01 to ISSO-INV-07)
+
+### ISSO-INV-01: Auto-Seed from Boundary
+
+**Task**: Create initial inventory from boundary resources
+**Precondition**: Authorization boundary defined (ISSM phase)
+
+```text
+@ato Auto-seed the hardware inventory for Eagle Eye from the authorization boundary
+```
+
+**Expected Tool**: `inventory_auto_seed`
+**Expected Output**: List of created hardware items mapped from boundary resources
+**Verification**: `created_count` > 0; re-running returns `created_count` = 0 (idempotent)
+**Record**: created = ___
+
+### ISSO-INV-02: Add Hardware Item
+
+**Task**: Register a hardware item not in the boundary
+
+```text
+@ato Add hardware item "web-server-01" to Eagle Eye — it's a Dell Server at 10.0.0.1
+```
+
+**Expected Tool**: `inventory_add_item`
+**Expected Output**: Created item with `id`, `type` = "Hardware", `status` = "Active"
+**Record**: item_id = ___
+
+### ISSO-INV-03: Add Software on Hardware
+
+**Task**: Register software installed on the hardware item
+
+```text
+@ato Add software "RHEL 9.2" by Red Hat on web-server-01 in Eagle Eye — it's an OperatingSystem
+```
+
+**Expected Tool**: `inventory_add_item` with `parent_hardware_id`
+**Expected Output**: Created software item linked to parent hardware
+**Record**: item_id = ___
+
+### ISSO-INV-04: Update Hardware Location
+
+**Task**: Update the location field on an existing hardware item
+
+```text
+@ato Update web-server-01 location to "DC-East Rack A-12"
+```
+
+**Expected Tool**: `inventory_update_item`
+**Expected Output**: Updated item with new location, `modified_at` timestamp updated
+
+### ISSO-INV-05: Check Inventory Completeness
+
+**Task**: Verify inventory completeness before export
+
+```text
+@ato Check the inventory completeness for Eagle Eye
+```
+
+**Expected Tool**: `inventory_completeness`
+**Expected Output**: `completeness_score`, `is_complete`, lists of issues (if any)
+**Record**: score = ___, is_complete = ___
+
+### ISSO-INV-06: Export to eMASS Excel
+
+**Task**: Export inventory to Excel for eMASS upload
+
+```text
+@ato Export the HW/SW inventory for Eagle Eye to Excel
+```
+
+**Expected Tool**: `inventory_export`
+**Expected Output**: Base64-encoded Excel with Hardware and Software worksheets
+**Verification**: Decode and open file — verify two worksheets with correct column headers
+
+### ISSO-INV-07: Decommission Hardware (Cascade)
+
+**Task**: Decommission a hardware item and verify cascade to child software
+
+```text
+@ato Decommission web-server-01 — rationale: "End of life, replaced by web-server-02"
+```
+
+**Expected Tool**: `inventory_decommission_item`
+**Expected Output**: Item status = Decommissioned, child software also decommissioned
+**Record**: cascaded_children = ___
+
+---
+
+## Narrative Governance (ISSO-NGV-01 to ISSO-NGV-07)
+
+> Feature 024: Narrative version history, diff, rollback, and approval submission workflows.
+
+### ISSO-NGV-01: Write Narrative (Version 1)
+
+**Task**: Write a control narrative for AC-1 to create the initial version
+
+```text
+@ato Write the AC-1 narrative for Eagle Eye: "The organization develops, documents, and disseminates an access control policy..."
+```
+
+**Expected Tool**: `compliance_write_narrative`
+**Expected Output**: Narrative saved with `version_number: 1`, `approval_status: Draft`
+**Record**: version_number = ___
+
+### ISSO-NGV-02: Update Narrative (Version 2)
+
+**Task**: Update the AC-1 narrative with a change reason to create version 2
+
+```text
+@ato Update the AC-1 narrative for Eagle Eye: "Updated: The organization maintains access control policy consistent with..." — change reason: "Updated per ISSM feedback on 2026 assessment"
+```
+
+**Expected Tool**: `compliance_write_narrative` with `change_reason` parameter
+**Expected Output**: `version_number: 2`, `previous_version: 1`, `approval_status: Draft`
+**Record**: version_number = ___
+
+### ISSO-NGV-03: View Narrative Version History
+
+**Task**: Retrieve the full version history for AC-1
+
+```text
+@ato Show the version history for the AC-1 narrative of Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_history`
+**Expected Output**: List of versions (newest first) with `total_versions: 2`, each showing `version_number`, `authored_by`, `authored_at`, `change_reason`
+**Record**: total_versions = ___
+
+### ISSO-NGV-04: Diff Narrative Versions
+
+**Task**: Compare versions 1 and 2 of the AC-1 narrative
+
+```text
+@ato Show the diff between version 1 and version 2 of the AC-1 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_diff`
+**Expected Output**: Unified diff text with `lines_added` and `lines_removed` counts
+**Record**: lines_added = ___ | lines_removed = ___
+
+### ISSO-NGV-05: Rollback Narrative
+
+**Task**: Roll back AC-1 narrative to version 1 (creates version 3 as copy-forward)
+
+```text
+@ato Roll back the AC-1 narrative for Eagle Eye to version 1
+```
+
+**Expected Tool**: `compliance_rollback_narrative`
+**Expected Output**: `new_version_number: 3`, `rolled_back_to: 1`, `status: Draft`
+**Record**: new_version_number = ___
+
+### ISSO-NGV-06: Submit Narrative for ISSM Review
+
+**Task**: Submit the AC-1 narrative for ISSM review
+
+```text
+@ato Submit the AC-1 narrative for Eagle Eye for ISSM review
+```
+
+**Expected Tool**: `compliance_submit_narrative`
+**Expected Output**: `previous_status: Draft`, `new_status: InReview`, `submitted_by`, `submitted_at`
+**Record**: new_status = ___
+
+### ISSO-NGV-07: Batch Submit AC Family Narratives
+
+**Task**: Submit all Draft narratives in the AC family for ISSM review
+
+```text
+@ato Submit all AC family narratives for Eagle Eye for ISSM review
+```
+
+**Expected Tool**: `compliance_batch_submit_narratives` with `family_filter` = "AC"
+**Expected Output**: `submitted_count`, `skipped_count`, `submitted_controls`, `skipped_controls`
+**Record**: submitted_count = ___ | skipped_count = ___

--- a/docs/persona-test-cases/scripts/sca-test-script.md
+++ b/docs/persona-test-cases/scripts/sca-test-script.md
@@ -637,3 +637,83 @@ Dismiss alert ALT-{id}
 | SSP Completion | ___% | SCA-25 |
 
 **Checkpoint**: ⬜ SCA (29 tests) complete. Assessment artifacts generated, OSCAL validated, RBAC enforced. AO testing can begin.
+
+---
+
+## HW/SW Inventory Verification (SCA-INV-01 to SCA-INV-03)
+
+### SCA-INV-01: Check Inventory Completeness
+
+**Task**: Verify inventory completeness before assessment
+
+```text
+@ato Check inventory completeness for Eagle Eye
+```
+
+**Expected Tool**: `inventory_completeness`
+**Expected Output**: `completeness_score`, `is_complete`, `unmatched_boundary_resources`, `hardware_without_software`
+**Verification**: Review any incomplete items and flag to ISSO
+
+### SCA-INV-02: List Hardware Inventory
+
+**Task**: Review hardware inventory against boundary
+
+```text
+@ato List all hardware inventory items for Eagle Eye
+```
+
+**Expected Tool**: `inventory_list` with `type` = "hardware"
+**Expected Output**: List of hardware items matching boundary resources
+
+### SCA-INV-03: Export Inventory Snapshot
+
+**Task**: Archive inventory snapshot for assessment records
+
+```text
+@ato Export the inventory for Eagle Eye to Excel
+```
+
+**Expected Tool**: `inventory_export`
+**Expected Output**: Base64-encoded Excel workbook for archival
+
+---
+
+## Narrative Governance Verification (SCA-NGV-01 to SCA-NGV-03)
+
+> Feature 024: SCAs verify narrative approval status before assessment and cannot perform review actions.
+
+### SCA-NGV-01: View Narrative Approval Progress
+
+**Task**: Check overall narrative approval status before conducting assessment
+
+```text
+@ato Show the narrative approval progress for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_approval_progress`
+**Expected Output**: Overall approval percentage, per-family breakdown, review queue, staleness warnings
+**Record**: approval_percentage = ___
+
+### SCA-NGV-02: View Narrative Version History
+
+**Task**: Review the version history for a control under assessment
+
+```text
+@ato Show the version history for the AC-1 narrative of Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_history`
+**Expected Output**: List of versions showing authorship and approval status
+**Record**: total_versions = ___
+
+### SCA-NGV-03: Review Narrative (DENIED — RBAC)
+
+**Task**: Attempt to review a narrative (should be denied — SCA cannot review)
+
+```text
+@ato Approve the AC-1 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_review_narrative`
+**Expected Output**: 403 Forbidden — SCA role does not have review permissions
+**Record**: HTTP status = ___

--- a/docs/persona-test-cases/scripts/unified-rmf-test-script.md
+++ b/docs/persona-test-cases/scripts/unified-rmf-test-script.md
@@ -680,6 +680,168 @@ Validate all interconnection agreements for Eagle Eye
 
 ---
 
+### ISSO HW/SW Inventory (Feature 025)
+
+**Active Persona**: ISSO | **Role**: `Compliance.Analyst` | **Interface**: VS Code `@ato`
+
+---
+
+### ISSO-INV-01: Auto-Seed Inventory from Boundary
+
+**Precondition**: Authorization boundary defined
+
+```text
+@ato Auto-seed the hardware inventory for Eagle Eye from the authorization boundary
+```
+
+**Expected Tool**: `inventory_auto_seed`
+**Expected**: `created_count` > 0; items mapped from boundary resources
+
+---
+
+### ISSO-INV-02: Add Additional Hardware
+
+**Precondition**: ISSO-INV-01
+
+```text
+@ato Add hardware item "web-server-01" to Eagle Eye — Dell Server at 10.0.0.1
+```
+
+**Expected Tool**: `inventory_add_item`
+**Expected**: Item created with status Active
+
+---
+
+### ISSO-INV-03: Check Completeness Before Export
+
+**Precondition**: ISSO-INV-02
+
+```text
+@ato Check inventory completeness for Eagle Eye
+```
+
+**Expected Tool**: `inventory_completeness`
+**Expected**: `completeness_score`, `is_complete`, issue breakdown
+
+---
+
+### ISSO-INV-04: Export to eMASS Excel
+
+**Precondition**: ISSO-INV-03
+
+```text
+@ato Export the HW/SW inventory for Eagle Eye
+```
+
+**Expected Tool**: `inventory_export`
+**Expected**: Base64-encoded Excel workbook with Hardware and Software worksheets
+
+---
+
+### ISSO Narrative Governance (Feature 024)
+
+**Active Persona**: ISSO | **Role**: `Compliance.Analyst` | **Interface**: VS Code `@ato`
+
+---
+
+### ISSO-NGV-01: View Narrative Version History
+
+**Precondition**: ISSO-04 (narrative written for a control)
+
+```text
+@ato Show the version history for the AC-2 narrative of Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_history`
+**Expected**: List of versions (newest first) with `total_versions`, `version_number`, `authored_by`, `authored_at`
+
+### ISSO-NGV-02: Diff Narrative Versions
+
+**Precondition**: At least 2 versions exist for a control
+
+```text
+@ato Show the diff between version 1 and version 2 of the AC-2 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_diff`
+**Expected**: Unified diff text with `lines_added` and `lines_removed`
+
+### ISSO-NGV-03: Submit Narrative for ISSM Review
+
+**Precondition**: ISSO-NGV-01
+
+```text
+@ato Submit the AC-2 narrative for Eagle Eye for ISSM review
+```
+
+**Expected Tool**: `compliance_submit_narrative`
+**Expected**: `previous_status: Draft`, `new_status: InReview`
+
+### ISSO-NGV-04: Batch Submit AC Family Narratives
+
+**Precondition**: Multiple Draft narratives exist in AC family
+
+```text
+@ato Submit all AC family narratives for Eagle Eye for ISSM review
+```
+
+**Expected Tool**: `compliance_batch_submit_narratives` with `family_filter` = "AC"
+**Expected**: `submitted_count`, `skipped_count`, `submitted_controls`
+
+---
+
+### ISSM Narrative Review (Feature 024)
+
+**Active Persona**: ISSM | **Role**: `Compliance.SecurityLead` | **Interface**: Microsoft Teams
+
+---
+
+### ISSM-NGV-01: View Narrative Approval Progress
+
+**Precondition**: ISSO-NGV-03 (narratives submitted for review)
+
+```text
+@ato Show the narrative approval progress for Eagle Eye
+```
+
+**Expected Tool**: `compliance_narrative_approval_progress`
+**Expected**: Overall counts, `approval_percentage`, per-family breakdown, `review_queue` containing submitted controls
+
+### ISSM-NGV-02: Approve Narrative
+
+**Precondition**: ISSO-NGV-03
+
+```text
+@ato Approve the AC-2 narrative for Eagle Eye
+```
+
+**Expected Tool**: `compliance_review_narrative` with `decision` = "approve"
+**Expected**: `new_status: Approved`, `reviewed_by`, `reviewed_at`
+
+### ISSM-NGV-03: Request Revision with Comments
+
+**Precondition**: Another narrative in InReview status
+
+```text
+@ato Request revision of the AC-3 narrative for Eagle Eye — comments: "Please add Azure AD configuration details"
+```
+
+**Expected Tool**: `compliance_review_narrative` with `decision` = "request_revision"
+**Expected**: `new_status: NeedsRevision`, comments stored
+
+### ISSM-NGV-04: Batch Approve Narratives
+
+**Precondition**: Multiple InReview narratives in a family
+
+```text
+@ato Batch approve all AC family narratives for Eagle Eye
+```
+
+**Expected Tool**: `compliance_batch_review_narratives` with `decision` = "approve"
+**Expected**: `reviewed_count`, `skipped_count`
+
+---
+
 ### ISSO SSP Authoring
 
 **Active Persona**: ISSO | **Role**: `Compliance.Analyst` | **Interface**: VS Code `@ato`

--- a/docs/persona-test-cases/test-data-setup.md
+++ b/docs/persona-test-cases/test-data-setup.md
@@ -35,6 +35,18 @@ These values are used throughout all test cases. If you change any value, update
 | `AGREEMENT_TYPE` | Memorandum of Agreement (MOA) | ISSM-53 |
 | `SSP_SECTION_5` | System Architecture | ISSO-31, ENG-29 |
 | `SSP_SECTION_6` | Technical Controls | ISSO-32, ENG-29 |
+| `HW_ITEM_NAME` | web-server-01 | INV-01, INV-02, INV-03 |
+| `HW_MANUFACTURER` | Dell | INV-01 |
+| `HW_IP_ADDRESS` | 10.0.0.1 | INV-01 |
+| `SW_ITEM_NAME` | RHEL 9.2 | INV-01 (software) |
+| `SW_VENDOR` | Red Hat | INV-01 (software) |
+| `SW_VERSION` | 9.2 | INV-01 (software) |
+| `NGV_CONTROL_ID` | AC-1 | NGV-01 through NGV-07 |
+| `NGV_CONTROL_FAMILY` | AC | NGV-06, NGV-07 |
+| `NGV_NARRATIVE_TEXT` | The organization develops, documents, and disseminates an access control policy... | NGV-01 |
+| `NGV_UPDATED_TEXT` | Updated: The organization maintains access control policy consistent with... | NGV-02 |
+| `NGV_CHANGE_REASON` | Updated per ISSM feedback on 2026 assessment | NGV-02 |
+| `NGV_REVIEWER` | ISSM (SecurityLead) | NGV-04, NGV-06 |
 
 ---
 

--- a/docs/persona-test-cases/tool-validation.md
+++ b/docs/persona-test-cases/tool-validation.md
@@ -235,6 +235,20 @@ This document provides the cross-reference validation of all 106 MCP tools refer
 | 105 | `pim_deny_request` | AUTH-07 | ⬜ | |
 | 106 | `jit_request_access` | AUTH-05 | ⬜ | |
 
+### HW/SW Inventory (9 tools) — F025
+
+| # | Tool Name | Spec TC-IDs | Present | Notes |
+|---|-----------|-------------|---------|-------|
+| 107 | `inventory_add_item` | INV-01 | ⬜ | |
+| 108 | `inventory_update_item` | INV-02 | ⬜ | |
+| 109 | `inventory_decommission_item` | INV-03 | ⬜ | |
+| 110 | `inventory_list` | INV-04 | ⬜ | |
+| 111 | `inventory_get` | INV-05 | ⬜ | |
+| 112 | `inventory_export` | INV-06 | ⬜ | |
+| 113 | `inventory_import` | INV-07 | ⬜ | |
+| 114 | `inventory_completeness` | INV-08 | ⬜ | |
+| 115 | `inventory_auto_seed` | INV-09 | ⬜ | |
+
 ---
 
 ## Validation Summary
@@ -260,7 +274,8 @@ This document provides the cross-reference validation of all 106 MCP tools refer
 | CKL Export | 1 | ___ | ___ |
 | Kanban | 11 | ___ | ___ |
 | PIM / Auth | 8 | ___ | ___ |
-| **Total** | **106** | **___** | **___** |
+| HW/SW Inventory | 9 | ___ | ___ |
+| **Total** | **115** | **___** | **___** |
 
 ---
 
@@ -276,7 +291,7 @@ If any tools are missing, document them here for T007 blocked items:
 
 ## Validation Result
 
-- ⬜ **PASS** — All 106 tools present. Proceed to persona testing.
+- ⬜ **PASS** — All 115 tools present. Proceed to persona testing.
 - ⬜ **FAIL** — Missing tools detected. Resolve before proceeding.
 
 **Validated By**: _______________ | **Date**: _______________

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -11,6 +11,7 @@
 | **AO** | Authorizing Official — Senior official with authority to formally assume responsibility for operating a system at an acceptable level of risk |
 | **ATO** | Authority to Operate — Formal authorization granted by the AO for a system to operate |
 | **ATOwC** | ATO with Conditions — Authorization that includes specific constraints or compensating controls |
+| **Approval Workflow** | Narrative governance process where ISSOs submit Draft narratives for ISSM review, transitioning through Draft → InReview → Approved or NeedsRevision status lifecycle |
 
 ## B
 
@@ -65,12 +66,14 @@
 | Term | Definition |
 |------|-----------|
 | **GRC** | Governance, Risk, and Compliance |
+| **Hardware Inventory** | Catalog of physical and virtual computing resources (servers, workstations, network devices, storage) within a system's authorization boundary |
 
 ## I
 
 | Term | Definition |
 |------|-----------|
 | **IaC** | Infrastructure as Code — Machine-readable configuration files (Terraform, Bicep, ARM templates) |
+| **Inventory Completeness Check** | Automated assessment verifying all inventory items have required fields, all boundary resources have inventory entries, and all hardware has registered software |
 | **ISA** | Interconnection Security Agreement — Document governing the security of a connection between two systems |
 | **ISCP** | Information System Contingency Plan — Plan for restoring system operations after disruption |
 | **IATT** | Interim Authority to Test — Temporary authorization for testing purposes |
@@ -107,6 +110,8 @@
 | **NIST 800-53** | Security and Privacy Controls for Information Systems and Organizations (Rev. 5) |
 | **NIST 800-60** | Guide for Mapping Types of Information and Information Systems to Security Categories |
 | **NIST 800-137** | Information Security Continuous Monitoring for Federal Information Systems |
+| **Narrative Governance** | Version control and approval workflow system for SSP control narratives — provides version history, line-level diffing, rollback, and ISSM approval workflows (Feature 024) |
+| **Narrative Version** | An immutable, append-only record capturing the full text of a control narrative at a point in time, with authorship, status, and optional change reason |
 | **NSS** | National Security System |
 
 ## O
@@ -132,6 +137,7 @@
 |------|-----------|
 | **RAR** | Risk Assessment Report — Documents risks identified during security assessment |
 | **RBAC** | Role-Based Access Control — Authorization model based on assigned roles |
+| **Review Decision** | ISSM verdict on a submitted narrative — either Approve (transitions to Approved status) or Request Revision (transitions to NeedsRevision with mandatory reviewer comments) |
 | **RMF** | Risk Management Framework — NIST framework for managing security risk (SP 800-37) |
 
 ## S
@@ -197,4 +203,7 @@
 | **Registered System** | An information system registered in ATO Copilot for RMF lifecycle management |
 | **Risk Acceptance** | Formal AO decision to accept residual risk for a specific control finding |
 | **RMF Step** | One of seven lifecycle phases: Prepare, Categorize, Select, Implement, Assess, Authorize, Monitor |
+| **Auto-Seed** | ATO Copilot feature that automatically creates hardware inventory items from authorization boundary resources, mapping Azure resource types to hardware functions |
+| **eMASS HW/SW Export** | Excel workbook export with Hardware and Software worksheets formatted for import into the Enterprise Mission Assurance Support Service (eMASS) |
 | **Significant Change** | An event that may require system reauthorization per NIST SP 800-37 |
+| **Software Inventory** | Catalog of software applications, operating systems, middleware, and security tools installed on hardware within a system's authorization boundary |

--- a/docs/release-notes/v1.22.0.md
+++ b/docs/release-notes/v1.22.0.md
@@ -1,0 +1,202 @@
+# Release Notes — v1.22.0
+
+> **Release Date:** March 11, 2026
+> **Branch:** `025-hw-sw-inventory`
+> **Tests:** 4,268 passing (4,075 unit + 193 integration) · Build: 0 errors
+
+---
+
+## Feature 024: Narrative Governance — Version Control + Approval Workflow
+
+ATO Copilot adds **version history**, **line-level diffing**, **rollback**, and **ISSM approval workflows** to per-control SSP narratives. Every narrative edit now creates an immutable version record, enabling full audit trail (CM-3, AU-12), safe rollback, and separation-of-duties enforcement (CM-5) through a Draft → InReview → Approved lifecycle.
+
+---
+
+### New MCP Tools
+
+| Tool | Description | RBAC |
+|------|-------------|------|
+| `compliance_narrative_history` | Retrieve paginated version history for a control narrative (newest first) | All compliance roles |
+| `compliance_narrative_diff` | Compare two versions with line-level unified diff (DiffPlex) | All compliance roles |
+| `compliance_rollback_narrative` | Copy-forward rollback — creates new version from prior content, resets to Draft | ISSO, Engineer |
+| `compliance_submit_narrative` | Submit a Draft narrative for ISSM review (transitions to InReview) | ISSO, Engineer |
+| `compliance_review_narrative` | Approve or request revision of a narrative under review | ISSM |
+| `compliance_batch_review_narratives` | Batch approve/reject narratives by control family or control ID list | ISSM |
+| `compliance_narrative_approval_progress` | Dashboard: aggregate approval counts, per-family breakdown, review queue, staleness warnings | All compliance roles |
+| `compliance_batch_submit_narratives` | Submit all Draft narratives for a family (or all) for ISSM review | ISSO, Engineer |
+
+### Enhanced MCP Tools
+
+| Tool | Changes |
+|------|---------|
+| `compliance_write_narrative` | New optional `expected_version` (optimistic concurrency) and `change_reason` parameters. Response now includes `version_number`, `approval_status`, `previous_version`. Rejects writes to InReview narratives. |
+
+---
+
+### Key Capabilities
+
+#### Narrative Version History (US1)
+- Every narrative write creates an immutable, append-only `NarrativeVersion` record
+- Paginated history retrieval with authorship, timestamp, change reason, and approval status
+- Line-level unified diff between any two versions (powered by DiffPlex)
+- Copy-forward rollback creates a new Draft version — no data is ever deleted
+
+#### Narrative Approval Workflow (US2)
+- Status lifecycle: Draft → InReview → Approved | NeedsRevision
+- ISSO/Engineer authors and submits; ISSM reviews and approves or requests revision
+- Edit guard: InReview narratives are locked from modification until reviewed
+- NeedsRevision includes mandatory reviewer comments for actionable feedback
+- Editing an Approved narrative creates a new Draft — the Approved version remains authoritative for SSP generation
+
+#### Approval Progress Dashboard (US3)
+- Overall approval percentage across all controls
+- Per-family breakdown (e.g., AC: 20/25 approved, SI: 8/12 approved)
+- Review queue listing control IDs currently in InReview status
+- Staleness warnings when unapproved Draft versions exist under an Approved SSP §10
+
+#### Batch Operations (US4)
+- Batch submit all Draft narratives for a control family in one action
+- Batch approve/reject InReview narratives by family or control ID list
+- Idempotent — already-submitted narratives are skipped with skip count reported
+
+#### Concurrent Edit Protection (US5)
+- Optional `expected_version` parameter for optimistic concurrency
+- Stale writes rejected with conflict error including current version, last modifier, and timestamp
+
+---
+
+### Downstream Integration
+
+| Downstream Tool | Integration |
+|-----------------|-------------|
+| **SSP §10** (`compliance_generate_ssp`) | Uses `ApprovedVersionId` with fallback to `Narrative` field for SSP generation |
+| **SSP Completeness** (`compliance_ssp_completeness`) | Shows staleness warning when unapproved versions exist under Approved §10 |
+| **ConMon Monitoring** | Approval status tracked in continuous monitoring dashboards |
+| **Audit Trail** | All version records retained indefinitely per NARA requirements |
+
+---
+
+### Data Model Changes
+
+- **`NarrativeVersion` entity** — New: append-only version records with `VersionNumber`, `Content`, `Status`, `AuthoredBy`, `AuthoredAt`, `ChangeReason`, `SubmittedBy`, `SubmittedAt`
+- **`NarrativeReview` entity** — New: review records with `ReviewedBy`, `Decision` (Approve/RequestRevision), `ReviewerComments`, `ReviewedAt`
+- **`ControlImplementation` extensions** — New fields: `ApprovalStatus`, `CurrentVersion`, `ApprovedVersionId` (FK → NarrativeVersion)
+- **`ReviewDecision` enum** — New: `Approve`, `RequestRevision`
+- **Reused**: `SspSectionStatus` enum for approval status lifecycle
+
+### New Components
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `INarrativeGovernanceService` | `Core/Interfaces/Compliance/` | Service interface for narrative governance operations |
+| `NarrativeGovernanceService` | `Agents/Compliance/Services/` | Version history, diffing, rollback, approval workflows |
+| `NarrativeGovernanceTools` | `Agents/Compliance/Tools/` | 8 MCP tool classes for narrative governance |
+| `NarrativeGovernanceModels` | `Core/Models/Compliance/` | Entity models + DTOs (NarrativeDiff, GovernanceProgressReport, etc.) |
+
+---
+
+## Feature 025: Hardware/Software Inventory Management
+
+ATO Copilot adds a **complete HW/SW inventory** capability — register hardware and software components, track eMASS-required fields (manufacturer, model, serial number, IP/MAC, vendor, version, patch level), export to **eMASS-compatible Excel**, import from spreadsheets, auto-seed from the authorization boundary, and verify completeness before SSP submission.
+
+---
+
+### New MCP Tools
+
+| Tool | Description | RBAC |
+|------|-------------|------|
+| `inventory_add_item` | Register a hardware or software item with eMASS-required fields | ISSO, Engineer |
+| `inventory_update_item` | Update fields on an existing inventory item (version, location, IP, etc.) | ISSO, Engineer |
+| `inventory_list` | List/filter inventory items by type, vendor, function, or status (paginated) | All compliance roles |
+| `inventory_remove_item` | Decommission an item (soft delete with rationale and cascade to child SW) | ISSO |
+| `inventory_export` | Export inventory to eMASS-format Excel workbook (Hardware + Software worksheets) | ISSO, SCA |
+| `inventory_import` | Import inventory from eMASS-format Excel with dry-run preview | ISSO |
+| `inventory_completeness` | Check completeness: missing fields, unmatched boundary resources, bare hardware | ISSO, SCA |
+| `inventory_auto_seed` | Auto-create HW items from authorization boundary resources (idempotent) | ISSO |
+| `inventory_decommission_item` | Decommission hardware with cascade to child software items | ISSO |
+
+### Enhanced MCP Tools
+
+| Tool | Changes |
+|------|---------|
+| `compliance_generate_ssp` | SSP §11 now includes HW/SW inventory summary tables when inventory items exist |
+
+---
+
+### Key Capabilities
+
+#### HW/SW Component Registry (US1)
+- Hardware items: manufacturer, model, serial number, function, IP address, MAC address, location
+- Software items: vendor, version, patch level, license type, function, linked to parent hardware
+- Parent-child relationship between hardware and installed software
+- Soft-delete decommissioning with rationale, timestamp, and cascade to child software
+
+#### Query & Filter Inventory (US2)
+- Filter by type (hardware/software), vendor, function, status
+- Paginated results with configurable page size
+- Hardware detail view includes list of installed software
+
+#### eMASS-Compatible Export (US3)
+- Excel workbook with "Hardware" and "Software" worksheets
+- Column headers match eMASS import format
+- Option to include/exclude decommissioned items
+
+#### Inventory Completeness Check (US4)
+- Identifies required fields missing per item
+- Flags boundary resources without corresponding inventory entries
+- Warns about hardware items with no software installed
+- Returns completeness score (0–100%) and `is_complete` flag
+
+#### SSP Integration (US5)
+- SSP §11 auto-populates HW/SW inventory tables from registered items
+- Empty inventory shows placeholder rather than omitting the section
+
+#### Excel Import (US6)
+- Round-trip with eMASS export format
+- Hardware worksheet processed before Software to resolve parent references
+- Dry-run mode for preview without persistence
+- Row-level error reporting for validation failures
+
+---
+
+### Downstream Integration
+
+| Downstream Tool | Integration |
+|-----------------|-------------|
+| **SSP §11** (`compliance_generate_ssp`) | HW/SW tables auto-populated from inventory items |
+| **OSCAL Export** (`compliance_export_oscal_ssp`) | Inventory items feed `system-implementation.inventory-items` |
+| **ConMon Monitoring** | Inventory completeness tracked as SSP readiness metric |
+| **eMASS Import** | Excel export ready for direct eMASS bulk upload |
+
+---
+
+### Data Model Changes
+
+- **`InventoryItem` entity** — New: 22 fields including `ItemType` (Hardware/Software), `ItemName`, `Manufacturer`, `Model`, `SerialNumber`, `Function`, `IpAddress`, `MacAddress`, `Location`, `Vendor`, `Version`, `PatchLevel`, `LicenseType`, `Status`, `ParentItemId`, `DecommissionedAt`, `DecommissionRationale`
+- **`InventoryItemType` enum** — New: `Hardware`, `Software`
+- **`InventoryItemFunction` enum** — New: `Server`, `Workstation`, `NetworkDevice`, `StorageDevice`, `OperatingSystem`, `Middleware`, `Database`, `Application`, `SecurityTool`, `Other`
+- **`InventoryItemStatus` enum** — New: `Active`, `Decommissioned`
+
+### New Components
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `IInventoryService` | `Core/Interfaces/Compliance/` | Service interface for inventory management |
+| `InventoryService` | `Agents/Compliance/Services/` | CRUD, export, import, completeness, auto-seed |
+| `InventoryTools` | `Agents/Compliance/Tools/` | 9 MCP tool classes for inventory management |
+| `InventoryModels` | `Core/Models/Compliance/` | Entity model + enums |
+
+---
+
+## Documentation Updates
+
+Comprehensive documentation added for both features across all documentation files:
+
+- **API Reference** (`docs/api/mcp-server.md`) — 17 new tool entries (8 narrative governance + 9 inventory)
+- **Data Model** (`docs/architecture/data-model.md`) — NarrativeVersion, NarrativeReview, InventoryItem entities
+- **Tool Catalog** (`docs/architecture/agent-tool-catalog.md`) — Full tool specifications with parameters, responses, error codes
+- **Architecture Overview** (`docs/architecture/overview.md`) — NarrativeGovernanceService and InventoryService in service layer
+- **Persona Guides** — Narrative governance and inventory workflows for ISSM, Engineer, and SCA
+- **Getting Started** — Quick-start bullets for ISSO and Engineer
+- **Glossary** — 9 new terms (Approval Workflow, Narrative Governance, Narrative Version, Review Decision, Hardware Inventory, Inventory Completeness Check, Software Inventory, Auto-Seed, eMASS HW/SW Export)
+- **Persona Test Cases** — 18 result template rows, 18 test script scenarios, cross-persona flows, unified RMF integration

--- a/specs/025-hw-sw-inventory/checklists/requirements.md
+++ b/specs/025-hw-sw-inventory/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Hardware/Software Inventory
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions section documents reasonable defaults for eMASS column headers, IP/MAC format, function classifications, and auto-seeding behavior.
+- No [NEEDS CLARIFICATION] markers were needed — the feature description was specific enough (eMASS HW/SW format is well-documented in DoD standards) and reasonable defaults exist for all unspecified details.

--- a/specs/025-hw-sw-inventory/contracts/inventory-service.md
+++ b/specs/025-hw-sw-inventory/contracts/inventory-service.md
@@ -1,0 +1,359 @@
+# Interface Contracts: IInventoryService
+
+**Feature**: 025-hw-sw-inventory | **Date**: 2026-03-11
+
+---
+
+## Service Interface: `IInventoryService`
+
+**Namespace**: `Ato.Copilot.Core.Interfaces.Compliance`
+**Registration**: `services.AddSingleton<IInventoryService, InventoryService>()`
+
+### Methods
+
+---
+
+#### `AddItemAsync`
+
+Add a hardware or software inventory item to a system.
+
+```csharp
+Task<InventoryItem> AddItemAsync(
+    string registeredSystemId,
+    InventoryItemInput input,
+    string addedBy,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `registeredSystemId` | `string` | Yes | Target system GUID. |
+| `input` | `InventoryItemInput` | Yes | Item data (see Input Types below). |
+| `addedBy` | `string` | Yes | User identity. |
+
+**Returns**: The created `InventoryItem`.
+
+**Errors**:
+- `SYSTEM_NOT_FOUND`: System does not exist.
+- `VALIDATION_FAILED`: Required fields missing per FR-018.
+- `DUPLICATE_IP`: IP address already exists in this system's inventory.
+- `PARENT_NOT_FOUND`: `ParentHardwareId` references a non-existent or non-hardware item.
+
+---
+
+#### `UpdateItemAsync`
+
+Update fields on an existing inventory item.
+
+```csharp
+Task<InventoryItem> UpdateItemAsync(
+    string itemId,
+    InventoryItemInput input,
+    string modifiedBy,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `itemId` | `string` | Yes | Inventory item GUID. |
+| `input` | `InventoryItemInput` | Yes | Updated fields (null fields = no change). |
+| `modifiedBy` | `string` | Yes | User identity. |
+
+**Returns**: The updated `InventoryItem`.
+
+**Errors**:
+- `ITEM_NOT_FOUND`: Item does not exist.
+- `VALIDATION_FAILED`: Updated values violate FR-018 rules.
+- `DUPLICATE_IP`: New IP address conflicts with another item in the same system.
+
+---
+
+#### `DecommissionItemAsync`
+
+Soft-delete an inventory item (and cascade to SW children if HW).
+
+```csharp
+Task<InventoryItem> DecommissionItemAsync(
+    string itemId,
+    string rationale,
+    string decommissionedBy,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `itemId` | `string` | Yes | Inventory item GUID. |
+| `rationale` | `string` | Yes | Reason for decommissioning. |
+| `decommissionedBy` | `string` | Yes | User identity. |
+
+**Returns**: The decommissioned `InventoryItem`.
+
+**Errors**:
+- `ITEM_NOT_FOUND`: Item does not exist.
+- `ALREADY_DECOMMISSIONED`: Item is already decommissioned.
+
+**Side Effects**: If the item is hardware with active software children, all children are also decommissioned with the same rationale (FR-005).
+
+---
+
+#### `GetItemAsync`
+
+Retrieve a single inventory item by ID, including its installed software (if HW).
+
+```csharp
+Task<InventoryItem?> GetItemAsync(
+    string itemId,
+    CancellationToken cancellationToken = default);
+```
+
+**Returns**: The `InventoryItem` with `InstalledSoftware` populated (for HW items), or null.
+
+---
+
+#### `ListItemsAsync`
+
+List and filter inventory items for a system.
+
+```csharp
+Task<IReadOnlyList<InventoryItem>> ListItemsAsync(
+    string registeredSystemId,
+    InventoryListOptions? options = null,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `registeredSystemId` | `string` | Yes | System GUID. |
+| `options` | `InventoryListOptions?` | No | Filter/pagination options. |
+
+**Returns**: Filtered list of `InventoryItem` entries.
+
+---
+
+#### `ExportToExcelAsync`
+
+Export inventory as eMASS-compatible Excel workbook bytes.
+
+```csharp
+Task<byte[]> ExportToExcelAsync(
+    string registeredSystemId,
+    InventoryExportOptions? options = null,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `registeredSystemId` | `string` | Yes | System GUID. |
+| `options` | `InventoryExportOptions?` | No | Export options (type filter, include decommissioned). |
+
+**Returns**: `.xlsx` file bytes.
+
+**Errors**:
+- `SYSTEM_NOT_FOUND`: System does not exist.
+- `NO_INVENTORY_DATA`: System has no inventory items.
+
+---
+
+#### `ImportFromExcelAsync`
+
+Import inventory items from an eMASS-format Excel workbook.
+
+```csharp
+Task<InventoryImportResult> ImportFromExcelAsync(
+    byte[] fileBytes,
+    string registeredSystemId,
+    bool dryRun,
+    string importedBy,
+    CancellationToken cancellationToken = default);
+```
+
+**Parameters**:
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileBytes` | `byte[]` | Yes | Excel workbook bytes. |
+| `registeredSystemId` | `string` | Yes | Target system GUID. |
+| `dryRun` | `bool` | Yes | If true, validate only — don't persist. |
+| `importedBy` | `string` | Yes | User identity. |
+
+**Returns**: `InventoryImportResult` with created/skipped counts and errors.
+
+---
+
+#### `CheckCompletenessAsync`
+
+Run completeness check on a system's inventory.
+
+```csharp
+Task<InventoryCompleteness> CheckCompletenessAsync(
+    string registeredSystemId,
+    CancellationToken cancellationToken = default);
+```
+
+**Returns**: `InventoryCompleteness` result with issues and score.
+
+---
+
+#### `AutoSeedFromBoundaryAsync`
+
+Create inventory items from authorization boundary resources.
+
+```csharp
+Task<IReadOnlyList<InventoryItem>> AutoSeedFromBoundaryAsync(
+    string registeredSystemId,
+    string seededBy,
+    CancellationToken cancellationToken = default);
+```
+
+**Returns**: List of newly created `InventoryItem` entries (only items for previously unmatched boundary resources).
+
+**Errors**:
+- `SYSTEM_NOT_FOUND`: System does not exist.
+- `NO_BOUNDARY_DATA`: System has no boundary resources.
+
+---
+
+## Input Types
+
+### InventoryItemInput
+
+Used by `AddItemAsync` and `UpdateItemAsync`. For updates, null fields are not changed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ItemName` | `string?` | Display name. |
+| `Type` | `InventoryItemType?` | Hardware or Software. |
+| `HardwareFunction` | `HardwareFunction?` | HW function classification. |
+| `SoftwareFunction` | `SoftwareFunction?` | SW function classification. |
+| `Manufacturer` | `string?` | HW manufacturer. |
+| `Model` | `string?` | HW model. |
+| `SerialNumber` | `string?` | HW serial number. |
+| `IpAddress` | `string?` | IPv4/IPv6 address. |
+| `MacAddress` | `string?` | MAC address. |
+| `Location` | `string?` | Physical/logical location. |
+| `Vendor` | `string?` | SW vendor. |
+| `Version` | `string?` | SW version. |
+| `PatchLevel` | `string?` | SW patch level. |
+| `LicenseType` | `string?` | License type. |
+| `ParentHardwareId` | `string?` | Parent HW item ID (for SW). |
+
+### InventoryListOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Type` | `InventoryItemType?` | null | Filter by type. |
+| `Function` | `string?` | null | Filter by function name (HW or SW). |
+| `Vendor` | `string?` | null | Filter by vendor/manufacturer (contains). |
+| `Status` | `InventoryItemStatus?` | `Active` | Filter by status. Null = all. |
+| `SearchText` | `string?` | null | Free-text search on item name. |
+| `PageSize` | `int` | 50 | Results per page. |
+| `PageNumber` | `int` | 1 | Page number (1-based). |
+
+### InventoryExportOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ExportType` | `string` | `"all"` | `"hardware"`, `"software"`, or `"all"`. |
+| `IncludeDecommissioned` | `bool` | `false` | Include decommissioned items. |
+
+---
+
+## MCP Tool Contracts
+
+All tools extend `BaseTool` and follow the standard response envelope.
+
+### `inventory_add_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |
+| `type` | string | Yes | `"hardware"` or `"software"`. |
+| `item_name` | string | Yes | Display name. |
+| `function` | string | Yes | Function classification (e.g., "server", "operating_system"). |
+| `manufacturer` | string | No | HW manufacturer. |
+| `model` | string | No | HW model. |
+| `serial_number` | string | No | HW serial number. |
+| `ip_address` | string | No | IPv4/IPv6 address. |
+| `mac_address` | string | No | MAC address. |
+| `location` | string | No | Physical/logical location. |
+| `vendor` | string | No | SW vendor. |
+| `version` | string | No | SW version. |
+| `patch_level` | string | No | SW patch level. |
+| `license_type` | string | No | License type. |
+| `parent_hardware_id` | string | No | Parent HW item ID (for SW). |
+
+### `inventory_update_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | Yes | Inventory item GUID. |
+| `item_name` | string | No | Updated name. |
+| `manufacturer` | string | No | Updated manufacturer. |
+| `model` | string | No | Updated model. |
+| `serial_number` | string | No | Updated serial number. |
+| `ip_address` | string | No | Updated IP address. |
+| `mac_address` | string | No | Updated MAC address. |
+| `location` | string | No | Updated location. |
+| `vendor` | string | No | Updated vendor. |
+| `version` | string | No | Updated version. |
+| `patch_level` | string | No | Updated patch level. |
+| `license_type` | string | No | Updated license type. |
+| `parent_hardware_id` | string | No | Updated parent HW item ID. |
+
+### `inventory_decommission_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | Yes | Inventory item GUID. |
+| `rationale` | string | Yes | Reason for decommissioning. |
+
+### `inventory_list`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |
+| `type` | string | No | `"hardware"` or `"software"`. |
+| `function` | string | No | Function filter. |
+| `vendor` | string | No | Vendor/manufacturer filter. |
+| `status` | string | No | `"active"` (default) or `"decommissioned"`. |
+| `search` | string | No | Free-text search on item name. |
+| `page_size` | integer | No | Results per page (default 50). |
+| `page` | integer | No | Page number (default 1). |
+
+### `inventory_get`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `item_id` | string | Yes | Inventory item GUID. |
+
+### `inventory_export`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |
+| `export_type` | string | No | `"hardware"`, `"software"`, or `"all"` (default). |
+| `include_decommissioned` | boolean | No | Include decommissioned items (default false). |
+
+### `inventory_import`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |
+| `file_base64` | string | Yes | Base64-encoded Excel workbook. |
+| `dry_run` | boolean | No | Validate only, don't persist (default false). |
+
+### `inventory_completeness`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |
+
+### `inventory_auto_seed`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `system_id` | string | Yes | System GUID, name, or acronym. |

--- a/specs/025-hw-sw-inventory/data-model.md
+++ b/specs/025-hw-sw-inventory/data-model.md
@@ -1,0 +1,211 @@
+# Data Model: Hardware/Software Inventory
+
+**Feature**: 025-hw-sw-inventory | **Date**: 2026-03-11
+
+---
+
+## Entities
+
+### InventoryItem
+
+A single hardware or software component within a system's authorization boundary.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `Id` | `string` | `[Key] [MaxLength(36)]`, default `Guid.NewGuid().ToString()` | Unique identifier (GUID string). |
+| `RegisteredSystemId` | `string` | `[Required] [MaxLength(36)]`, FK → `RegisteredSystem.Id` | System this item belongs to. |
+| `ItemName` | `string` | `[Required] [MaxLength(300)]` | Display name (e.g., "Web Server 01", "Red Hat Enterprise Linux 9"). |
+| `Type` | `InventoryItemType` | `[Required]`, enum → string | `Hardware` or `Software`. |
+| `HardwareFunction` | `HardwareFunction?` | nullable, enum → string | Function classification for hardware items: Server, Workstation, NetworkDevice, Storage, Other. Null for software items. |
+| `SoftwareFunction` | `SoftwareFunction?` | nullable, enum → string | Function classification for software items: OperatingSystem, Database, Middleware, Application, SecurityTool, Other. Null for hardware items. |
+| `Manufacturer` | `string?` | `[MaxLength(300)]` | Hardware manufacturer (e.g., "Dell", "Cisco"). |
+| `Model` | `string?` | `[MaxLength(300)]` | Hardware model (e.g., "PowerEdge R740"). |
+| `SerialNumber` | `string?` | `[MaxLength(200)]` | Hardware serial number. |
+| `IpAddress` | `string?` | `[MaxLength(45)]` | IPv4 or IPv6 address. Max length 45 covers IPv6 full notation. |
+| `MacAddress` | `string?` | `[MaxLength(17)]` | MAC address in colon-separated hex (e.g., `00:1A:2B:3C:4D:5E`). |
+| `Location` | `string?` | `[MaxLength(500)]` | Physical or logical location. |
+| `Vendor` | `string?` | `[MaxLength(300)]` | Software vendor (e.g., "Microsoft", "Red Hat"). |
+| `Version` | `string?` | `[MaxLength(100)]` | Software version (e.g., "9.3", "2022 SP1"). |
+| `PatchLevel` | `string?` | `[MaxLength(200)]` | Current patch level or update identifier. |
+| `LicenseType` | `string?` | `[MaxLength(200)]` | License type (e.g., "Enterprise", "Open Source", "Government"). |
+| `Status` | `InventoryItemStatus` | `[Required]`, enum → string, default `Active` | `Active` or `Decommissioned`. |
+| `ParentHardwareId` | `string?` | `[MaxLength(36)]`, FK → self (`InventoryItem.Id`) | Optional reference to parent hardware item (for SW installed on HW). Null for standalone/SaaS/PaaS software. |
+| `BoundaryResourceId` | `string?` | `[MaxLength(36)]`, FK → `AuthorizationBoundary.Id` | Optional link to boundary resource for auto-seed idempotency. |
+| `DecommissionDate` | `DateTime?` | | UTC date when item was decommissioned. |
+| `DecommissionRationale` | `string?` | `[MaxLength(2000)]` | Reason for decommissioning. |
+| `CreatedBy` | `string` | `[Required] [MaxLength(200)]` | User who created the item. |
+| `CreatedAt` | `DateTime` | default `DateTime.UtcNow` | Creation timestamp (UTC). |
+| `ModifiedBy` | `string?` | `[MaxLength(200)]` | User who last modified the item. |
+| `ModifiedAt` | `DateTime?` | | Last modification timestamp (UTC). |
+
+#### Navigation Properties
+
+| Property | Type | Relationship |
+|----------|------|-------------|
+| `RegisteredSystem` | `RegisteredSystem?` | Many-to-one (FK: `RegisteredSystemId`) |
+| `ParentHardware` | `InventoryItem?` | Self-referencing many-to-one (FK: `ParentHardwareId`) |
+| `InstalledSoftware` | `ICollection<InventoryItem>` | Self-referencing one-to-many (inverse of `ParentHardware`) |
+| `BoundaryResource` | `AuthorizationBoundary?` | Many-to-one (FK: `BoundaryResourceId`) |
+
+---
+
+## Enums
+
+### InventoryItemType
+
+```csharp
+public enum InventoryItemType { Hardware, Software }
+```
+
+### InventoryItemStatus
+
+```csharp
+public enum InventoryItemStatus { Active, Decommissioned }
+```
+
+### HardwareFunction
+
+```csharp
+public enum HardwareFunction { Server, Workstation, NetworkDevice, Storage, Other }
+```
+
+### SoftwareFunction
+
+```csharp
+public enum SoftwareFunction { OperatingSystem, Database, Middleware, Application, SecurityTool, Other }
+```
+
+---
+
+## Computed Types (Not Persisted)
+
+### InventoryCompleteness
+
+Returned by `IInventoryService.CheckCompletenessAsync()`. Not stored in the database.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SystemId` | `string` | The system being checked. |
+| `TotalItems` | `int` | Total inventory items (active only). |
+| `HardwareCount` | `int` | Total active hardware items. |
+| `SoftwareCount` | `int` | Total active software items. |
+| `ItemsWithMissingFields` | `IReadOnlyList<InventoryIssue>` | Items missing required fields per FR-018. |
+| `UnmatchedBoundaryResources` | `IReadOnlyList<UnmatchedBoundaryResource>` | Boundary resources with no inventory item. |
+| `HardwareWithoutSoftware` | `IReadOnlyList<string>` | IDs of HW items with no SW children. |
+| `CompletenessScore` | `double` | Percentage: (items without issues) / total items × 100. |
+| `IsComplete` | `bool` | True if no issues found across all three dimensions. |
+
+### InventoryIssue
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ItemId` | `string` | The inventory item ID. |
+| `ItemName` | `string` | The inventory item name. |
+| `MissingFields` | `IReadOnlyList<string>` | List of field names that are missing. |
+
+### UnmatchedBoundaryResource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `BoundaryResourceId` | `string` | The `AuthorizationBoundary.Id`. |
+| `ResourceName` | `string?` | The boundary resource display name. |
+| `ResourceType` | `string` | The Azure resource type string. |
+
+### InventoryImportResult
+
+Returned by `IInventoryService.ImportFromExcelAsync()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SystemId` | `string` | Target system ID. |
+| `DryRun` | `bool` | Whether this was a dry-run. |
+| `HardwareCreated` | `int` | Number of hardware items created. |
+| `SoftwareCreated` | `int` | Number of software items created. |
+| `RowsSkipped` | `int` | Number of rows skipped due to errors. |
+| `Errors` | `IReadOnlyList<ImportRowError>` | Per-row error details. |
+
+### ImportRowError
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Worksheet` | `string` | "Hardware" or "Software". |
+| `RowNumber` | `int` | 1-based row number in the worksheet. |
+| `Error` | `string` | Human-readable error description. |
+
+---
+
+## EF Core Configuration
+
+### DbContext Registration
+
+Add to `AtoCopilotContext`:
+
+```csharp
+// ─── HW/SW Inventory (Feature 025) ──────────────────────────────────────
+/// <summary>Hardware and software inventory items for registered systems.</summary>
+public DbSet<InventoryItem> InventoryItems => Set<InventoryItem>();
+```
+
+### OnModelCreating Configuration
+
+```csharp
+// ─── Inventory Item (Feature 025) ────────────────────────────────────────
+modelBuilder.Entity<InventoryItem>(e =>
+{
+    e.HasKey(i => i.Id);
+
+    // Enum-to-string conversions
+    e.Property(i => i.Type).HasConversion<string>();
+    e.Property(i => i.Status).HasConversion<string>();
+    e.Property(i => i.HardwareFunction).HasConversion<string>();
+    e.Property(i => i.SoftwareFunction).HasConversion<string>();
+
+    // FK → RegisteredSystem (required)
+    e.HasOne(i => i.RegisteredSystem)
+     .WithMany()
+     .HasForeignKey(i => i.RegisteredSystemId)
+     .OnDelete(DeleteBehavior.Cascade);
+
+    // Self-referencing FK: SW → parent HW (optional)
+    e.HasOne(i => i.ParentHardware)
+     .WithMany(i => i.InstalledSoftware)
+     .HasForeignKey(i => i.ParentHardwareId)
+     .OnDelete(DeleteBehavior.Restrict);
+
+    // FK → AuthorizationBoundary (optional, for auto-seed idempotency)
+    e.HasOne(i => i.BoundaryResource)
+     .WithMany()
+     .HasForeignKey(i => i.BoundaryResourceId)
+     .OnDelete(DeleteBehavior.SetNull);
+
+    // Indexes
+    e.HasIndex(i => i.RegisteredSystemId);
+    e.HasIndex(i => new { i.RegisteredSystemId, i.Type });
+    e.HasIndex(i => new { i.RegisteredSystemId, i.IpAddress })
+     .IsUnique()
+     .HasFilter("[IpAddress] IS NOT NULL");
+    e.HasIndex(i => i.BoundaryResourceId);
+});
+```
+
+---
+
+## Entity Relationship Diagram
+
+```
+RegisteredSystem (1) ──────── (*) InventoryItem
+                                      │
+                                      │ ParentHardwareId (self-ref, optional)
+                                      ▼
+                               InventoryItem (parent HW)
+                                      │
+                                      │ InstalledSoftware (collection)
+                                      ▼
+                               InventoryItem (child SW) [0..*]
+
+AuthorizationBoundary (1) ──── (0..1) InventoryItem.BoundaryResourceId
+```
+
+- `RegisteredSystem` → `InventoryItem`: One system has many inventory items (Cascade delete).
+- `InventoryItem` → `InventoryItem` (self): Software optionally references parent hardware (Restrict delete — cannot delete HW with active SW children).
+- `AuthorizationBoundary` → `InventoryItem`: Optional link for auto-seed tracking (SetNull on boundary delete).

--- a/specs/025-hw-sw-inventory/plan.md
+++ b/specs/025-hw-sw-inventory/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Hardware/Software Inventory
+
+**Branch**: `025-hw-sw-inventory` | **Date**: 2026-03-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/025-hw-sw-inventory/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Add a Hardware/Software Inventory capability to ATO Copilot that enables ISSOs, Engineers, and SCAs to register, update, query, import, and export HW/SW components for eMASS-compliant SSP packages. The feature introduces a new `InventoryItem` entity, an `IInventoryService` service, 8+ MCP tools, eMASS-compatible Excel import/export using ClosedXML, auto-seeding from existing `AuthorizationBoundary` resources, a completeness check, and SSP section integration. The existing `EmassExportService` pattern (ClosedXML workbook generation, `IServiceScopeFactory` for scoped DbContext) is reused for inventory export/import.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9.0
+**Primary Dependencies**: EF Core 9.0.0 (SQLite dev / SQL Server prod), ClosedXML (Excel I/O), System.Text.Json, FluentAssertions + xUnit + Moq (tests)
+**Storage**: EF Core — `AtoCopilotContext` with `DbSet<InventoryItem>`. SQLite for dev, SQL Server for prod.
+**Testing**: xUnit + FluentAssertions + Moq. Unit tests in `Tests.Unit/`, integration tests in `Tests.Integration/`.
+**Target Platform**: Azure Government (.NET 9 server, MCP protocol via stdio + HTTP)
+**Project Type**: Server-side library extending existing MCP agent platform
+**Performance Goals**: Simple inventory queries < 5s, export/import < 30s for single system scope (per Constitution VIII)
+**Constraints**: < 512MB memory steady-state, all collections paginated (default 50), all async methods accept CancellationToken
+**Scale/Scope**: Typical system inventories: 10-200 HW items, 50-500 SW items. Import files up to ~1000 rows.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Documentation as Source of Truth | PASS | Spec references existing `/docs/` structure; Documentation Updates section lists 20 doc files to update. |
+| II. BaseAgent/BaseTool Architecture | PASS | All new tools will extend `BaseTool`, implement `Name`, `Description`, `Parameters`, `ExecuteCoreAsync()`. No new agent needed — tools register on existing ComplianceAgent. |
+| III. Testing Standards | PASS | Unit tests with xUnit/FluentAssertions/Moq for service + tools. Integration tests for MCP tool endpoints. Boundary/edge-case tests per spec edge cases section. |
+| IV. Azure Government & Compliance First | PASS | No new Azure API calls. Data stored in existing EF Core context (SQLite dev / SQL Server prod). No credentials stored. |
+| V. Observability & Structured Logging | PASS | Service will use `ILogger<T>` (Serilog). Tools inherit `BaseTool` instrumentation (ToolMetrics via `ExecuteAsync` wrapper). |
+| VI. Code Quality & Maintainability | PASS | XML docs on all public types. Single-responsibility methods. DI via constructor injection. No magic values — enums for function classifications. |
+| VII. User Experience Consistency | PASS | All tool responses follow standard envelope schema (`status`, `data`, `metadata`). Error responses include `message`, `errorCode`, `suggestion`. |
+| VIII. Performance Requirements | PASS | Inventory queries < 5s. Export/import < 30s. All collections paginated. CancellationToken on all async methods. |
+
+**Gate Result**: PASS — No violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-hw-sw-inventory/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Ato.Copilot.Core/
+│   ├── Models/Compliance/InventoryModels.cs          # InventoryItem entity, enums (HardwareFunction, SoftwareFunction, InventoryItemType, InventoryItemStatus)
+│   ├── Interfaces/Compliance/IInventoryService.cs    # Service interface
+│   └── Data/Context/AtoCopilotContext.cs              # Add DbSet<InventoryItem> + OnModelCreating config
+│
+├── Ato.Copilot.Agents/
+│   ├── Compliance/Services/InventoryService.cs        # IInventoryService implementation (CRUD, query, completeness, auto-seed, import)
+│   ├── Compliance/Tools/InventoryTools.cs             # 9 MCP tools (add, update, decommission, get, list, export, import, completeness-check, auto-seed)
+│   └── Extensions/ServiceCollectionExtensions.cs      # DI registration for IInventoryService + tools
+│
+tests/
+├── Ato.Copilot.Tests.Unit/
+│   ├── Compliance/InventoryServiceTests.cs            # Service-level unit tests
+│   └── Tools/InventoryToolTests.cs                    # Tool-level unit tests
+└── Ato.Copilot.Tests.Integration/
+    └── Compliance/InventoryIntegrationTests.cs        # End-to-end MCP tool tests
+```
+
+**Structure Decision**: Follows the established single-solution pattern. New entity in `Core/Models`, new service interface in `Core/Interfaces`, implementation + tools in `Agents/Compliance`. eMASS export is implemented in `InventoryService` (per R8 decision). No new projects needed.
+
+## Complexity Tracking
+
+No constitution violations. Feature follows all established patterns — no new projects, no new agent, no new architectural abstractions. Complexity is proportional to the 21 functional requirements and 6 user stories.
+
+---
+
+## Post-Design Constitution Re-Check
+
+*Re-evaluation after Phase 1 design artifacts are complete.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Documentation as Source of Truth | PASS | Research, data model, contracts, and quickstart all created under `/specs/025-hw-sw-inventory/`. |
+| II. BaseAgent/BaseTool Architecture | PASS | 9 tools defined in contracts — all extend `BaseTool`. Single `IInventoryService` with constructor-injected `IServiceScopeFactory` + `ILogger<T>`. |
+| III. Testing Standards | PASS | Data model defines clear entity boundaries for unit tests. Each service method has defined error codes for negative test cases. Import has dry-run for testability. |
+| IV. Azure Government & Compliance First | PASS | No new Azure interactions. eMASS format compliance verified in research. |
+| V. Observability & Structured Logging | PASS | Service uses structured logging with system/item IDs. Tools inherit `ToolMetrics` instrumentation. |
+| VI. Code Quality & Maintainability | PASS | 4 enums replace magic strings. Self-referencing FK is the simplest model for parent-child. No unnecessary abstractions. |
+| VII. User Experience Consistency | PASS | All 9 tools follow standard envelope. Error messages include `errorCode` + actionable `suggestion`. |
+| VIII. Performance Requirements | PASS | Paginated listing (default 50). Export operates on single-system scope. Import processes < 1000 rows in memory. Unique IP index accelerates validation. |
+
+**Post-Design Gate Result**: PASS — No violations found. Design is implementation-ready.

--- a/specs/025-hw-sw-inventory/quickstart.md
+++ b/specs/025-hw-sw-inventory/quickstart.md
@@ -1,0 +1,143 @@
+# Quickstart: Hardware/Software Inventory
+
+**Feature**: 025-hw-sw-inventory | **Date**: 2026-03-11
+
+---
+
+## Prerequisites
+
+- A registered system exists (via `compliance_register_system`)
+- Authorization boundary defined (via `compliance_define_boundary`) — needed for auto-seed
+
+---
+
+## Workflow: End-to-End Inventory Management
+
+### Step 1: Auto-Seed from Boundary (optional)
+
+Pre-populate hardware items from existing boundary resources:
+
+```
+Tool: inventory_auto_seed
+Parameters: { "system_id": "my-system" }
+```
+
+Creates one HW item per in-scope boundary resource with name and function pre-populated.
+
+### Step 2: Add Hardware Items
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "my-system",
+  "type": "hardware",
+  "item_name": "Web Server 01",
+  "function": "server",
+  "manufacturer": "Dell",
+  "model": "PowerEdge R740",
+  "serial_number": "SVC-2025-001",
+  "ip_address": "10.0.1.10",
+  "mac_address": "00:1A:2B:3C:4D:5E",
+  "location": "Azure US Gov Virginia"
+}
+```
+
+### Step 3: Add Software Items
+
+Link software to its parent hardware:
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "my-system",
+  "type": "software",
+  "item_name": "Red Hat Enterprise Linux 9",
+  "function": "operating_system",
+  "vendor": "Red Hat",
+  "version": "9.3",
+  "patch_level": "9.3-47.el9",
+  "license_type": "Enterprise",
+  "parent_hardware_id": "<hardware-item-id>"
+}
+```
+
+For SaaS/PaaS, omit `parent_hardware_id`:
+
+```
+Tool: inventory_add_item
+Parameters: {
+  "system_id": "my-system",
+  "type": "software",
+  "item_name": "Azure Active Directory",
+  "function": "security_tool",
+  "vendor": "Microsoft",
+  "version": "N/A"
+}
+```
+
+### Step 4: Review Inventory
+
+```
+Tool: inventory_list
+Parameters: { "system_id": "my-system" }
+```
+
+Filter by type:
+
+```
+Tool: inventory_list
+Parameters: { "system_id": "my-system", "type": "hardware" }
+```
+
+### Step 5: Check Completeness
+
+```
+Tool: inventory_completeness
+Parameters: { "system_id": "my-system" }
+```
+
+Returns missing fields, unmatched boundary resources, and HW items without SW.
+
+### Step 6: Export to eMASS
+
+```
+Tool: inventory_export
+Parameters: { "system_id": "my-system", "export_type": "all" }
+```
+
+Returns a base64-encoded .xlsx workbook with "Hardware" and "Software" worksheets.
+
+### Step 7: Import from Excel (Onboarding)
+
+```
+Tool: inventory_import
+Parameters: {
+  "system_id": "my-system",
+  "file_base64": "<base64-xlsx-data>",
+  "dry_run": true
+}
+```
+
+Dry-run first to see what would be created/skipped, then:
+
+```
+Tool: inventory_import
+Parameters: {
+  "system_id": "my-system",
+  "file_base64": "<base64-xlsx-data>",
+  "dry_run": false
+}
+```
+
+---
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **InventoryItem** | A single HW or SW component tracked with eMASS-required fields. |
+| **Parent-Child** | SW items optionally link to a parent HW item. SaaS/PaaS SW items have no parent. |
+| **Auto-Seed** | Creates HW items from boundary resources. Idempotent — only seeds unmatched resources. |
+| **Completeness Check** | Validates: required fields filled, boundary resources matched, HW items have SW. |
+| **Decommission** | Soft-delete with rationale. Decommissioning HW cascades to its SW children. |
+| **eMASS Round-Trip** | Export to .xlsx → upload to eMASS. Import from .xlsx → onboard existing inventories. |

--- a/specs/025-hw-sw-inventory/research.md
+++ b/specs/025-hw-sw-inventory/research.md
@@ -1,0 +1,171 @@
+# Research: Hardware/Software Inventory
+
+**Feature**: 025-hw-sw-inventory | **Date**: 2026-03-11
+
+---
+
+## R1: eMASS HW/SW Worksheet Column Format
+
+**Decision**: Use standard DoD eMASS Excel column headers for both export and import (round-trip compatibility).
+
+**Rationale**: The existing `EmassExportService` already uses eMASS-standard column headers for Controls (25 columns) and POA&M (24 columns). The HW/SW inventory export follows the same pattern. The eMASS HW/SW import template uses fixed column headers that vary slightly between eMASS versions but follow a stable core set.
+
+**Hardware Worksheet Columns** (10 columns):
+1. System Name
+2. Hardware Name
+3. Manufacturer
+4. Model
+5. Serial Number
+6. Function (Server, Workstation, Network Device, Storage, Other)
+7. IP Address
+8. MAC Address
+9. Location
+10. Status (Active, Decommissioned)
+
+**Software Worksheet Columns** (10 columns):
+1. System Name
+2. Software Name
+3. Vendor
+4. Version
+5. Patch Level
+6. Function (Operating System, Database, Middleware, Application, Security Tool, Other)
+7. License Type
+8. Installed On (hardware item name reference)
+9. Status (Active, Decommissioned)
+
+**Alternatives Considered**:
+- CSV format: Rejected — eMASS expects .xlsx; ClosedXML already in use.
+- Custom column schema: Rejected — would break eMASS import compatibility.
+
+---
+
+## R2: Entity Model Design — Single Table vs. Separate HW/SW Tables
+
+**Decision**: Use a single `InventoryItem` entity with a `Type` discriminator (`Hardware` / `Software`).
+
+**Rationale**: Hardware and software items share 80% of their fields (name, function, status, system FK, audit fields). The distinguishing fields (serial number, IP, MAC for HW; vendor, version, patch level, license type, parent HW FK for SW) are stored as nullable columns. This follows the existing codebase pattern where entities like `ComplianceFinding` use a type discriminator rather than separate tables. A single table simplifies queries (list all inventory), filtering (by type), export (single DbSet), and the parent-child relationship (self-referencing FK on same table).
+
+**Alternatives Considered**:
+- Separate `HardwareItem` and `SoftwareItem` tables with a shared base: Rejected — adds complexity for joined queries, requires two DbSets, complicates the parent-child FK (cross-table), and the EF Core TPH/TPT overhead isn't justified for this schema.
+- EF Core TPH inheritance: Rejected — introduces discriminator column management complexity and limits EF query flexibility with no meaningful benefit over a simple `Type` enum field.
+
+---
+
+## R3: eMASS Excel Import Pattern
+
+**Decision**: Extend the existing `EmassExportService` import pattern to support HW/SW worksheets with dry-run, partial import, and row-level error reporting.
+
+**Rationale**: The existing `EmassExportService.ImportAsync()` already demonstrates the import pattern:
+- Accepts `byte[]` file content + system ID + options (including `DryRun`)
+- Opens `XLWorkbook(stream)`, detects worksheet type by header inspection
+- Processes rows, maps columns to entities, validates, persists
+- Returns a result object with counts and errors
+
+The HW/SW import follows the same shape:
+1. Open workbook and look for "Hardware" and "Software" worksheets (by name) or detect by column headers
+2. Process "Hardware" worksheet first (so HW items exist when SW rows reference them via "Installed On")
+3. Validate each row against FR-018 (function-based required fields)
+4. In dry-run mode: collect results without calling `SaveChangesAsync`
+5. Return `InventoryImportResult` with created/skipped counts and per-row errors
+
+**Alternatives Considered**:
+- CSV import: Rejected — eMASS uses xlsx; would require a separate parser.
+- Streaming import (row-by-row save): Rejected — batch save is simpler, atomically consistent, and inventory sizes are small (< 1000 rows).
+
+---
+
+## R4: SSP Integration Strategy
+
+**Decision**: Integrate HW/SW inventory data into the SSP by auto-generating content for the authorization boundary section (§11) when generating the SSP document.
+
+**Rationale**: The existing `SspService` generates 13 sections per NIST 800-18. Section 11 ("Authorization Boundary") already describes the system boundary. HW/SW inventory tables are a natural sub-section of the boundary description. The `GenerateSspAsync` method assembles section content by querying the database — adding inventory queries follows the same pattern.
+
+Implementation approach:
+- When generating §11 (authorization_boundary), query `InventoryItems` for the system
+- Render hardware items as a Markdown table within the section
+- Render software items as a second Markdown table
+- If no inventory items exist, include a placeholder: "Inventory not yet populated"
+
+**Alternatives Considered**:
+- Add new SSP sections (§14, §15) for HW/SW: Rejected — NIST 800-18 specifies 13 sections; adding more breaks the standard structure.
+- Generate a separate HW/SW appendix document: Rejected — the spec requires integration within the SSP, not a separate document.
+
+---
+
+## R5: Auto-Seed from Authorization Boundary
+
+**Decision**: Map `AuthorizationBoundary` resources to `InventoryItem` entries using a direct FK (`BoundaryResourceId`) for idempotency.
+
+**Rationale**: The `AuthorizationBoundary` entity has: `ResourceId` (Azure resource ID), `ResourceType` (Azure resource type string), `ResourceName` (display name). Auto-seeding creates one HW `InventoryItem` per in-scope boundary resource:
+
+| Boundary Field | → InventoryItem Field |
+|----------------|----------------------|
+| `ResourceName` | `ItemName` |
+| `ResourceType` → mapped | `Function` (Server, Network Device, Storage, etc.) |
+| `Id` | `BoundaryResourceId` (FK for idempotency) |
+
+Azure resource type mapping heuristic:
+- `Microsoft.Compute/virtualMachines` → Server
+- `Microsoft.Network/*` → Network Device
+- `Microsoft.Storage/*` → Storage
+- Everything else → Other
+
+The `BoundaryResourceId` FK ensures re-running auto-seed only creates items for new/unmatched boundary resources (FR-014).
+
+**Alternatives Considered**:
+- Match by name to detect duplicates: Rejected — names can be changed; FK gives stable identity.
+- Store mapping in a separate join table: Rejected — unnecessary complexity for a simple optional FK.
+
+---
+
+## R6: Function Classification Enums
+
+**Decision**: Create two enums — `HardwareFunction` and `SoftwareFunction` — with string-backed EF Core value conversion.
+
+**Rationale**: The spec defines fixed function categories for hardware (Server, Workstation, Network Device, Storage, Other) and software (Operating System, Database, Middleware, Application, Security Tool, Other). These map directly to DoD SSP inventory templates. Using enums provides compile-time safety and consistent serialization. String-backed storage (via EF Core `EnumToStringConverter`) ensures database readability and avoids breaking changes when enum values are reordered.
+
+**Enum Definitions**:
+```csharp
+public enum HardwareFunction { Server, Workstation, NetworkDevice, Storage, Other }
+public enum SoftwareFunction { OperatingSystem, Database, Middleware, Application, SecurityTool, Other }
+public enum InventoryItemType { Hardware, Software }
+public enum InventoryItemStatus { Active, Decommissioned }
+```
+
+**Alternatives Considered**:
+- Free-text function field: Rejected — would produce inconsistent values, complicating export column mapping.
+- Single `InventoryFunction` enum combining HW + SW: Rejected — conflates two distinct classification domains; a Server is not the same dimension as an Operating System.
+
+---
+
+## R7: Completeness Check Design
+
+**Decision**: Implement as a computed result (not persisted) returned by `IInventoryService.CheckCompletenessAsync()`.
+
+**Rationale**: The completeness check aggregates three dimensions:
+1. **Missing required fields** — per FR-018 validation rules applied to all items
+2. **Unmatched boundary resources** — boundary resources with no corresponding inventory item (by `BoundaryResourceId` FK)
+3. **Hardware without software** — HW items with no SW children
+
+This is a read-only analysis that should reflect current state, not a cached snapshot. It returns an `InventoryCompleteness` result type with counts, a pass/fail flag, and per-item issue lists.
+
+**Alternatives Considered**:
+- Persist completeness results: Rejected — would become stale immediately after any inventory change.
+- Trigger completeness check on every mutation: Rejected — unnecessary overhead; check is on-demand per the spec.
+
+---
+
+## R8: Service Architecture — New Service vs. Extend Existing
+
+**Decision**: Create a new `IInventoryService` / `InventoryService` rather than extending `IEmassExportService` or `IBoundaryService`.
+
+**Rationale**: The inventory capability is a distinct domain concern with its own CRUD operations, validation rules, query patterns, and export format. It touches boundary data (auto-seed) and eMASS export (HW/SW worksheets) but has its own lifecycle. A dedicated service keeps responsibilities clean:
+- `IInventoryService`: CRUD, query, completeness check, auto-seed, import, export
+- `IEmassExportService`: Controls + POA&M export/import (unchanged)
+- `IBoundaryService`: Boundary resource management (unchanged)
+
+The inventory service follows the same pattern as other services: constructor injection of `IServiceScopeFactory` + `ILogger<T>`, singleton registration, scoped `AtoCopilotContext` access.
+
+**Alternatives Considered**:
+- Extend `IEmassExportService` with inventory methods: Rejected — SRP violation; export service shouldn't own CRUD.
+- Extend `IBoundaryService`: Rejected — boundary service manages Azure resource scoping, not DoD inventory metadata.

--- a/specs/025-hw-sw-inventory/spec.md
+++ b/specs/025-hw-sw-inventory/spec.md
@@ -1,0 +1,279 @@
+# Feature Specification: Hardware/Software Inventory
+
+**Feature Branch**: `025-hw-sw-inventory`
+**Created**: 2026-03-11
+**Status**: Draft
+**Input**: User description: "Hardware/Software inventory - eMASS requires a complete HW/SW list with versions, Auth boundary has resources but not a formal HW/SW inventory format."
+
+---
+
+## Part 1: The Problem
+
+### Background
+
+eMASS (Enterprise Mission Assurance Support Service) requires every system package to include a complete hardware and software inventory as part of the System Security Plan (SSP). This inventory must list every component within the authorization boundary — servers, workstations, network devices, operating systems, middleware, databases, and applications — along with version numbers, vendors, and IP/MAC addresses where applicable.
+
+ATO Copilot already tracks authorization boundary resources via the `AuthorizationBoundary` entity. However, boundary resources are Azure resource identifiers (e.g., subscription IDs, resource group IDs, VM resource IDs) — they tell the system **what cloud resources are in scope** but do not capture the formal HW/SW inventory detail that DoD assessors and eMASS require:
+
+- **Hardware**: manufacturer, model, serial number, function (server, workstation, network device), location, IP address, MAC address
+- **Software**: product name, vendor, version, patch level, license type, installation location, function (OS, middleware, database, application)
+
+### The Current Gap
+
+| What eMASS Requires | What ATO Copilot Has Today |
+|----------------------|---------------------------|
+| HW inventory with manufacturer, model, serial number, IP/MAC | `AuthorizationBoundary.ResourceType` + `ResourceName` — no manufacturer, model, serial, IP, or MAC |
+| SW inventory with vendor, product name, version, patch level | Nothing — software is not tracked at all |
+| Component function classification (server, workstation, router, etc.) | `ResourceType` stores Azure resource type strings, not DoD HW categories |
+| Mapping between HW items and the SW installed on them | No relationship between hardware and software exists |
+| eMASS-compatible HW/SW worksheet for import | `ExportControlsAsync` exports controls only, not inventory |
+| Ports, protocols, and services per component | Not tracked (deferred — separate eMASS artifact, out of scope for this feature) |
+
+### Who Benefits
+
+- **ISSO/ISSM**: No longer manually maintains HW/SW spreadsheets separate from ATO Copilot
+- **Engineer**: Can register components as they are provisioned and keep versions current
+- **SCA**: Can review the inventory for completeness before assessment
+- **AO**: Gets a complete SSP package where the HW/SW sections are auto-populated
+
+---
+
+## Part 2: The Product
+
+### What We're Building
+
+A **Hardware/Software Inventory** capability that allows users to register, update, query, and export the HW/SW components of a registered system. The inventory integrates with the existing authorization boundary, enriches it with DoD-required detail, and exports in eMASS-compatible format.
+
+### What It Is
+
+- A **component registry** where each hardware or software item is tracked with the fields eMASS requires
+- A **parent-child relationship** between hardware and the software installed on it
+- **MCP tools** for adding, updating, listing, and removing inventory items
+- An **eMASS-compatible export** that produces the HW/SW inventory worksheets expected by eMASS import
+- A **completeness check** that identifies gaps before SSP submission
+- **Auto-enrichment from boundary** — optional seeding of inventory items from existing `AuthorizationBoundary` resources
+
+### What It Is NOT
+
+- Not an automated discovery/scan tool — it does not probe the network or call Azure APIs to discover running software (boundary definition already handles resource discovery)
+- Not a CMDB replacement — it tracks what eMASS needs, not full IT asset management fields
+- Not a license management system — it records license type for the inventory record but does not track entitlements or compliance
+- Not a vulnerability scanner — it records versions but does not correlate them with CVEs (that is a separate concern)
+- Not a ports, protocols, and services (PPS) tracker — PPS is a separate eMASS artifact and is deferred to a future feature
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — Register & Manage HW/SW Inventory Items (Priority: P1)
+
+As an ISSO or Engineer, I need to add hardware and software items to a system's inventory so that the SSP contains a complete HW/SW list for eMASS submission.
+
+**Why this priority**: Without the ability to create and manage inventory items, no other feature (export, completeness check, SSP integration) can function. This is the foundational data entry capability.
+
+**Independent Test**: Can be fully tested by adding HW and SW items via MCP tools and verifying they persist and can be retrieved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered system with no inventory items, **When** an ISSO adds a hardware item with manufacturer, model, function, and IP address, **Then** the item is persisted and appears in the system's inventory list.
+2. **Given** a system with a hardware item, **When** an Engineer adds a software item linked to that hardware item (e.g., an OS installed on a server), **Then** the software item is persisted with a reference to its parent hardware item.
+3. **Given** a system with existing inventory items, **When** a user updates the version of a software item, **Then** the version is updated and a last-modified timestamp is recorded.
+4. **Given** a system with inventory items, **When** a user removes an item, **Then** the item is marked as decommissioned (soft delete) with a decommission date and rationale.
+5. **Given** a system with boundary resources, **When** an ISSO requests auto-seeding of inventory from the boundary, **Then** one hardware inventory item is created per boundary resource with available fields pre-populated from the boundary data.
+
+---
+
+### User Story 2 — Query & Filter Inventory (Priority: P2)
+
+As an ISSO or SCA, I need to list and filter the HW/SW inventory for a system so I can review what is registered, find gaps, and verify completeness.
+
+**Why this priority**: Without query capability, users cannot review what has been entered. This is required before export or completeness checks are useful.
+
+**Independent Test**: Can be tested by seeding inventory items and querying with various filters (type, function, vendor, status).
+
+**Acceptance Scenarios**:
+
+1. **Given** a system with mixed HW and SW items, **When** a user lists inventory filtered by type "hardware", **Then** only hardware items are returned.
+2. **Given** a system with items from multiple vendors, **When** a user filters by vendor name, **Then** only items from that vendor are returned.
+3. **Given** a system with active and decommissioned items, **When** a user lists inventory with status "active", **Then** only active (non-decommissioned) items are returned; decommissioned items are excluded by default.
+4. **Given** a system with SW items linked to HW items, **When** a user queries a specific hardware item, **Then** the response includes the list of software installed on that hardware item.
+
+---
+
+### User Story 3 — Export eMASS-Compatible HW/SW Inventory (Priority: P2)
+
+As an ISSO, I need to export the HW/SW inventory in eMASS-compatible format so I can upload it directly to eMASS as part of the system package.
+
+**Why this priority**: eMASS export is the primary driver for this feature. Tied with US2 as both are essential for the core value proposition, but export requires data (US1) and benefits from query (US2).
+
+**Independent Test**: Can be tested by seeding inventory data, exporting to Excel, and verifying eMASS column headers and data mapping.
+
+**Acceptance Scenarios**:
+
+1. **Given** a system with hardware items, **When** an ISSO exports the HW inventory, **Then** an Excel workbook is produced with a "Hardware" worksheet containing eMASS-required columns (System Name, Hardware Name, Manufacturer, Model, Serial Number, Function, IP Address, MAC Address, Location, Status).
+2. **Given** a system with software items linked to hardware, **When** an ISSO exports the SW inventory, **Then** an Excel workbook is produced with a "Software" worksheet containing eMASS-required columns (System Name, Software Name, Vendor, Version, Patch Level, Function, License Type, Installed On, Status).
+3. **Given** a system with both HW and SW items, **When** an ISSO exports "all", **Then** a single Excel workbook is produced containing both "Hardware" and "Software" worksheets.
+4. **Given** a system with decommissioned items, **When** an ISSO exports the inventory, **Then** decommissioned items are excluded from the export by default, with an option to include them.
+
+---
+
+### User Story 4 — Inventory Completeness Check (Priority: P3)
+
+As an ISSO or SCA, I need to check inventory completeness so I know whether the HW/SW list is ready for eMASS submission.
+
+**Why this priority**: Completeness validation prevents eMASS rejection and reduces assessment rework, but requires US1-US3 to be in place first.
+
+**Independent Test**: Can be tested by seeding an inventory with deliberate gaps and verifying the completeness report identifies them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a system with hardware items missing required fields (e.g., no IP address on a server), **When** a user runs the completeness check, **Then** each missing required field is reported with the item name and the field that is missing.
+2. **Given** a system with boundary resources that have no corresponding inventory items, **When** a user runs the completeness check, **Then** unmatched boundary resources are flagged as "boundary resource without inventory entry."
+3. **Given** a system with hardware items that have no software installed, **When** a user runs the completeness check, **Then** a warning is raised ("Hardware item with no software entries — expected at minimum an OS").
+4. **Given** a system with a complete inventory (all required fields populated, all boundary resources matched, all HW items have SW), **When** a user runs the completeness check, **Then** the check returns a passing result with 100% completeness score.
+
+---
+
+### User Story 5 — SSP Integration (Priority: P3)
+
+As an ISSO, I need the HW/SW inventory to be included in the generated SSP so that the SSP document is complete without manual copy-paste from separate spreadsheets.
+
+**Why this priority**: SSP integration is the final piece that ties inventory management into the existing document generation pipeline. It depends on US1-US3 being complete.
+
+**Independent Test**: Can be tested by seeding inventory items and generating an SSP, then verifying that the HW/SW sections contain the inventory data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a system with HW/SW inventory items, **When** an ISSO generates the SSP, **Then** the SSP includes a "Hardware Inventory" section listing all active hardware items with key fields.
+2. **Given** a system with HW/SW inventory items, **When** an ISSO generates the SSP, **Then** the SSP includes a "Software Inventory" section listing all active software items with key fields.
+3. **Given** a system with no inventory items, **When** an ISSO generates the SSP, **Then** the SSP HW/SW sections contain a placeholder noting "Inventory not yet populated" rather than being omitted.
+
+---
+
+### User Story 6 — Import Inventory from Excel (Priority: P2)
+
+As an ISSO, I need to import existing HW/SW inventory data from an Excel spreadsheet so I can onboard systems that already have inventories without manually adding items one-by-one.
+
+**Why this priority**: Many DoD systems have existing HW/SW inventories in spreadsheets. Bulk import dramatically reduces onboarding friction and creates a natural round-trip with the eMASS export. Tied with US2/US3 as part of the core value proposition.
+
+**Independent Test**: Can be tested by creating an Excel file matching the eMASS export format, importing it, and verifying all items are created with correct field mappings.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Excel file with a "Hardware" worksheet matching the eMASS export column format, **When** an ISSO imports it for a registered system, **Then** one hardware inventory item is created per row with fields mapped from the column headers.
+2. **Given** an Excel file with a "Software" worksheet matching the eMASS export column format, **When** an ISSO imports it for a registered system, **Then** one software inventory item is created per row, with the "Installed On" column used to link SW items to existing HW items by name.
+3. **Given** an import file with rows that fail validation (e.g., missing required fields per FR-018), **When** the import is run, **Then** valid rows are imported and invalid rows are reported with row number and error detail.
+4. **Given** an import file, **When** an ISSO runs the import in dry-run mode, **Then** the system reports what would be created/skipped without persisting any data.
+
+---
+
+### Edge Cases
+
+- What happens when a user tries to add a software item linked to a hardware item that does not exist? → Rejected with a clear error identifying the missing hardware item.
+- What happens when a user decommissions a hardware item that still has active software entries? → The software entries are also marked as decommissioned with the same rationale.
+- What happens when auto-seeding from boundary is run a second time after new boundary resources are added? → Only new/unmatched boundary resources are seeded; existing inventory items are not duplicated.
+- What happens when a user exports inventory for a system with zero items? → Export returns an error indicating no inventory data exists.
+- What happens when a hardware item has duplicate IP addresses within the same system? → Rejected with a uniqueness constraint violation error.
+- What happens when an import file contains rows referencing a hardware item (via "Installed On") that does not yet exist? → If the HW item exists in an earlier row of the same import, it is created first (Hardware worksheet processed before Software); otherwise the SW row is skipped with an error.
+- What happens when an import file contains duplicate items (same name/type) as existing inventory? → Duplicates are skipped and reported; existing items are not overwritten.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow users to add hardware inventory items with the following fields: item name, manufacturer, model, serial number, function (server, workstation, network device, storage, other), IP address, MAC address, location, and status (active, decommissioned).
+- **FR-002**: System MUST allow users to add software inventory items with the following fields: product name, vendor, version, patch level, function (operating system, database, middleware, application, security tool, other), license type, and an optional reference to the hardware item it is installed on. Software items for managed/SaaS/PaaS components MAY exist without a parent hardware reference.
+- **FR-003**: System MUST allow users to update any field of an existing inventory item and record the last-modified timestamp and modifier identity.
+- **FR-004**: System MUST support soft-deletion (decommissioning) of inventory items with a decommission date and rationale rather than hard deletion.
+- **FR-005**: When a hardware item is decommissioned, all software items linked to it MUST also be decommissioned with the same rationale.
+- **FR-006**: System MUST allow users to list inventory items with filtering by type (hardware/software), function, vendor, status, and free-text search on item name.
+- **FR-007**: System MUST return software children when querying a specific hardware item.
+- **FR-008**: System MUST export hardware inventory to an eMASS-compatible Excel worksheet with the column headers: System Name, Hardware Name, Manufacturer, Model, Serial Number, Function, IP Address, MAC Address, Location, Status.
+- **FR-009**: System MUST export software inventory to an eMASS-compatible Excel worksheet with the column headers: System Name, Software Name, Vendor, Version, Patch Level, Function, License Type, Installed On (hardware reference), Status.
+- **FR-010**: System MUST support combined export producing a single workbook with both Hardware and Software worksheets.
+- **FR-011**: System MUST exclude decommissioned items from export by default, with an option to include them.
+- **FR-012**: System MUST provide a completeness check that reports: missing required fields per item, boundary resources without inventory entries, and hardware items without any software entries.
+- **FR-013**: System MUST support auto-seeding inventory items from the existing authorization boundary resources, creating one hardware item per boundary resource with pre-populated fields where available.
+- **FR-014**: Auto-seeding MUST be idempotent — running it again after new boundary resources are added creates only new entries for unmatched resources. Idempotency is enforced via an optional `BoundaryResourceId` foreign key on each inventory item that references the source `AuthorizationBoundary` entry.
+- **FR-015**: System MUST integrate HW/SW inventory sections into the generated SSP document.
+- **FR-016**: IP addresses MUST be unique within a system's hardware inventory.
+- **FR-017**: Each inventory item MUST be associated with exactly one registered system.
+- **FR-018**: System MUST enforce function-based required field validation at creation time:
+  - **All hardware items**: item name, function, and manufacturer are required.
+  - **Hardware with function server or network device**: IP address is additionally required.
+  - **All software items**: product name, vendor, and version are required.
+  - All other fields are optional at creation time but flagged by the completeness check (FR-012) if missing at export time.
+- **FR-019**: System MUST support importing inventory items from an Excel workbook using the same eMASS column format as the export (round-trip compatibility). The workbook may contain a "Hardware" worksheet, a "Software" worksheet, or both.
+- **FR-020**: During import, rows that fail validation (per FR-018) MUST be skipped and reported with row number and error detail; valid rows MUST still be imported.
+- **FR-021**: System MUST support a dry-run import mode that reports what would be created or skipped without persisting any data.
+
+### Key Entities
+
+- **InventoryItem**: Represents a single hardware or software component within a system's authorization boundary. Key attributes: item name, type (hardware/software), function classification, vendor/manufacturer, version (for SW), serial number (for HW), IP/MAC addresses (for HW), status (active/decommissioned), optional parent hardware reference (for SW items — not required for managed/SaaS/PaaS components), optional `BoundaryResourceId` FK linking to the source `AuthorizationBoundary` entry (used for auto-seed idempotency). Belongs to one RegisteredSystem.
+- **InventoryCompleteness**: A computed result (not persisted) representing the completeness state of a system's inventory — counts of items with missing required fields, unmatched boundary resources, and hardware without software entries.
+
+---
+
+## Clarifications
+
+### Session 2026-03-11
+
+- Q: Should software items be allowed to exist without a parent hardware reference (for SaaS/PaaS/managed services)? → A: Yes — hardware parent is optional; SW items can exist independently for managed/SaaS components.
+- Q: Should the spec include ports, protocols, and services (PPS) tracking per inventory item? → A: No — PPS is deferred to a separate feature; explicitly out of scope.
+- Q: What level of field validation should be enforced at inventory item creation time? → A: Function-based required fields — servers/network devices require IP; all HW requires manufacturer; all SW requires vendor+version. Remaining fields are optional at creation but flagged by completeness check.
+- Q: How should the inventory-to-boundary-resource linkage be maintained for auto-seed idempotency? → A: Direct FK — each inventory item has an optional `BoundaryResourceId` referencing its source `AuthorizationBoundary` entry.
+- Q: Should the spec include importing inventory items from an Excel/CSV file? → A: Yes — include Excel import using the same eMASS column format as the export, enabling round-trip capability. Supports dry-run mode and partial import with row-level error reporting.
+
+---
+
+## Assumptions
+
+- The eMASS HW/SW import template column headers follow the standard DoD eMASS Excel format. If a specific eMASS version requires different headers, the export can be updated without changing the data model.
+- IP addresses are IPv4 or IPv6 strings; no network validation is performed beyond format checks.
+- MAC addresses are stored as colon-separated hex strings (e.g., `00:1A:2B:3C:4D:5E`); no format enforcement beyond reasonable length.
+- "Function" classifications for hardware (server, workstation, network device, storage, other) and software (operating system, database, middleware, application, security tool, other) are based on common DoD SSP templates and may be extended via enum additions.
+- Auto-seeding from boundary maps `AuthorizationBoundary.ResourceType` to the closest hardware function and uses `ResourceName` as the inventory item name. Fields not available from the boundary (e.g., serial number, IP) are left blank for manual completion.
+- Inventory data does not require the same narrative governance (version control / approval workflow) as control narratives — items are tracked with simple create/update/decommission audit fields.
+
+---
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: An ISSO can add a hardware item and its associated software items in under 2 minutes using MCP tools.
+- **SC-002**: An ISSO can export a complete HW/SW inventory to eMASS-compatible Excel in a single tool invocation.
+- **SC-003**: The completeness check identifies 100% of missing required fields and unmatched boundary resources.
+- **SC-004**: Auto-seeding from boundary resources creates inventory entries for all in-scope boundary resources in a single operation.
+- **SC-005**: The generated SSP includes HW/SW inventory sections that are accepted by assessors without manual supplementation for systems with complete inventory data.
+- **SC-006**: 90% of ISSOs can populate a 50-item inventory and export it to eMASS in under 30 minutes.
+- **SC-007**: An ISSO can import a 100-row Excel inventory file and receive a complete import report (created/skipped counts with errors) in a single tool invocation.
+
+---
+
+## Documentation Updates
+
+The following documentation MUST be updated as part of this feature delivery:
+
+- **[docs/api/mcp-server.md](docs/api/mcp-server.md)**: Add all 9 new HW/SW inventory MCP tools (add/update/decommission/get/list/export/import/completeness-check/auto-seed) with parameter descriptions, example invocations, and return types.
+- **[docs/architecture/data-model.md](docs/architecture/data-model.md)**: Add the `InventoryItem` entity with all fields, relationships (RegisteredSystem FK, optional parent HW FK, optional BoundaryResourceId FK), and the computed `InventoryCompleteness` result type.
+- **[docs/architecture/agent-tool-catalog.md](docs/architecture/agent-tool-catalog.md)**: Register all new inventory tools in the tool catalog with capability descriptions, required parameters, and persona access mappings.
+- **[docs/guides/isso-guide.md](docs/guides/isso-guide.md)** *(new or update existing ISSO guide)*: Add a "Managing HW/SW Inventory" section covering the end-to-end workflow: auto-seed from boundary → add/edit items → run completeness check → export to eMASS → import from Excel.
+- **[docs/guides/engineer-guide.md](docs/guides/engineer-guide.md)**: Add inventory registration guidance — how engineers register components as they are provisioned and keep versions current.
+- **[docs/guides/sca-guide.md](docs/guides/sca-guide.md)**: Add inventory review guidance — how SCAs review inventory completeness and verify HW/SW coverage before assessment.
+- **[docs/getting-started/isso.md](docs/getting-started/isso.md)**: Update the ISSO getting-started guide to mention HW/SW inventory as a core capability with a link to the detailed guide.
+- **[docs/getting-started/engineer.md](docs/getting-started/engineer.md)**: Update the Engineer getting-started guide to mention component registration.
+- **[docs/reference/glossary.md](docs/reference/glossary.md)**: Add terms: "Hardware Inventory", "Software Inventory", "Inventory Completeness Check", "Auto-Seed", "eMASS HW/SW Export".
+- **[docs/architecture/overview.md](docs/architecture/overview.md)**: Update the architecture overview to include the inventory service in the system component diagram.
+- **[docs/persona-test-cases/tool-validation.md](docs/persona-test-cases/tool-validation.md)**: Add validation test cases for all new inventory MCP tools — covering expected inputs, outputs, and error scenarios per persona (ISSO, Engineer, SCA).
+- **[docs/persona-test-cases/test-data-setup.md](docs/persona-test-cases/test-data-setup.md)**: Add seed data instructions for HW/SW inventory items (sample hardware, software, parent-child relationships, boundary linkages) needed for persona test execution.
+- **[docs/persona-test-cases/environment-checklist.md](docs/persona-test-cases/environment-checklist.md)**: Add checklist items verifying inventory tools are registered, inventory data is seeded, and eMASS export/import round-trip is functional.
+- **[docs/persona-test-cases/results-template.md](docs/persona-test-cases/results-template.md)**: Add inventory-related rows to the results template for tracking pass/fail status of inventory tool validation tests.
+- **[docs/persona-test-cases/scripts/isso-test-script.md](docs/persona-test-cases/scripts/isso-test-script.md)**: Add test scenarios for ISSO inventory workflows — add/edit items, run completeness check, export to eMASS, import from Excel.
+- **[docs/persona-test-cases/scripts/engineer-test-script.md](docs/persona-test-cases/scripts/engineer-test-script.md)**: Add test scenarios for Engineer registering components and updating versions.
+- **[docs/persona-test-cases/scripts/sca-test-script.md](docs/persona-test-cases/scripts/sca-test-script.md)**: Add test scenarios for SCA reviewing inventory completeness before assessment.
+- **[docs/persona-test-cases/scripts/issm-test-script.md](docs/persona-test-cases/scripts/issm-test-script.md)**: Add test scenarios for ISSM reviewing inventory status across systems in the portfolio.
+- **[docs/persona-test-cases/scripts/cross-persona-test-script.md](docs/persona-test-cases/scripts/cross-persona-test-script.md)**: Add cross-persona inventory scenarios — e.g., Engineer registers items → ISSO runs completeness check → SCA verifies → ISSO exports.
+- **[docs/persona-test-cases/scripts/unified-rmf-test-script.md](docs/persona-test-cases/scripts/unified-rmf-test-script.md)**: Add HW/SW inventory steps to the unified RMF lifecycle test flow (inventory ties into Categorize/Implement/Assess phases).

--- a/specs/025-hw-sw-inventory/tasks.md
+++ b/specs/025-hw-sw-inventory/tasks.md
@@ -1,0 +1,244 @@
+# Tasks: HW/SW Inventory Management
+
+**Input**: Design documents from `/specs/025-hw-sw-inventory/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/inventory-service.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the entity model, service interface, and database configuration that all user stories depend on
+
+- [X] T001 [P] Create InventoryItem entity, 4 enums (InventoryItemType, InventoryItemStatus, HardwareFunction, SoftwareFunction), 5 computed types (InventoryCompleteness, InventoryIssue, UnmatchedBoundaryResource, InventoryImportResult, ImportRowError), and 3 input types (InventoryItemInput, InventoryListOptions, InventoryExportOptions) in src/Ato.Copilot.Core/Models/Compliance/InventoryModels.cs
+- [X] T002 [P] Create IInventoryService interface with all 9 method signatures (AddItemAsync, UpdateItemAsync, DecommissionItemAsync, GetItemAsync, ListItemsAsync, ExportToExcelAsync, ImportFromExcelAsync, CheckCompletenessAsync, AutoSeedFromBoundaryAsync) in src/Ato.Copilot.Core/Interfaces/Compliance/IInventoryService.cs
+- [X] T003 Add DbSet<InventoryItem> and OnModelCreating EF Core configuration (string-backed enum conversions, indexes on RegisteredSystemId+Type, unique IP index, self-referencing ParentHardwareId FK, optional BoundaryResourceId FK) in src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create service and tool scaffolding with DI registration so user story implementation can begin
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Create InventoryService class implementing IInventoryService with constructor injection (IServiceScopeFactory, ILogger<InventoryService>) and stub methods throwing NotImplementedException in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T005 Create InventoryTools.cs file with BaseTool scaffolding for all 9 tool classes (InventoryAddItemTool, InventoryUpdateItemTool, InventoryDecommissionItemTool, InventoryListTool, InventoryGetTool, InventoryExportTool, InventoryImportTool, InventoryCompletenessTool, InventoryAutoSeedTool) with Name, Description, and Parameters definitions in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+- [X] T006 Register IInventoryService as singleton, InventoryService as singleton, and all 9 InventoryTool classes using the dual-registration pattern (AddSingleton<ToolType>() + AddSingleton<BaseTool>(sp => sp.GetRequiredService<ToolType>())) in src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs
+
+**Checkpoint**: Foundation ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Register & Manage HW/SW Items (Priority: P1) 🎯 MVP
+
+**Goal**: ISSO can add, update, decommission, and retrieve hardware and software inventory items. Auto-seed from boundary resources provides a quick-start path.
+
+**Independent Test**: Add a hardware item and a linked software item, update fields, decommission the hardware item → verify software is also decommissioned. Run auto-seed on a system with boundary resources → verify inventory items are created and re-running does not duplicate.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Implement AddItemAsync with function-based required field validation (FR-018: all HW requires name+function+manufacturer; server/network requires +IP; all SW requires name+vendor+version), unique IP constraint within system (FR-016), system existence check, and ParentHardwareId validation in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T008 [US1] Implement UpdateItemAsync with partial field update (null fields unchanged), modified timestamp and modifier identity tracking (FR-003), IP uniqueness re-validation, and ITEM_NOT_FOUND error handling in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T009 [US1] Implement DecommissionItemAsync with soft-deletion setting DecommissionedDate and DecommissionRationale, cascade decommission of all child software items with same rationale (FR-004, FR-005), and ALREADY_DECOMMISSIONED rejection if item is already decommissioned, in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T010 [US1] Implement GetItemAsync with eager-loading of InstalledSoftware navigation property for hardware items (FR-007), returning null when item does not exist, in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T011 [US1] Implement AutoSeedFromBoundaryAsync with boundary resource querying, ResourceType-to-HardwareFunction mapping (VMs→Server, Network→NetworkDevice, Storage→Storage, else→Other), BoundaryResourceId FK for idempotency (FR-013, FR-014), and NO_BOUNDARY_DATA error handling in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T012 [US1] Implement inventory_add_item tool ExecuteAsync — parse system_id/type/item_name/function and optional fields, call AddItemAsync, return created item in standard envelope in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+- [X] T013 [US1] Implement inventory_update_item tool ExecuteAsync — parse item_id and optional update fields, call UpdateItemAsync, return updated item in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+- [X] T014 [US1] Implement inventory_decommission_item tool ExecuteAsync — parse item_id and rationale, call DecommissionItemAsync, return decommissioned item in standard envelope with cascaded child count in metadata in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+- [X] T015 [US1] Implement inventory_get tool ExecuteAsync — parse item_id, call GetItemAsync, return item with software children in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+- [X] T016 [US1] Implement inventory_auto_seed tool ExecuteAsync — parse system_id, call AutoSeedFromBoundaryAsync, return list of created items in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+
+**Checkpoint**: US1 complete — ISSO can register, manage, and auto-seed inventory items
+
+---
+
+## Phase 4: User Story 2 — Query & Filter Inventory (Priority: P2)
+
+**Goal**: ISSO can list and search inventory items with filtering by type, function, vendor, status, and free-text name search with pagination.
+
+**Independent Test**: Add several hardware and software items with different functions/vendors, then filter by type=hardware, filter by function=server, search by name substring, and paginate results.
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] Implement ListItemsAsync with IQueryable filtering by Type, Function (string match against HardwareFunction/SoftwareFunction), Vendor/Manufacturer (contains), Status (default Active), free-text SearchText on ItemName (contains), and PageSize/PageNumber pagination (FR-006) in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T018 [US2] Implement inventory_list tool ExecuteAsync — parse system_id and optional filter parameters (type, function, vendor, status, search, page_size, page), call ListItemsAsync, return paginated results in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+
+**Checkpoint**: US2 complete — ISSO can query and filter inventory
+
+---
+
+## Phase 5: User Story 3 — Export to eMASS Excel (Priority: P2)
+
+**Goal**: ISSO can export hardware and software inventory to an eMASS-compatible Excel workbook with separate Hardware and Software worksheets.
+
+**Independent Test**: Add hardware and software items (including one decommissioned), export with default settings → verify two worksheets with correct column headers and only active items. Export with include_decommissioned=true → verify decommissioned items appear.
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Implement ExportToExcelAsync with ClosedXML — create workbook with Hardware worksheet (columns: System Name, Hardware Name, Manufacturer, Model, Serial Number, Function, IP Address, MAC Address, Location, Status per FR-008) and Software worksheet (columns: System Name, Software Name, Vendor, Version, Patch Level, Function, License Type, Installed On, Status per FR-009), support ExportType filter (hardware/software/all per FR-010), exclude decommissioned by default with IncludeDecommissioned option (FR-011), and return byte array with NO_INVENTORY_DATA error for empty inventory in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T020 [US3] Implement inventory_export tool ExecuteAsync — parse system_id, optional export_type and include_decommissioned, call ExportToExcelAsync, return base64-encoded workbook in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+
+**Checkpoint**: US3 complete — ISSO can export inventory to eMASS Excel
+
+---
+
+## Phase 6: User Story 6 — Import from Excel (Priority: P2)
+
+**Goal**: ISSO can import existing HW/SW inventory from an Excel workbook using the same eMASS column format as the export, with dry-run mode and partial import with row-level error reporting.
+
+**Independent Test**: Create an Excel file matching the export format with valid and invalid rows, import with dry_run=true → verify report without persistence. Import without dry_run → verify valid rows created, invalid rows reported with row numbers and error details. Re-import same file → verify duplicates are skipped.
+
+### Implementation for User Story 6
+
+- [X] T021 [US6] Implement ImportFromExcelAsync with ClosedXML parsing — read Hardware and Software worksheets using eMASS column headers (FR-019), process Hardware worksheet first so SW "Installed On" references resolve (edge case), apply FR-018 validation per row, skip and report invalid rows with row number and error detail (FR-020), skip duplicates (same name+type as existing), support dry-run mode returning InventoryImportResult without persisting (FR-021), and return created/skipped/error counts in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T022 [US6] Implement inventory_import tool ExecuteAsync — parse system_id, file_base64, and optional dry_run flag, decode base64 to byte array, call ImportFromExcelAsync, return import result summary in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+
+**Checkpoint**: US6 complete — ISSO can import inventory from Excel with round-trip compatibility
+
+---
+
+## Phase 7: User Story 4 — Completeness Check (Priority: P3)
+
+**Goal**: ISSO can run a completeness check that identifies missing required fields per item, boundary resources without inventory entries, and hardware items without any software entries.
+
+**Independent Test**: Add items with some missing optional fields, add boundary resources without corresponding inventory, add HW without SW → run completeness check → verify all three issue categories are reported with accurate counts.
+
+### Implementation for User Story 4
+
+- [X] T023 [US4] Implement CheckCompletenessAsync — query all active inventory items and all boundary resources for the system, compute three issue dimensions: (1) per-item missing required fields based on FR-018 rules returning InventoryIssue list, (2) boundary resources with no matching BoundaryResourceId FK returning UnmatchedBoundaryResource list, (3) hardware items with no software children, aggregate into InventoryCompleteness result with TotalItems/IssueCount/IsComplete flag (FR-012) in src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+- [X] T024 [US4] Implement inventory_completeness tool ExecuteAsync — parse system_id, call CheckCompletenessAsync, return completeness result with issue details in src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+
+**Checkpoint**: US4 complete — ISSO can assess inventory completeness before export
+
+---
+
+## Phase 8: User Story 5 — SSP Integration (Priority: P3)
+
+**Goal**: Generated SSP document includes HW/SW inventory tables in the §11 authorization boundary section.
+
+**Independent Test**: Add hardware and software items to a system, generate SSP → verify §11 contains HW inventory table and SW inventory table with correct data.
+
+### Implementation for User Story 5
+
+- [X] T025 [US5] Integrate HW/SW inventory into SSP generation — inject IInventoryService into SspService, query active inventory items for the system, render hardware inventory table and software inventory table in the §11 boundary section of the SSP document (FR-015) in src/Ato.Copilot.Agents/Compliance/Services/SspService.cs
+
+**Checkpoint**: US5 complete — SSP §11 includes HW/SW inventory tables
+
+---
+
+## Phase 9: Testing
+
+**Purpose**: Unit and integration tests for InventoryService and InventoryTools following xUnit + FluentAssertions + Moq patterns
+
+- [X] T026 Create InventoryServiceTests.cs with unit tests covering: AddItemAsync (valid HW, valid SW, function-based validation failures, duplicate IP rejection, missing parent HW rejection, SaaS SW without parent), UpdateItemAsync (partial update, modified timestamp, IP uniqueness), DecommissionItemAsync (soft-delete, cascade to child SW, already-decommissioned rejection), GetItemAsync (with InstalledSoftware children, not found), AutoSeedFromBoundaryAsync (create from boundary, idempotent re-run, no boundary data error), ListItemsAsync (filter by type/function/vendor/status/search, pagination), ExportToExcelAsync (HW+SW worksheets, decommissioned filter, empty inventory error), ImportFromExcelAsync (valid import, partial import with row errors, dry-run mode, duplicate skip, HW-before-SW ordering), CheckCompletenessAsync (missing fields, unmatched boundary, HW without SW, all-complete scenario) in tests/Ato.Copilot.Tests.Unit/Compliance/InventoryServiceTests.cs
+- [X] T027 [P] Create InventoryToolTests.cs with unit tests for all 9 MCP tools verifying: correct parameter parsing, service method delegation, standard response envelope format, error propagation with errorCode and suggestion in tests/Ato.Copilot.Tests.Unit/Tools/InventoryToolTests.cs
+- [X] T028 [P] Create InventoryIntegrationTests.cs with integration tests for all 9 MCP tools (inventory_add_item, inventory_update_item, inventory_decommission_item, inventory_list, inventory_get, inventory_export, inventory_import, inventory_completeness, inventory_auto_seed) covering happy-path and at least one error-path per tool in tests/Ato.Copilot.Tests.Integration/Compliance/InventoryIntegrationTests.cs
+
+---
+
+## Phase 10: Documentation
+
+**Purpose**: Update all documentation files specified in the feature specification
+
+- [X] T029 [P] Add all 9 inventory MCP tools (inventory_add_item, inventory_update_item, inventory_decommission_item, inventory_list, inventory_get, inventory_export, inventory_import, inventory_completeness, inventory_auto_seed) with parameter descriptions, example invocations, and return types in docs/api/mcp-server.md
+- [X] T030 [P] Add InventoryItem entity with all fields, RegisteredSystem FK, optional ParentHardwareId FK, optional BoundaryResourceId FK, and InventoryCompleteness computed type in docs/architecture/data-model.md
+- [X] T031 [P] Register all 9 inventory tools in the tool catalog with capability descriptions, required parameters, and persona access mappings (ISSO, Engineer, SCA) in docs/architecture/agent-tool-catalog.md
+- [X] T032 [P] Update architecture overview to include InventoryService in the system component diagram in docs/architecture/overview.md
+- [X] T033 [P] Add "Managing HW/SW Inventory" section covering end-to-end workflow (auto-seed → add/edit → completeness check → export → import) in docs/guides/isso-guide.md
+- [X] T034 [P] Add inventory registration guidance for engineers registering components and keeping versions current in docs/guides/engineer-guide.md
+- [X] T035 [P] Add inventory review guidance for SCAs reviewing completeness and verifying HW/SW coverage before assessment in docs/guides/sca-guide.md
+- [X] T036 [P] Update ISSO getting-started guide to mention HW/SW inventory as a core capability with link to detailed guide in docs/getting-started/isso.md
+- [X] T037 [P] Update Engineer getting-started guide to mention component registration in docs/getting-started/engineer.md
+- [X] T038 [P] Add terms (Hardware Inventory, Software Inventory, Inventory Completeness Check, Auto-Seed, eMASS HW/SW Export) in docs/reference/glossary.md
+- [X] T039 [P] Add validation test cases for all 9 inventory MCP tools covering expected inputs, outputs, and error scenarios per persona in docs/persona-test-cases/tool-validation.md
+- [X] T040 [P] Add seed data instructions for HW/SW inventory items (sample hardware, software, parent-child relationships, boundary linkages) in docs/persona-test-cases/test-data-setup.md
+- [X] T041 [P] Add checklist items verifying inventory tools are registered, data is seeded, and eMASS export/import round-trip is functional in docs/persona-test-cases/environment-checklist.md
+- [X] T042 [P] Add inventory-related rows to the results template for tracking pass/fail status in docs/persona-test-cases/results-template.md
+- [X] T043 [P] Add test scenarios for ISSO inventory workflows (add/edit, completeness check, export, import) in docs/persona-test-cases/scripts/isso-test-script.md
+- [X] T044 [P] Add test scenarios for Engineer registering components and updating versions in docs/persona-test-cases/scripts/engineer-test-script.md
+- [X] T045 [P] Add test scenarios for SCA reviewing inventory completeness before assessment in docs/persona-test-cases/scripts/sca-test-script.md
+- [X] T046 [P] Add test scenarios for ISSM reviewing inventory status across systems in portfolio in docs/persona-test-cases/scripts/issm-test-script.md
+- [X] T047 [P] Add cross-persona inventory scenarios (Engineer registers → ISSO completeness check → SCA verifies → ISSO exports) in docs/persona-test-cases/scripts/cross-persona-test-script.md
+- [X] T048 [P] Add HW/SW inventory steps to the unified RMF lifecycle test flow (Categorize/Implement/Assess phases) in docs/persona-test-cases/scripts/unified-rmf-test-script.md
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and validation
+
+- [X] T049 Verify solution builds with zero errors and all existing + new unit tests pass
+- [X] T050 Run quickstart.md 7-step workflow end-to-end validation (auto-seed → add HW → add SW → list → completeness → export → import)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (Phase 1) — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational (Phase 2) — MVP, implement first
+- **US2 (Phase 4)**: Depends on Foundational (Phase 2) — can start after Phase 2, independent of US1
+- **US3 (Phase 5)**: Depends on Foundational (Phase 2) — can start after Phase 2, independent of US1/US2
+- **US6 (Phase 6)**: Depends on Phase 5 (US3) for round-trip format compatibility verification
+- **US4 (Phase 7)**: Depends on Foundational (Phase 2) — can start after Phase 2, independent of other stories
+- **US5 (Phase 8)**: Depends on Foundational (Phase 2) — can start after Phase 2, requires inventory data for SSP rendering
+- **Testing (Phase 9)**: Depends on all user stories (Phases 3–8) being complete
+- **Documentation (Phase 10)**: Depends on all user stories (Phases 3–8) being complete
+- **Polish (Phase 11)**: Depends on Testing and Documentation (Phases 9–10)
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependencies on other stories — MVP deliverable
+- **US2 (P2)**: Independent — uses same entity/service, no cross-story dependencies
+- **US3 (P2)**: Independent — export reads from existing inventory data
+- **US6 (P2)**: Soft dependency on US3 — uses same eMASS column format for round-trip compatibility
+- **US4 (P3)**: Independent — completeness check reads inventory + boundary data
+- **US5 (P3)**: Independent — SSP integration reads inventory data
+
+### Within Each User Story
+
+- Service methods before tools (tools call service methods)
+- AddItemAsync first in US1 (establishes validation patterns used by other methods)
+- Core CRUD (T007–T010) before auto-seed (T011) since auto-seed creates items
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- All Phase 10 documentation tasks (T029–T048) can run in parallel (different files)
+- T026, T027, and T028 can run in parallel (different test files)
+- After Phase 2 completes, US1–US5 can theoretically start in parallel (if staffed), though sequential P1→P2→P3 is recommended for single-implementor flow
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+After Phase 2 completes:
+
+Sequential (same file — InventoryService.cs):
+  T007 → T008 → T009 → T010 → T011
+
+Sequential (same file — InventoryTools.cs):
+  T012 → T013 → T014 → T015 → T016
+
+These two sequences CAN run in parallel (different files):
+  [InventoryService.cs] T007 → T008 → T009 → T010 → T011
+  [InventoryTools.cs]   T012 → T013 → T014 → T015 → T016
+```
+
+---
+
+## Implementation Strategy
+
+- **MVP Scope**: Phase 1 + Phase 2 + Phase 3 (US1) — delivers core CRUD and auto-seed capability
+- **Incremental Delivery**: Each user story phase produces an independently testable increment
+- **Recommended Order**: Phases 1–8 sequentially (P1 → P2 → P3), then Phase 9 (tests), Phase 10 (docs), Phase 11 (polish)
+- **Total Tasks**: 50

--- a/src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/InventoryService.cs
@@ -1,0 +1,760 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Agents.Compliance.Services;
+
+/// <summary>
+/// Implements HW/SW inventory management: CRUD, export, import,
+/// completeness checking, and auto-seed from boundary resources.
+/// </summary>
+/// <remarks>Feature 025 – HW/SW Inventory.</remarks>
+public class InventoryService : IInventoryService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<InventoryService> _logger;
+
+    public InventoryService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<InventoryService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    // ─── T007: AddItemAsync ──────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryItem> AddItemAsync(
+        string registeredSystemId,
+        InventoryItemInput input,
+        string addedBy,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // System existence check
+        var systemExists = await db.RegisteredSystems
+            .AnyAsync(s => s.Id == registeredSystemId, cancellationToken);
+        if (!systemExists)
+            throw new InvalidOperationException("SYSTEM_NOT_FOUND: System does not exist.");
+
+        // Parse enums
+        if (input.Type == null)
+            throw new InvalidOperationException("VALIDATION_FAILED: 'type' is required.");
+        if (string.IsNullOrWhiteSpace(input.ItemName))
+            throw new InvalidOperationException("VALIDATION_FAILED: 'item_name' is required.");
+
+        var itemType = input.Type.Value;
+
+        // FR-018: Function-based required field validation
+        if (itemType == InventoryItemType.Hardware)
+        {
+            if (input.HardwareFunction == null)
+                throw new InvalidOperationException("VALIDATION_FAILED: 'function' is required for hardware items.");
+            if (string.IsNullOrWhiteSpace(input.Manufacturer))
+                throw new InvalidOperationException("VALIDATION_FAILED: 'manufacturer' is required for hardware items.");
+
+            // Server / NetworkDevice additionally require IP
+            if (input.HardwareFunction is HardwareFunction.Server or HardwareFunction.NetworkDevice
+                && string.IsNullOrWhiteSpace(input.IpAddress))
+            {
+                throw new InvalidOperationException("VALIDATION_FAILED: 'ip_address' is required for server and network device hardware.");
+            }
+        }
+        else // Software
+        {
+            if (input.SoftwareFunction == null)
+                throw new InvalidOperationException("VALIDATION_FAILED: 'function' is required for software items.");
+            if (string.IsNullOrWhiteSpace(input.Vendor))
+                throw new InvalidOperationException("VALIDATION_FAILED: 'vendor' is required for software items.");
+            if (string.IsNullOrWhiteSpace(input.Version))
+                throw new InvalidOperationException("VALIDATION_FAILED: 'version' is required for software items.");
+        }
+
+        // FR-016: Unique IP within system
+        if (!string.IsNullOrWhiteSpace(input.IpAddress))
+        {
+            var ipExists = await db.InventoryItems
+                .AnyAsync(i => i.RegisteredSystemId == registeredSystemId
+                    && i.IpAddress == input.IpAddress
+                    && i.Status == InventoryItemStatus.Active,
+                    cancellationToken);
+            if (ipExists)
+                throw new InvalidOperationException("DUPLICATE_IP: IP address already exists in this system's inventory.");
+        }
+
+        // ParentHardwareId validation
+        if (!string.IsNullOrWhiteSpace(input.ParentHardwareId))
+        {
+            var parent = await db.InventoryItems
+                .FirstOrDefaultAsync(i => i.Id == input.ParentHardwareId, cancellationToken);
+            if (parent == null)
+                throw new InvalidOperationException("PARENT_NOT_FOUND: Parent hardware item does not exist.");
+            if (parent.Type != InventoryItemType.Hardware)
+                throw new InvalidOperationException("PARENT_NOT_FOUND: Parent item is not a hardware item.");
+        }
+
+        var item = new InventoryItem
+        {
+            RegisteredSystemId = registeredSystemId,
+            ItemName = input.ItemName,
+            Type = itemType,
+            HardwareFunction = input.HardwareFunction,
+            SoftwareFunction = input.SoftwareFunction,
+            Manufacturer = input.Manufacturer,
+            Model = input.Model,
+            SerialNumber = input.SerialNumber,
+            IpAddress = input.IpAddress,
+            MacAddress = input.MacAddress,
+            Location = input.Location,
+            Vendor = input.Vendor,
+            Version = input.Version,
+            PatchLevel = input.PatchLevel,
+            LicenseType = input.LicenseType,
+            ParentHardwareId = input.ParentHardwareId,
+            CreatedBy = addedBy
+        };
+
+        db.InventoryItems.Add(item);
+        await db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Added inventory item {ItemId} ({Type}/{Name}) to system {SystemId}",
+            item.Id, item.Type, item.ItemName, registeredSystemId);
+
+        return item;
+    }
+
+    // ─── T008: UpdateItemAsync ───────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryItem> UpdateItemAsync(
+        string itemId,
+        InventoryItemInput input,
+        string modifiedBy,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var item = await db.InventoryItems
+            .FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+        if (item == null)
+            throw new InvalidOperationException("ITEM_NOT_FOUND: Inventory item does not exist.");
+
+        // Apply partial updates (null = no change)
+        if (input.ItemName != null) item.ItemName = input.ItemName;
+        if (input.HardwareFunction != null) item.HardwareFunction = input.HardwareFunction;
+        if (input.SoftwareFunction != null) item.SoftwareFunction = input.SoftwareFunction;
+        if (input.Manufacturer != null) item.Manufacturer = input.Manufacturer;
+        if (input.Model != null) item.Model = input.Model;
+        if (input.SerialNumber != null) item.SerialNumber = input.SerialNumber;
+        if (input.MacAddress != null) item.MacAddress = input.MacAddress;
+        if (input.Location != null) item.Location = input.Location;
+        if (input.Vendor != null) item.Vendor = input.Vendor;
+        if (input.Version != null) item.Version = input.Version;
+        if (input.PatchLevel != null) item.PatchLevel = input.PatchLevel;
+        if (input.LicenseType != null) item.LicenseType = input.LicenseType;
+        if (input.ParentHardwareId != null) item.ParentHardwareId = input.ParentHardwareId;
+
+        // IP address update with uniqueness re-validation
+        if (input.IpAddress != null)
+        {
+            if (!string.IsNullOrWhiteSpace(input.IpAddress))
+            {
+                var ipExists = await db.InventoryItems
+                    .AnyAsync(i => i.RegisteredSystemId == item.RegisteredSystemId
+                        && i.IpAddress == input.IpAddress
+                        && i.Id != itemId
+                        && i.Status == InventoryItemStatus.Active,
+                        cancellationToken);
+                if (ipExists)
+                    throw new InvalidOperationException("DUPLICATE_IP: IP address already exists in this system's inventory.");
+            }
+            item.IpAddress = input.IpAddress;
+        }
+
+        // FR-003: Record modifier and timestamp
+        item.ModifiedBy = modifiedBy;
+        item.ModifiedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Updated inventory item {ItemId} by {ModifiedBy}", itemId, modifiedBy);
+
+        return item;
+    }
+
+    // ─── T009: DecommissionItemAsync ─────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryItem> DecommissionItemAsync(
+        string itemId,
+        string rationale,
+        string decommissionedBy,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var item = await db.InventoryItems
+            .Include(i => i.InstalledSoftware)
+            .FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+        if (item == null)
+            throw new InvalidOperationException("ITEM_NOT_FOUND: Inventory item does not exist.");
+
+        if (item.Status == InventoryItemStatus.Decommissioned)
+            throw new InvalidOperationException("ALREADY_DECOMMISSIONED: Item is already decommissioned.");
+
+        // Soft-delete
+        item.Status = InventoryItemStatus.Decommissioned;
+        item.DecommissionDate = DateTime.UtcNow;
+        item.DecommissionRationale = rationale;
+        item.ModifiedBy = decommissionedBy;
+        item.ModifiedAt = DateTime.UtcNow;
+
+        // FR-005: Cascade decommission to child software
+        if (item.Type == InventoryItemType.Hardware && item.InstalledSoftware != null)
+        {
+            foreach (var sw in item.InstalledSoftware.Where(s => s.Status == InventoryItemStatus.Active))
+            {
+                sw.Status = InventoryItemStatus.Decommissioned;
+                sw.DecommissionDate = DateTime.UtcNow;
+                sw.DecommissionRationale = rationale;
+                sw.ModifiedBy = decommissionedBy;
+                sw.ModifiedAt = DateTime.UtcNow;
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Decommissioned inventory item {ItemId} by {DecommissionedBy}",
+            itemId, decommissionedBy);
+
+        return item;
+    }
+
+    // ─── T010: GetItemAsync ──────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryItem?> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // FR-007: Eager-load InstalledSoftware for hardware items
+        return await db.InventoryItems
+            .Include(i => i.InstalledSoftware)
+            .FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+    }
+
+    // ─── T011: AutoSeedFromBoundaryAsync ─────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<InventoryItem>> AutoSeedFromBoundaryAsync(
+        string registeredSystemId,
+        string seededBy,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // System existence check
+        var systemExists = await db.RegisteredSystems
+            .AnyAsync(s => s.Id == registeredSystemId, cancellationToken);
+        if (!systemExists)
+            throw new InvalidOperationException("SYSTEM_NOT_FOUND: System does not exist.");
+
+        // Get in-boundary resources
+        var boundaryResources = await db.AuthorizationBoundaries
+            .Where(b => b.RegisteredSystemId == registeredSystemId && b.IsInBoundary)
+            .ToListAsync(cancellationToken);
+
+        if (boundaryResources.Count == 0)
+            throw new InvalidOperationException("NO_BOUNDARY_DATA: System has no boundary resources.");
+
+        // FR-014: Get already-linked boundary resource IDs for idempotency
+        var linkedBoundaryIds = await db.InventoryItems
+            .Where(i => i.RegisteredSystemId == registeredSystemId && i.BoundaryResourceId != null)
+            .Select(i => i.BoundaryResourceId!)
+            .ToListAsync(cancellationToken);
+
+        var linkedSet = new HashSet<string>(linkedBoundaryIds);
+        var created = new List<InventoryItem>();
+
+        foreach (var br in boundaryResources)
+        {
+            if (linkedSet.Contains(br.Id))
+                continue; // Already linked — idempotent skip
+
+            var hwFunction = MapResourceTypeToFunction(br.ResourceType);
+
+            var item = new InventoryItem
+            {
+                RegisteredSystemId = registeredSystemId,
+                ItemName = br.ResourceName ?? br.ResourceId,
+                Type = InventoryItemType.Hardware,
+                HardwareFunction = hwFunction,
+                Manufacturer = br.InheritanceProvider,
+                BoundaryResourceId = br.Id,
+                CreatedBy = seededBy
+            };
+
+            db.InventoryItems.Add(item);
+            created.Add(item);
+        }
+
+        if (created.Count > 0)
+            await db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Auto-seeded {Count} inventory items from boundary resources for system {SystemId}",
+            created.Count, registeredSystemId);
+
+        return created;
+    }
+
+    // ─── T017: ListItemsAsync ────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<InventoryItem>> ListItemsAsync(
+        string registeredSystemId,
+        InventoryListOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var opts = options ?? new InventoryListOptions();
+
+        IQueryable<InventoryItem> query = db.InventoryItems
+            .Where(i => i.RegisteredSystemId == registeredSystemId);
+
+        // Status filter (default Active)
+        if (opts.Status != null)
+            query = query.Where(i => i.Status == opts.Status.Value);
+        else
+            query = query.Where(i => i.Status == InventoryItemStatus.Active);
+
+        // Type filter
+        if (opts.Type != null)
+            query = query.Where(i => i.Type == opts.Type.Value);
+
+        // Function filter (match against HW or SW function as string)
+        if (!string.IsNullOrWhiteSpace(opts.Function))
+        {
+            var fn = opts.Function;
+            query = query.Where(i =>
+                (i.HardwareFunction != null && i.HardwareFunction.ToString()! == fn) ||
+                (i.SoftwareFunction != null && i.SoftwareFunction.ToString()! == fn));
+        }
+
+        // Vendor/Manufacturer filter (contains)
+        if (!string.IsNullOrWhiteSpace(opts.Vendor))
+        {
+            var vendor = opts.Vendor;
+            query = query.Where(i =>
+                (i.Vendor != null && i.Vendor.Contains(vendor)) ||
+                (i.Manufacturer != null && i.Manufacturer.Contains(vendor)));
+        }
+
+        // Free-text search on ItemName
+        if (!string.IsNullOrWhiteSpace(opts.SearchText))
+        {
+            var search = opts.SearchText;
+            query = query.Where(i => i.ItemName.Contains(search));
+        }
+
+        // Pagination
+        var pageSize = opts.PageSize > 0 ? opts.PageSize : 50;
+        var pageNumber = opts.PageNumber > 0 ? opts.PageNumber : 1;
+
+        query = query
+            .OrderBy(i => i.ItemName)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize);
+
+        return await query.ToListAsync(cancellationToken);
+    }
+
+    // ─── T019: ExportToExcelAsync ────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<byte[]> ExportToExcelAsync(
+        string registeredSystemId,
+        InventoryExportOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var systemExists = await db.RegisteredSystems
+            .AnyAsync(s => s.Id == registeredSystemId, cancellationToken);
+        if (!systemExists)
+            throw new InvalidOperationException("SYSTEM_NOT_FOUND: System does not exist.");
+
+        var opts = options ?? new InventoryExportOptions();
+
+        IQueryable<InventoryItem> query = db.InventoryItems
+            .Where(i => i.RegisteredSystemId == registeredSystemId);
+
+        if (!opts.IncludeDecommissioned)
+            query = query.Where(i => i.Status == InventoryItemStatus.Active);
+
+        var items = await query.ToListAsync(cancellationToken);
+
+        if (items.Count == 0)
+            throw new InvalidOperationException("NO_INVENTORY_DATA: System has no inventory items.");
+
+        var hwItems = (opts.ExportType?.Equals("software", StringComparison.OrdinalIgnoreCase) == true)
+            ? new List<InventoryItem>()
+            : items.Where(i => i.Type == InventoryItemType.Hardware).ToList();
+
+        var swItems = (opts.ExportType?.Equals("hardware", StringComparison.OrdinalIgnoreCase) == true)
+            ? new List<InventoryItem>()
+            : items.Where(i => i.Type == InventoryItemType.Software).ToList();
+
+        using var workbook = new ClosedXML.Excel.XLWorkbook();
+
+        // Hardware worksheet
+        if (hwItems.Count > 0 || opts.ExportType?.Equals("software", StringComparison.OrdinalIgnoreCase) != true)
+        {
+            var hwSheet = workbook.Worksheets.Add("Hardware");
+            var hwHeaders = new[] { "System Name", "Hardware Name", "Manufacturer", "Model", "Serial Number", "Function", "IP Address", "MAC Address", "Location", "Status" };
+            for (var c = 0; c < hwHeaders.Length; c++)
+                hwSheet.Cell(1, c + 1).Value = hwHeaders[c];
+
+            for (var r = 0; r < hwItems.Count; r++)
+            {
+                var hw = hwItems[r];
+                hwSheet.Cell(r + 2, 1).Value = hw.RegisteredSystemId;
+                hwSheet.Cell(r + 2, 2).Value = hw.ItemName;
+                hwSheet.Cell(r + 2, 3).Value = hw.Manufacturer ?? string.Empty;
+                hwSheet.Cell(r + 2, 4).Value = hw.Model ?? string.Empty;
+                hwSheet.Cell(r + 2, 5).Value = hw.SerialNumber ?? string.Empty;
+                hwSheet.Cell(r + 2, 6).Value = hw.HardwareFunction?.ToString() ?? string.Empty;
+                hwSheet.Cell(r + 2, 7).Value = hw.IpAddress ?? string.Empty;
+                hwSheet.Cell(r + 2, 8).Value = hw.MacAddress ?? string.Empty;
+                hwSheet.Cell(r + 2, 9).Value = hw.Location ?? string.Empty;
+                hwSheet.Cell(r + 2, 10).Value = hw.Status.ToString();
+            }
+        }
+
+        // Software worksheet
+        if (swItems.Count > 0 || opts.ExportType?.Equals("hardware", StringComparison.OrdinalIgnoreCase) != true)
+        {
+            var swSheet = workbook.Worksheets.Add("Software");
+            var swHeaders = new[] { "System Name", "Software Name", "Vendor", "Version", "Patch Level", "Function", "License Type", "Installed On", "Status" };
+            for (var c = 0; c < swHeaders.Length; c++)
+                swSheet.Cell(1, c + 1).Value = swHeaders[c];
+
+            for (var r = 0; r < swItems.Count; r++)
+            {
+                var sw = swItems[r];
+                swSheet.Cell(r + 2, 1).Value = sw.RegisteredSystemId;
+                swSheet.Cell(r + 2, 2).Value = sw.ItemName;
+                swSheet.Cell(r + 2, 3).Value = sw.Vendor ?? string.Empty;
+                swSheet.Cell(r + 2, 4).Value = sw.Version ?? string.Empty;
+                swSheet.Cell(r + 2, 5).Value = sw.PatchLevel ?? string.Empty;
+                swSheet.Cell(r + 2, 6).Value = sw.SoftwareFunction?.ToString() ?? string.Empty;
+                swSheet.Cell(r + 2, 7).Value = sw.LicenseType ?? string.Empty;
+                swSheet.Cell(r + 2, 8).Value = sw.ParentHardwareId ?? string.Empty;
+                swSheet.Cell(r + 2, 9).Value = sw.Status.ToString();
+            }
+        }
+
+        using var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        return ms.ToArray();
+    }
+
+    // ─── T021: ImportFromExcelAsync ──────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryImportResult> ImportFromExcelAsync(
+        byte[] fileBytes,
+        string registeredSystemId,
+        bool dryRun,
+        string importedBy,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var systemExists = await db.RegisteredSystems
+            .AnyAsync(s => s.Id == registeredSystemId, cancellationToken);
+        if (!systemExists)
+            throw new InvalidOperationException("SYSTEM_NOT_FOUND: System does not exist.");
+
+        var existingItems = await db.InventoryItems
+            .Where(i => i.RegisteredSystemId == registeredSystemId)
+            .Select(i => new { i.ItemName, i.Type, i.IpAddress })
+            .ToListAsync(cancellationToken);
+        var existingNames = new HashSet<string>(existingItems.Select(i => $"{i.ItemName}|{i.Type}"));
+        var existingIps = new HashSet<string>(existingItems.Where(i => i.IpAddress != null).Select(i => i.IpAddress!));
+
+        var result = new InventoryImportResult { SystemId = registeredSystemId };
+        var importErrors = new List<ImportRowError>();
+
+        using var ms = new MemoryStream(fileBytes);
+        using var workbook = new ClosedXML.Excel.XLWorkbook(ms);
+
+        // Process Hardware worksheet first (so SW "Installed On" references resolve)
+        if (workbook.TryGetWorksheet("Hardware", out var hwSheet))
+        {
+            var lastRow = hwSheet.LastRowUsed()?.RowNumber() ?? 1;
+            for (var row = 2; row <= lastRow; row++)
+            {
+                var name = hwSheet.Cell(row, 2).GetString().Trim();
+                var mfg = hwSheet.Cell(row, 3).GetString().Trim();
+                var model = hwSheet.Cell(row, 4).GetString().Trim();
+                var serial = hwSheet.Cell(row, 5).GetString().Trim();
+                var funcStr = hwSheet.Cell(row, 6).GetString().Trim();
+                var ip = hwSheet.Cell(row, 7).GetString().Trim();
+                var mac = hwSheet.Cell(row, 8).GetString().Trim();
+                var loc = hwSheet.Cell(row, 9).GetString().Trim();
+
+                // Validate required fields (FR-018)
+                var errors = new List<string>();
+                if (string.IsNullOrWhiteSpace(name)) errors.Add("Hardware Name is required");
+                if (string.IsNullOrWhiteSpace(mfg)) errors.Add("Manufacturer is required");
+
+                HardwareFunction? hwFunc = null;
+                if (string.IsNullOrWhiteSpace(funcStr))
+                    errors.Add("Function is required");
+                else if (!Enum.TryParse<HardwareFunction>(funcStr, true, out var parsedFunc))
+                    errors.Add($"Invalid function '{funcStr}'");
+                else
+                    hwFunc = parsedFunc;
+
+                if (hwFunc is HardwareFunction.Server or HardwareFunction.NetworkDevice && string.IsNullOrWhiteSpace(ip))
+                    errors.Add("IP Address is required for server/network device");
+
+                // Duplicate check
+                if (!string.IsNullOrWhiteSpace(name) && existingNames.Contains($"{name}|Hardware"))
+                {
+                    result.RowsSkipped++;
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(ip) && existingIps.Contains(ip))
+                    errors.Add($"Duplicate IP address: {ip}");
+
+                if (errors.Count > 0)
+                {
+                    importErrors.Add(new ImportRowError { RowNumber = row, Worksheet = "Hardware", Error = string.Join("; ", errors) });
+                    continue;
+                }
+
+                var item = new InventoryItem
+                {
+                    RegisteredSystemId = registeredSystemId,
+                    ItemName = name,
+                    Type = InventoryItemType.Hardware,
+                    HardwareFunction = hwFunc,
+                    Manufacturer = string.IsNullOrWhiteSpace(mfg) ? null : mfg,
+                    Model = string.IsNullOrWhiteSpace(model) ? null : model,
+                    SerialNumber = string.IsNullOrWhiteSpace(serial) ? null : serial,
+                    IpAddress = string.IsNullOrWhiteSpace(ip) ? null : ip,
+                    MacAddress = string.IsNullOrWhiteSpace(mac) ? null : mac,
+                    Location = string.IsNullOrWhiteSpace(loc) ? null : loc,
+                    CreatedBy = importedBy
+                };
+
+                if (!dryRun)
+                    db.InventoryItems.Add(item);
+
+                existingNames.Add($"{name}|Hardware");
+                if (!string.IsNullOrWhiteSpace(ip)) existingIps.Add(ip);
+                result.HardwareCreated++;
+            }
+        }
+
+        // Process Software worksheet
+        if (workbook.TryGetWorksheet("Software", out var swSheet))
+        {
+            var lastRow = swSheet.LastRowUsed()?.RowNumber() ?? 1;
+            for (var row = 2; row <= lastRow; row++)
+            {
+                var name = swSheet.Cell(row, 2).GetString().Trim();
+                var vendor = swSheet.Cell(row, 3).GetString().Trim();
+                var version = swSheet.Cell(row, 4).GetString().Trim();
+                var patchLevel = swSheet.Cell(row, 5).GetString().Trim();
+                var funcStr = swSheet.Cell(row, 6).GetString().Trim();
+                var licType = swSheet.Cell(row, 7).GetString().Trim();
+                var installedOn = swSheet.Cell(row, 8).GetString().Trim();
+
+                // Validate required fields (FR-018)
+                var errors = new List<string>();
+                if (string.IsNullOrWhiteSpace(name)) errors.Add("Software Name is required");
+                if (string.IsNullOrWhiteSpace(vendor)) errors.Add("Vendor is required");
+                if (string.IsNullOrWhiteSpace(version)) errors.Add("Version is required");
+
+                SoftwareFunction? swFunc = null;
+                if (!string.IsNullOrWhiteSpace(funcStr) && !Enum.TryParse<SoftwareFunction>(funcStr, true, out var parsedSwFunc))
+                    errors.Add($"Invalid function '{funcStr}'");
+                else if (!string.IsNullOrWhiteSpace(funcStr))
+                    swFunc = Enum.Parse<SoftwareFunction>(funcStr, true);
+
+                // Duplicate check
+                if (!string.IsNullOrWhiteSpace(name) && existingNames.Contains($"{name}|Software"))
+                {
+                    result.RowsSkipped++;
+                    continue;
+                }
+
+                if (errors.Count > 0)
+                {
+                    importErrors.Add(new ImportRowError { RowNumber = row, Worksheet = "Software", Error = string.Join("; ", errors) });
+                    continue;
+                }
+
+                var item = new InventoryItem
+                {
+                    RegisteredSystemId = registeredSystemId,
+                    ItemName = name,
+                    Type = InventoryItemType.Software,
+                    SoftwareFunction = swFunc,
+                    Vendor = string.IsNullOrWhiteSpace(vendor) ? null : vendor,
+                    Version = string.IsNullOrWhiteSpace(version) ? null : version,
+                    PatchLevel = string.IsNullOrWhiteSpace(patchLevel) ? null : patchLevel,
+                    LicenseType = string.IsNullOrWhiteSpace(licType) ? null : licType,
+                    ParentHardwareId = string.IsNullOrWhiteSpace(installedOn) ? null : installedOn,
+                    CreatedBy = importedBy
+                };
+
+                if (!dryRun)
+                    db.InventoryItems.Add(item);
+
+                existingNames.Add($"{name}|Software");
+                result.SoftwareCreated++;
+            }
+        }
+
+        result.Errors = importErrors;
+
+        if (!dryRun && (result.HardwareCreated > 0 || result.SoftwareCreated > 0))
+            await db.SaveChangesAsync(cancellationToken);
+
+        result.DryRun = dryRun;
+
+        _logger.LogInformation("Import completed for system {SystemId}: {HwCreated} HW + {SwCreated} SW created, {Skipped} skipped, {Errors} errors (dry_run={DryRun})",
+            registeredSystemId, result.HardwareCreated, result.SoftwareCreated, result.RowsSkipped, result.Errors.Count, dryRun);
+
+        return result;
+    }
+
+    // ─── T023: CheckCompletenessAsync ────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<InventoryCompleteness> CheckCompletenessAsync(
+        string registeredSystemId,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        var systemExists = await db.RegisteredSystems
+            .AnyAsync(s => s.Id == registeredSystemId, cancellationToken);
+        if (!systemExists)
+            throw new InvalidOperationException("SYSTEM_NOT_FOUND: System does not exist.");
+
+        var items = await db.InventoryItems
+            .Where(i => i.RegisteredSystemId == registeredSystemId && i.Status != InventoryItemStatus.Decommissioned)
+            .ToListAsync(cancellationToken);
+
+        var hwItems = items.Where(i => i.Type == InventoryItemType.Hardware).ToList();
+        var swItems = items.Where(i => i.Type == InventoryItemType.Software).ToList();
+
+        // Dimension 1: Missing required fields (FR-018)
+        var missingFields = new List<InventoryIssue>();
+        foreach (var item in items)
+        {
+            var missing = new List<string>();
+            if (string.IsNullOrWhiteSpace(item.ItemName)) missing.Add("ItemName");
+
+            if (item.Type == InventoryItemType.Hardware)
+            {
+                if (string.IsNullOrWhiteSpace(item.Manufacturer)) missing.Add("Manufacturer");
+                if (item.HardwareFunction == null) missing.Add("HardwareFunction");
+                if (item.HardwareFunction is HardwareFunction.Server or HardwareFunction.NetworkDevice
+                    && string.IsNullOrWhiteSpace(item.IpAddress))
+                    missing.Add("IpAddress");
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(item.Vendor)) missing.Add("Vendor");
+                if (string.IsNullOrWhiteSpace(item.Version)) missing.Add("Version");
+            }
+
+            if (missing.Count > 0)
+                missingFields.Add(new InventoryIssue { ItemId = item.Id, ItemName = item.ItemName, MissingFields = missing });
+        }
+
+        // Dimension 2: Boundary resources not represented in inventory
+        var linkedBoundaryIds = items
+            .Where(i => i.BoundaryResourceId != null)
+            .Select(i => i.BoundaryResourceId!)
+            .ToHashSet();
+
+        var unmatchedBoundary = await db.AuthorizationBoundaries
+            .Where(b => b.RegisteredSystemId == registeredSystemId && b.IsInBoundary)
+            .Where(b => !linkedBoundaryIds.Contains(b.Id))
+            .Select(b => new UnmatchedBoundaryResource
+            {
+                BoundaryResourceId = b.Id,
+                ResourceName = b.ResourceName,
+                ResourceType = b.ResourceType
+            })
+            .ToListAsync(cancellationToken);
+
+        // Dimension 3: Hardware items with zero installed software
+        var hwIdsWithSw = swItems
+            .Where(s => s.ParentHardwareId != null)
+            .Select(s => s.ParentHardwareId!)
+            .ToHashSet();
+        var hwWithoutSw = hwItems
+            .Where(h => !hwIdsWithSw.Contains(h.Id))
+            .Select(h => h.Id)
+            .ToList();
+
+        // Compute score
+        var issueItemIds = missingFields.Select(i => i.ItemId).ToHashSet();
+        var itemsWithIssues = issueItemIds.Count + hwWithoutSw.Count(id => !issueItemIds.Contains(id));
+        var score = items.Count > 0 ? Math.Round((double)(items.Count - itemsWithIssues) / items.Count * 100, 1) : 100.0;
+        var isComplete = missingFields.Count == 0 && unmatchedBoundary.Count == 0 && hwWithoutSw.Count == 0;
+
+        return new InventoryCompleteness
+        {
+            SystemId = registeredSystemId,
+            TotalItems = items.Count,
+            HardwareCount = hwItems.Count,
+            SoftwareCount = swItems.Count,
+            ItemsWithMissingFields = missingFields,
+            UnmatchedBoundaryResources = unmatchedBoundary,
+            HardwareWithoutSoftware = hwWithoutSw,
+            CompletenessScore = score,
+            IsComplete = isComplete
+        };
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static HardwareFunction MapResourceTypeToFunction(string resourceType)
+    {
+        var upper = resourceType.ToUpperInvariant();
+        if (upper.Contains("VM") || upper.Contains("VIRTUAL") || upper.Contains("COMPUTE"))
+            return HardwareFunction.Server;
+        if (upper.Contains("NETWORK") || upper.Contains("FIREWALL") || upper.Contains("GATEWAY")
+            || upper.Contains("LOADBALANCER") || upper.Contains("NSG"))
+            return HardwareFunction.NetworkDevice;
+        if (upper.Contains("STORAGE") || upper.Contains("DISK") || upper.Contains("BLOB"))
+            return HardwareFunction.Storage;
+        return HardwareFunction.Other;
+    }
+}

--- a/src/Ato.Copilot.Agents/Compliance/Services/SspService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/SspService.cs
@@ -464,6 +464,11 @@ public class SspService : ISspService
             .Where(b => b.RegisteredSystemId == systemId && b.IsInBoundary)
             .ToListAsync(cancellationToken);
 
+        var inventoryItems = await context.InventoryItems
+            .Where(i => i.RegisteredSystemId == systemId && i.Status != InventoryItemStatus.Decommissioned)
+            .OrderBy(i => i.Type).ThenBy(i => i.ItemName)
+            .ToListAsync(cancellationToken);
+
         var sspSections = await context.SspSections
             .Where(s => s.RegisteredSystemId == systemId)
             .ToDictionaryAsync(s => s.SectionNumber, cancellationToken);
@@ -571,7 +576,7 @@ public class SspService : ISspService
                     7 => GenerateSection7Content(interconnections, system, storedSection),
                     9 => GenerateSection9Content(baseline, narratives),
                     10 => GenerateSection10Content(system, baseline, narratives, approvedVersions),
-                    11 => GenerateSection11Content(boundaries, storedSection),
+                    11 => GenerateSection11Content(boundaries, inventoryItems, storedSection),
                     _ => ""
                 };
 
@@ -1372,9 +1377,10 @@ public class SspService : ISspService
         return sb.ToString().TrimEnd();
     }
 
-    /// <summary>§11 Authorization Boundary: resource inventory + authored boundary narrative.</summary>
+    /// <summary>§11 Authorization Boundary: resource inventory + HW/SW inventory tables + authored boundary narrative.</summary>
     internal static string GenerateSection11Content(
         List<AuthorizationBoundary> boundaries,
+        List<InventoryItem> inventoryItems,
         SspSection? section)
     {
         var sb = new StringBuilder();
@@ -1425,6 +1431,42 @@ public class SspService : ISspService
             {
                 sb.AppendLine($"| {b.ResourceId} | {b.ResourceType} | {b.ExclusionRationale ?? "—"} |");
             }
+        }
+
+        // ─── HW/SW Inventory Tables (FR-015) ────────────────────────────────
+        var hwItems = inventoryItems.Where(i => i.Type == InventoryItemType.Hardware).ToList();
+        var swItems = inventoryItems.Where(i => i.Type == InventoryItemType.Software).ToList();
+
+        if (hwItems.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("### Hardware Inventory");
+            sb.AppendLine();
+            sb.AppendLine("| Name | Manufacturer | Model | Serial Number | Function | IP Address | MAC Address | Location |");
+            sb.AppendLine("|------|-------------|-------|---------------|----------|------------|-------------|----------|");
+            foreach (var h in hwItems)
+            {
+                sb.AppendLine($"| {h.ItemName} | {h.Manufacturer ?? "—"} | {h.Model ?? "—"} | {h.SerialNumber ?? "—"} | {h.HardwareFunction?.ToString() ?? "—"} | {h.IpAddress ?? "—"} | {h.MacAddress ?? "—"} | {h.Location ?? "—"} |");
+            }
+        }
+
+        if (swItems.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("### Software Inventory");
+            sb.AppendLine();
+            sb.AppendLine("| Name | Vendor | Version | Patch Level | Function | License Type |");
+            sb.AppendLine("|------|--------|---------|-------------|----------|-------------|");
+            foreach (var s in swItems)
+            {
+                sb.AppendLine($"| {s.ItemName} | {s.Vendor ?? "—"} | {s.Version ?? "—"} | {s.PatchLevel ?? "—"} | {s.SoftwareFunction?.ToString() ?? "—"} | {s.LicenseType ?? "—"} |");
+            }
+        }
+
+        if (hwItems.Count == 0 && swItems.Count == 0 && boundaries.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("*No hardware/software inventory items have been registered. Use `inventory_auto_seed` to populate from boundary resources.*");
         }
 
         return sb.ToString().TrimEnd();

--- a/src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Tools/InventoryTools.cs
@@ -1,0 +1,935 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Agents.Common;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Agents.Compliance.Tools;
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_add_item
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_add_item — Add a hardware or software inventory item.
+/// </summary>
+public class InventoryAddItemTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryAddItemTool(
+        IInventoryService svc,
+        ILogger<InventoryAddItemTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_add_item";
+
+    public override string Description =>
+        "Add a hardware or software inventory item to a registered system. " +
+        "Validates required fields per item type and function classification.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true },
+        ["type"] = new() { Name = "type", Description = "'hardware' or 'software'", Type = "string", Required = true },
+        ["item_name"] = new() { Name = "item_name", Description = "Display name of the item", Type = "string", Required = true },
+        ["function"] = new() { Name = "function", Description = "Function classification (e.g., 'server', 'operating_system')", Type = "string", Required = true },
+        ["manufacturer"] = new() { Name = "manufacturer", Description = "HW manufacturer", Type = "string", Required = false },
+        ["model"] = new() { Name = "model", Description = "HW model", Type = "string", Required = false },
+        ["serial_number"] = new() { Name = "serial_number", Description = "HW serial number", Type = "string", Required = false },
+        ["ip_address"] = new() { Name = "ip_address", Description = "IPv4/IPv6 address", Type = "string", Required = false },
+        ["mac_address"] = new() { Name = "mac_address", Description = "MAC address", Type = "string", Required = false },
+        ["location"] = new() { Name = "location", Description = "Physical/logical location", Type = "string", Required = false },
+        ["vendor"] = new() { Name = "vendor", Description = "SW vendor", Type = "string", Required = false },
+        ["version"] = new() { Name = "version", Description = "SW version", Type = "string", Required = false },
+        ["patch_level"] = new() { Name = "patch_level", Description = "SW patch level", Type = "string", Required = false },
+        ["license_type"] = new() { Name = "license_type", Description = "License type", Type = "string", Required = false },
+        ["parent_hardware_id"] = new() { Name = "parent_hardware_id", Description = "Parent HW item ID (for software)", Type = "string", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var systemId = GetArg<string>(arguments, "system_id");
+        var typeStr = GetArg<string>(arguments, "type");
+        var itemName = GetArg<string>(arguments, "item_name");
+        var functionStr = GetArg<string>(arguments, "function");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return Error("INVALID_INPUT", "The 'system_id' parameter is required.");
+        if (string.IsNullOrWhiteSpace(typeStr))
+            return Error("INVALID_INPUT", "The 'type' parameter is required.");
+        if (string.IsNullOrWhiteSpace(itemName))
+            return Error("INVALID_INPUT", "The 'item_name' parameter is required.");
+        if (string.IsNullOrWhiteSpace(functionStr))
+            return Error("INVALID_INPUT", "The 'function' parameter is required.");
+
+        if (!Enum.TryParse<InventoryItemType>(typeStr, true, out var itemType))
+            return Error("INVALID_INPUT", "Invalid 'type'. Must be 'hardware' or 'software'.");
+
+        var input = new InventoryItemInput
+        {
+            ItemName = itemName,
+            Type = itemType,
+            Manufacturer = GetArg<string>(arguments, "manufacturer"),
+            Model = GetArg<string>(arguments, "model"),
+            SerialNumber = GetArg<string>(arguments, "serial_number"),
+            IpAddress = GetArg<string>(arguments, "ip_address"),
+            MacAddress = GetArg<string>(arguments, "mac_address"),
+            Location = GetArg<string>(arguments, "location"),
+            Vendor = GetArg<string>(arguments, "vendor"),
+            Version = GetArg<string>(arguments, "version"),
+            PatchLevel = GetArg<string>(arguments, "patch_level"),
+            LicenseType = GetArg<string>(arguments, "license_type"),
+            ParentHardwareId = GetArg<string>(arguments, "parent_hardware_id")
+        };
+
+        // Parse function enum based on type
+        if (itemType == InventoryItemType.Hardware)
+        {
+            if (Enum.TryParse<HardwareFunction>(functionStr, true, out var hwFunc))
+                input.HardwareFunction = hwFunc;
+            else
+                return Error("INVALID_INPUT", $"Invalid hardware function '{functionStr}'. Valid values: Server, Workstation, NetworkDevice, Storage, Other.");
+        }
+        else
+        {
+            if (Enum.TryParse<SoftwareFunction>(functionStr, true, out var swFunc))
+                input.SoftwareFunction = swFunc;
+            else
+                return Error("INVALID_INPUT", $"Invalid software function '{functionStr}'. Valid values: OperatingSystem, Database, Middleware, Application, SecurityTool, Other.");
+        }
+
+        try
+        {
+            var item = await _svc.AddItemAsync(systemId, input, "copilot-user", cancellationToken);
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = MapItem(item),
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static object MapItem(InventoryItem item) => new
+    {
+        id = item.Id,
+        system_id = item.RegisteredSystemId,
+        item_name = item.ItemName,
+        type = item.Type.ToString(),
+        hardware_function = item.HardwareFunction?.ToString(),
+        software_function = item.SoftwareFunction?.ToString(),
+        manufacturer = item.Manufacturer,
+        model = item.Model,
+        serial_number = item.SerialNumber,
+        ip_address = item.IpAddress,
+        mac_address = item.MacAddress,
+        location = item.Location,
+        vendor = item.Vendor,
+        version = item.Version,
+        patch_level = item.PatchLevel,
+        license_type = item.LicenseType,
+        status = item.Status.ToString(),
+        parent_hardware_id = item.ParentHardwareId,
+        boundary_resource_id = item.BoundaryResourceId,
+        decommission_date = item.DecommissionDate?.ToString("O"),
+        decommission_rationale = item.DecommissionRationale,
+        created_by = item.CreatedBy,
+        created_at = item.CreatedAt.ToString("O"),
+        modified_by = item.ModifiedBy,
+        modified_at = item.ModifiedAt?.ToString("O")
+    };
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_update_item
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_update_item — Update fields on an existing inventory item.
+/// </summary>
+public class InventoryUpdateItemTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryUpdateItemTool(
+        IInventoryService svc,
+        ILogger<InventoryUpdateItemTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_update_item";
+
+    public override string Description =>
+        "Update fields on an existing inventory item. Null fields are not changed.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["item_id"] = new() { Name = "item_id", Description = "Inventory item GUID", Type = "string", Required = true },
+        ["item_name"] = new() { Name = "item_name", Description = "Updated name", Type = "string", Required = false },
+        ["manufacturer"] = new() { Name = "manufacturer", Description = "Updated manufacturer", Type = "string", Required = false },
+        ["model"] = new() { Name = "model", Description = "Updated model", Type = "string", Required = false },
+        ["serial_number"] = new() { Name = "serial_number", Description = "Updated serial number", Type = "string", Required = false },
+        ["ip_address"] = new() { Name = "ip_address", Description = "Updated IP address", Type = "string", Required = false },
+        ["mac_address"] = new() { Name = "mac_address", Description = "Updated MAC address", Type = "string", Required = false },
+        ["location"] = new() { Name = "location", Description = "Updated location", Type = "string", Required = false },
+        ["vendor"] = new() { Name = "vendor", Description = "Updated vendor", Type = "string", Required = false },
+        ["version"] = new() { Name = "version", Description = "Updated version", Type = "string", Required = false },
+        ["patch_level"] = new() { Name = "patch_level", Description = "Updated patch level", Type = "string", Required = false },
+        ["license_type"] = new() { Name = "license_type", Description = "Updated license type", Type = "string", Required = false },
+        ["parent_hardware_id"] = new() { Name = "parent_hardware_id", Description = "Updated parent HW item ID", Type = "string", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var itemId = GetArg<string>(arguments, "item_id");
+
+        if (string.IsNullOrWhiteSpace(itemId))
+            return Error("INVALID_INPUT", "The 'item_id' parameter is required.");
+
+        var input = new InventoryItemInput
+        {
+            ItemName = GetArg<string>(arguments, "item_name"),
+            Manufacturer = GetArg<string>(arguments, "manufacturer"),
+            Model = GetArg<string>(arguments, "model"),
+            SerialNumber = GetArg<string>(arguments, "serial_number"),
+            IpAddress = GetArg<string>(arguments, "ip_address"),
+            MacAddress = GetArg<string>(arguments, "mac_address"),
+            Location = GetArg<string>(arguments, "location"),
+            Vendor = GetArg<string>(arguments, "vendor"),
+            Version = GetArg<string>(arguments, "version"),
+            PatchLevel = GetArg<string>(arguments, "patch_level"),
+            LicenseType = GetArg<string>(arguments, "license_type"),
+            ParentHardwareId = GetArg<string>(arguments, "parent_hardware_id")
+        };
+
+        try
+        {
+            var item = await _svc.UpdateItemAsync(itemId, input, "copilot-user", cancellationToken);
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = MapItem(item),
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static object MapItem(InventoryItem item) => new
+    {
+        id = item.Id,
+        system_id = item.RegisteredSystemId,
+        item_name = item.ItemName,
+        type = item.Type.ToString(),
+        status = item.Status.ToString(),
+        modified_by = item.ModifiedBy,
+        modified_at = item.ModifiedAt?.ToString("O")
+    };
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_decommission_item
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_decommission_item — Soft-delete an inventory item.
+/// </summary>
+public class InventoryDecommissionItemTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryDecommissionItemTool(
+        IInventoryService svc,
+        ILogger<InventoryDecommissionItemTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_decommission_item";
+
+    public override string Description =>
+        "Soft-delete an inventory item with a decommission rationale. " +
+        "If the item is hardware, all child software items are also decommissioned.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["item_id"] = new() { Name = "item_id", Description = "Inventory item GUID", Type = "string", Required = true },
+        ["rationale"] = new() { Name = "rationale", Description = "Reason for decommissioning", Type = "string", Required = true }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var itemId = GetArg<string>(arguments, "item_id");
+        var rationale = GetArg<string>(arguments, "rationale");
+
+        if (string.IsNullOrWhiteSpace(itemId))
+            return Error("INVALID_INPUT", "The 'item_id' parameter is required.");
+        if (string.IsNullOrWhiteSpace(rationale))
+            return Error("INVALID_INPUT", "The 'rationale' parameter is required.");
+
+        try
+        {
+            var item = await _svc.DecommissionItemAsync(itemId, rationale, "copilot-user", cancellationToken);
+            var cascadedCount = item.InstalledSoftware?
+                .Count(s => s.Status == InventoryItemStatus.Decommissioned) ?? 0;
+
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    id = item.Id,
+                    item_name = item.ItemName,
+                    type = item.Type.ToString(),
+                    status = item.Status.ToString(),
+                    decommission_date = item.DecommissionDate?.ToString("O"),
+                    decommission_rationale = item.DecommissionRationale
+                },
+                metadata = new
+                {
+                    tool = Name,
+                    duration_ms = sw.ElapsedMilliseconds,
+                    timestamp = DateTime.UtcNow.ToString("O"),
+                    cascaded_decommissions = cascadedCount
+                }
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_list
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_list — List and filter inventory items for a system.
+/// </summary>
+public class InventoryListTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryListTool(
+        IInventoryService svc,
+        ILogger<InventoryListTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_list";
+
+    public override string Description =>
+        "List and filter hardware/software inventory items for a system with " +
+        "options for type, function, vendor, status, and free-text search.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true },
+        ["type"] = new() { Name = "type", Description = "'hardware' or 'software'", Type = "string", Required = false },
+        ["function"] = new() { Name = "function", Description = "Function filter", Type = "string", Required = false },
+        ["vendor"] = new() { Name = "vendor", Description = "Vendor/manufacturer filter", Type = "string", Required = false },
+        ["status"] = new() { Name = "status", Description = "'active' (default) or 'decommissioned'", Type = "string", Required = false },
+        ["search"] = new() { Name = "search", Description = "Free-text search on item name", Type = "string", Required = false },
+        ["page_size"] = new() { Name = "page_size", Description = "Results per page (default 50)", Type = "integer", Required = false },
+        ["page"] = new() { Name = "page", Description = "Page number (default 1)", Type = "integer", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var systemId = GetArg<string>(arguments, "system_id");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return Error("INVALID_INPUT", "The 'system_id' parameter is required.");
+
+        var typeStr = GetArg<string>(arguments, "type");
+        var functionStr = GetArg<string>(arguments, "function");
+        var vendor = GetArg<string>(arguments, "vendor");
+        var statusStr = GetArg<string>(arguments, "status");
+        var search = GetArg<string>(arguments, "search");
+        var pageSizeStr = GetArg<string>(arguments, "page_size");
+        var pageStr = GetArg<string>(arguments, "page");
+
+        var options = new InventoryListOptions
+        {
+            Function = functionStr,
+            Vendor = vendor,
+            SearchText = search,
+            PageSize = int.TryParse(pageSizeStr, out var ps) ? ps : 50,
+            PageNumber = int.TryParse(pageStr, out var p) ? p : 1
+        };
+
+        if (!string.IsNullOrWhiteSpace(typeStr) && Enum.TryParse<InventoryItemType>(typeStr, true, out var itemType))
+            options.Type = itemType;
+
+        if (!string.IsNullOrWhiteSpace(statusStr) && Enum.TryParse<InventoryItemStatus>(statusStr, true, out var itemStatus))
+            options.Status = itemStatus;
+
+        try
+        {
+            var items = await _svc.ListItemsAsync(systemId, options, cancellationToken);
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    system_id = systemId,
+                    count = items.Count,
+                    page = options.PageNumber,
+                    page_size = options.PageSize,
+                    items = items.Select(i => new
+                    {
+                        id = i.Id,
+                        item_name = i.ItemName,
+                        type = i.Type.ToString(),
+                        hardware_function = i.HardwareFunction?.ToString(),
+                        software_function = i.SoftwareFunction?.ToString(),
+                        manufacturer = i.Manufacturer,
+                        vendor = i.Vendor,
+                        version = i.Version,
+                        ip_address = i.IpAddress,
+                        status = i.Status.ToString()
+                    })
+                },
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_get
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_get — Retrieve a single inventory item by ID.
+/// </summary>
+public class InventoryGetTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryGetTool(
+        IInventoryService svc,
+        ILogger<InventoryGetTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_get";
+
+    public override string Description =>
+        "Retrieve a single inventory item by ID, including installed software for hardware items.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["item_id"] = new() { Name = "item_id", Description = "Inventory item GUID", Type = "string", Required = true }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var itemId = GetArg<string>(arguments, "item_id");
+
+        if (string.IsNullOrWhiteSpace(itemId))
+            return Error("INVALID_INPUT", "The 'item_id' parameter is required.");
+
+        var item = await _svc.GetItemAsync(itemId, cancellationToken);
+        if (item == null)
+            return Error("ITEM_NOT_FOUND", $"Inventory item '{itemId}' not found.");
+
+        sw.Stop();
+        return JsonSerializer.Serialize(new
+        {
+            status = "success",
+            data = new
+            {
+                id = item.Id,
+                system_id = item.RegisteredSystemId,
+                item_name = item.ItemName,
+                type = item.Type.ToString(),
+                hardware_function = item.HardwareFunction?.ToString(),
+                software_function = item.SoftwareFunction?.ToString(),
+                manufacturer = item.Manufacturer,
+                model = item.Model,
+                serial_number = item.SerialNumber,
+                ip_address = item.IpAddress,
+                mac_address = item.MacAddress,
+                location = item.Location,
+                vendor = item.Vendor,
+                version = item.Version,
+                patch_level = item.PatchLevel,
+                license_type = item.LicenseType,
+                status = item.Status.ToString(),
+                parent_hardware_id = item.ParentHardwareId,
+                boundary_resource_id = item.BoundaryResourceId,
+                installed_software = item.InstalledSoftware?.Select(s => new
+                {
+                    id = s.Id,
+                    item_name = s.ItemName,
+                    software_function = s.SoftwareFunction?.ToString(),
+                    vendor = s.Vendor,
+                    version = s.Version,
+                    status = s.Status.ToString()
+                }),
+                created_by = item.CreatedBy,
+                created_at = item.CreatedAt.ToString("O")
+            },
+            metadata = Meta(sw)
+        }, JsonOpts);
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_export
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_export — Export inventory to eMASS-compatible Excel workbook.
+/// </summary>
+public class InventoryExportTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryExportTool(
+        IInventoryService svc,
+        ILogger<InventoryExportTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_export";
+
+    public override string Description =>
+        "Export a system's HW/SW inventory as an eMASS-compatible Excel workbook (base64-encoded).";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true },
+        ["export_type"] = new() { Name = "export_type", Description = "'hardware', 'software', or 'all' (default)", Type = "string", Required = false },
+        ["include_decommissioned"] = new() { Name = "include_decommissioned", Description = "Include decommissioned items (default false)", Type = "boolean", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var systemId = GetArg<string>(arguments, "system_id");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return Error("INVALID_INPUT", "The 'system_id' parameter is required.");
+
+        var exportType = GetArg<string>(arguments, "export_type") ?? "all";
+        var includeDecommStr = GetArg<string>(arguments, "include_decommissioned");
+        var includeDecomm = string.Equals(includeDecommStr, "true", StringComparison.OrdinalIgnoreCase);
+
+        var options = new InventoryExportOptions
+        {
+            ExportType = exportType,
+            IncludeDecommissioned = includeDecomm
+        };
+
+        try
+        {
+            var bytes = await _svc.ExportToExcelAsync(systemId, options, cancellationToken);
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    system_id = systemId,
+                    export_type = exportType,
+                    file_base64 = Convert.ToBase64String(bytes),
+                    file_size_bytes = bytes.Length
+                },
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_import
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_import — Import inventory from an eMASS-format Excel workbook.
+/// </summary>
+public class InventoryImportTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryImportTool(
+        IInventoryService svc,
+        ILogger<InventoryImportTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_import";
+
+    public override string Description =>
+        "Import HW/SW inventory from a base64-encoded eMASS-format Excel workbook " +
+        "with optional dry-run validation mode.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true },
+        ["file_base64"] = new() { Name = "file_base64", Description = "Base64-encoded Excel workbook", Type = "string", Required = true },
+        ["dry_run"] = new() { Name = "dry_run", Description = "Validate only, don't persist (default false)", Type = "boolean", Required = false }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var systemId = GetArg<string>(arguments, "system_id");
+            var fileBase64 = GetArg<string>(arguments, "file_base64");
+            var dryRun = arguments.TryGetValue("dry_run", out var dr) && dr is true;
+
+            byte[] fileBytes;
+            try
+            {
+                fileBytes = Convert.FromBase64String(fileBase64);
+            }
+            catch (FormatException)
+            {
+                return Error("INVALID_BASE64", "The file_base64 value is not valid base64.");
+            }
+
+            var result = await _svc.ImportFromExcelAsync(fileBytes, systemId, dryRun, "copilot", cancellationToken);
+            sw.Stop();
+
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    hardware_created = result.HardwareCreated,
+                    software_created = result.SoftwareCreated,
+                    rows_skipped = result.RowsSkipped,
+                    dry_run = result.DryRun,
+                    error_count = result.Errors.Count,
+                    errors = result.Errors.Select(e => new { row = e.RowNumber, worksheet = e.Worksheet, error = e.Error })
+                },
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            sw.Stop();
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_completeness
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_completeness — Run completeness check on a system's inventory.
+/// </summary>
+public class InventoryCompletenessTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryCompletenessTool(
+        IInventoryService svc,
+        ILogger<InventoryCompletenessTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_completeness";
+
+    public override string Description =>
+        "Run a completeness check on a system's inventory identifying missing fields, " +
+        "unmatched boundary resources, and hardware without software entries.";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var systemId = GetArg<string>(arguments, "system_id");
+            var result = await _svc.CheckCompletenessAsync(systemId, cancellationToken);
+            sw.Stop();
+
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    system_id = result.SystemId,
+                    total_items = result.TotalItems,
+                    hardware_count = result.HardwareCount,
+                    software_count = result.SoftwareCount,
+                    completeness_score = result.CompletenessScore,
+                    is_complete = result.IsComplete,
+                    items_with_missing_fields = result.ItemsWithMissingFields.Select(i => new
+                    {
+                        item_id = i.ItemId,
+                        item_name = i.ItemName,
+                        missing_fields = i.MissingFields
+                    }),
+                    unmatched_boundary_resources = result.UnmatchedBoundaryResources.Select(b => new
+                    {
+                        boundary_resource_id = b.BoundaryResourceId,
+                        resource_name = b.ResourceName,
+                        resource_type = b.ResourceType
+                    }),
+                    hardware_without_software = result.HardwareWithoutSoftware
+                },
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            sw.Stop();
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// inventory_auto_seed
+// ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// MCP tool: inventory_auto_seed — Create inventory items from boundary resources.
+/// </summary>
+public class InventoryAutoSeedTool : BaseTool
+{
+    private readonly IInventoryService _svc;
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public InventoryAutoSeedTool(
+        IInventoryService svc,
+        ILogger<InventoryAutoSeedTool> logger) : base(logger)
+    {
+        _svc = svc;
+    }
+
+    public override string Name => "inventory_auto_seed";
+
+    public override string Description =>
+        "Auto-seed inventory items from authorization boundary resources. " +
+        "Creates hardware items based on resource types — idempotent (skips already-linked resources).";
+
+    public override IReadOnlyDictionary<string, ToolParameter> Parameters => new Dictionary<string, ToolParameter>
+    {
+        ["system_id"] = new() { Name = "system_id", Description = "System GUID, name, or acronym", Type = "string", Required = true }
+    };
+
+    public override async Task<string> ExecuteCoreAsync(
+        Dictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var systemId = GetArg<string>(arguments, "system_id");
+
+        if (string.IsNullOrWhiteSpace(systemId))
+            return Error("INVALID_INPUT", "The 'system_id' parameter is required.");
+
+        try
+        {
+            var items = await _svc.AutoSeedFromBoundaryAsync(systemId, "copilot-user", cancellationToken);
+            sw.Stop();
+            return JsonSerializer.Serialize(new
+            {
+                status = "success",
+                data = new
+                {
+                    system_id = systemId,
+                    created_count = items.Count,
+                    items = items.Select(i => new
+                    {
+                        id = i.Id,
+                        item_name = i.ItemName,
+                        hardware_function = i.HardwareFunction?.ToString(),
+                        boundary_resource_id = i.BoundaryResourceId
+                    })
+                },
+                metadata = Meta(sw)
+            }, JsonOpts);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Error(ExtractErrorCode(ex), ex.Message);
+        }
+    }
+
+    private static string Error(string code, string message) =>
+        JsonSerializer.Serialize(new { status = "error", errorCode = code, message }, JsonOpts);
+
+    private object Meta(Stopwatch sw) => new
+    {
+        tool = Name,
+        duration_ms = sw.ElapsedMilliseconds,
+        timestamp = DateTime.UtcNow.ToString("O")
+    };
+
+    private static string ExtractErrorCode(InvalidOperationException ex) =>
+        ex.Message.Contains(':') ? ex.Message[..ex.Message.IndexOf(':')] : "OPERATION_FAILED";
+}

--- a/src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Ato.Copilot.Agents/Extensions/ServiceCollectionExtensions.cs
@@ -271,6 +271,9 @@ public static class ServiceCollectionExtensions
         // Narrative Governance service (Feature 024)
         services.AddSingleton<INarrativeGovernanceService, NarrativeGovernanceService>();
 
+        // ─── HW/SW Inventory service (Feature 025) ──────────────────────────
+        services.AddSingleton<IInventoryService, InventoryService>();
+
         // Narrative Governance tools (Feature 024)
         services.AddSingleton<NarrativeHistoryTool>();
         services.AddSingleton<NarrativeDiffTool>();
@@ -280,6 +283,17 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<BatchReviewNarrativesTool>();
         services.AddSingleton<NarrativeApprovalProgressTool>();
         services.AddSingleton<BatchSubmitNarrativesTool>();
+
+        // HW/SW Inventory tools (Feature 025)
+        services.AddSingleton<InventoryAddItemTool>();
+        services.AddSingleton<InventoryUpdateItemTool>();
+        services.AddSingleton<InventoryDecommissionItemTool>();
+        services.AddSingleton<InventoryListTool>();
+        services.AddSingleton<InventoryGetTool>();
+        services.AddSingleton<InventoryExportTool>();
+        services.AddSingleton<InventoryImportTool>();
+        services.AddSingleton<InventoryCompletenessTool>();
+        services.AddSingleton<InventoryAutoSeedTool>();
 
         // SSP Section Authoring tools (Feature 022)
         services.AddSingleton<WriteSspSectionTool>();
@@ -478,6 +492,17 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<BatchReviewNarrativesTool>());
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<NarrativeApprovalProgressTool>());
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<BatchSubmitNarrativesTool>());
+
+        // HW/SW Inventory tools as BaseTool (Feature 025)
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryAddItemTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryUpdateItemTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryDecommissionItemTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryListTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryGetTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryExportTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryImportTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryCompletenessTool>());
+        services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<InventoryAutoSeedTool>());
 
         // Assessment Artifact tools as BaseTool (Feature 015 - US7)
         services.AddSingleton<BaseTool>(sp => sp.GetRequiredService<AssessControlTool>());

--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -197,6 +197,11 @@ public class AtoCopilotContext : DbContext
     /// <summary>Review decisions recorded against narrative versions.</summary>
     public DbSet<NarrativeReview> NarrativeReviews => Set<NarrativeReview>();
 
+    // ─── HW/SW Inventory (Feature 025) ──────────────────────────────────────
+
+    /// <summary>Hardware and software inventory items for registered systems.</summary>
+    public DbSet<InventoryItem> InventoryItems => Set<InventoryItem>();
+
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -1690,6 +1695,64 @@ public class AtoCopilotContext : DbContext
                 .WithMany(e => e.Reviews)
                 .HasForeignKey(e => e.NarrativeVersionId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ─── Inventory Item (Feature 025) ────────────────────────────────────────
+        modelBuilder.Entity<InventoryItem>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(36);
+            entity.Property(e => e.RegisteredSystemId).HasMaxLength(36).IsRequired();
+            entity.Property(e => e.ItemName).HasMaxLength(300).IsRequired();
+            entity.Property(e => e.Type).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.Status).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.HardwareFunction).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.SoftwareFunction).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.Manufacturer).HasMaxLength(300);
+            entity.Property(e => e.Model).HasMaxLength(300);
+            entity.Property(e => e.SerialNumber).HasMaxLength(200);
+            entity.Property(e => e.IpAddress).HasMaxLength(45);
+            entity.Property(e => e.MacAddress).HasMaxLength(17);
+            entity.Property(e => e.Location).HasMaxLength(500);
+            entity.Property(e => e.Vendor).HasMaxLength(300);
+            entity.Property(e => e.Version).HasMaxLength(100);
+            entity.Property(e => e.PatchLevel).HasMaxLength(200);
+            entity.Property(e => e.LicenseType).HasMaxLength(200);
+            entity.Property(e => e.ParentHardwareId).HasMaxLength(36);
+            entity.Property(e => e.BoundaryResourceId).HasMaxLength(36);
+            entity.Property(e => e.DecommissionRationale).HasMaxLength(2000);
+            entity.Property(e => e.CreatedBy).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.ModifiedBy).HasMaxLength(200);
+
+            // FK → RegisteredSystem (required)
+            entity.HasOne(e => e.RegisteredSystem)
+                .WithMany()
+                .HasForeignKey(e => e.RegisteredSystemId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Self-referencing FK: SW → parent HW (optional)
+            entity.HasOne(e => e.ParentHardware)
+                .WithMany(e => e.InstalledSoftware)
+                .HasForeignKey(e => e.ParentHardwareId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // FK → AuthorizationBoundary (optional, for auto-seed idempotency)
+            entity.HasOne(e => e.BoundaryResource)
+                .WithMany()
+                .HasForeignKey(e => e.BoundaryResourceId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            // Indexes
+            entity.HasIndex(e => e.RegisteredSystemId)
+                .HasDatabaseName("IX_InventoryItem_SystemId");
+            entity.HasIndex(e => new { e.RegisteredSystemId, e.Type })
+                .HasDatabaseName("IX_InventoryItem_System_Type");
+            entity.HasIndex(e => new { e.RegisteredSystemId, e.IpAddress })
+                .IsUnique()
+                .HasFilter("[IpAddress] IS NOT NULL")
+                .HasDatabaseName("IX_InventoryItem_System_Ip");
+            entity.HasIndex(e => e.BoundaryResourceId)
+                .HasDatabaseName("IX_InventoryItem_BoundaryResourceId");
         });
     }
 

--- a/src/Ato.Copilot.Core/Interfaces/Compliance/IInventoryService.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Compliance/IInventoryService.cs
@@ -1,0 +1,126 @@
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Core.Interfaces.Compliance;
+
+/// <summary>
+/// Service for managing hardware and software inventory items within
+/// registered systems' authorization boundaries.
+/// </summary>
+public interface IInventoryService
+{
+    /// <summary>
+    /// Add a hardware or software inventory item to a system.
+    /// </summary>
+    /// <param name="registeredSystemId">Target system GUID.</param>
+    /// <param name="input">Item data.</param>
+    /// <param name="addedBy">User identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created inventory item.</returns>
+    Task<InventoryItem> AddItemAsync(
+        string registeredSystemId,
+        InventoryItemInput input,
+        string addedBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update fields on an existing inventory item. Null fields in input are not changed.
+    /// </summary>
+    /// <param name="itemId">Inventory item GUID.</param>
+    /// <param name="input">Updated fields.</param>
+    /// <param name="modifiedBy">User identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated inventory item.</returns>
+    Task<InventoryItem> UpdateItemAsync(
+        string itemId,
+        InventoryItemInput input,
+        string modifiedBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Soft-delete an inventory item. If the item is hardware with active software
+    /// children, all children are also decommissioned with the same rationale.
+    /// </summary>
+    /// <param name="itemId">Inventory item GUID.</param>
+    /// <param name="rationale">Reason for decommissioning.</param>
+    /// <param name="decommissionedBy">User identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decommissioned inventory item.</returns>
+    Task<InventoryItem> DecommissionItemAsync(
+        string itemId,
+        string rationale,
+        string decommissionedBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve a single inventory item by ID, including installed software (for HW items).
+    /// </summary>
+    /// <param name="itemId">Inventory item GUID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The inventory item with InstalledSoftware populated, or null.</returns>
+    Task<InventoryItem?> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// List and filter inventory items for a system with pagination.
+    /// </summary>
+    /// <param name="registeredSystemId">System GUID.</param>
+    /// <param name="options">Filter and pagination options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Filtered list of inventory items.</returns>
+    Task<IReadOnlyList<InventoryItem>> ListItemsAsync(
+        string registeredSystemId,
+        InventoryListOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Export inventory as eMASS-compatible Excel workbook bytes.
+    /// </summary>
+    /// <param name="registeredSystemId">System GUID.</param>
+    /// <param name="options">Export options (type filter, include decommissioned).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Excel workbook bytes (.xlsx).</returns>
+    Task<byte[]> ExportToExcelAsync(
+        string registeredSystemId,
+        InventoryExportOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Import inventory items from an eMASS-format Excel workbook.
+    /// </summary>
+    /// <param name="fileBytes">Excel workbook bytes.</param>
+    /// <param name="registeredSystemId">Target system GUID.</param>
+    /// <param name="dryRun">If true, validate only — don't persist.</param>
+    /// <param name="importedBy">User identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Import result with created/skipped counts and errors.</returns>
+    Task<InventoryImportResult> ImportFromExcelAsync(
+        byte[] fileBytes,
+        string registeredSystemId,
+        bool dryRun,
+        string importedBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run completeness check on a system's inventory.
+    /// </summary>
+    /// <param name="registeredSystemId">System GUID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Completeness result with issues and score.</returns>
+    Task<InventoryCompleteness> CheckCompletenessAsync(
+        string registeredSystemId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create inventory items from authorization boundary resources.
+    /// Only creates items for previously unmatched boundary resources (idempotent).
+    /// </summary>
+    /// <param name="registeredSystemId">System GUID.</param>
+    /// <param name="seededBy">User identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of newly created inventory items.</returns>
+    Task<IReadOnlyList<InventoryItem>> AutoSeedFromBoundaryAsync(
+        string registeredSystemId,
+        string seededBy,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ato.Copilot.Core/Models/Compliance/InventoryModels.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/InventoryModels.cs
@@ -1,0 +1,392 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+// ─── Enums ───────────────────────────────────────────────────────────────────
+
+/// <summary>Inventory item type discriminator.</summary>
+public enum InventoryItemType
+{
+    /// <summary>Physical or virtual hardware component.</summary>
+    Hardware,
+
+    /// <summary>Software product or application.</summary>
+    Software
+}
+
+/// <summary>Inventory item lifecycle status.</summary>
+public enum InventoryItemStatus
+{
+    /// <summary>Item is currently active and in use.</summary>
+    Active,
+
+    /// <summary>Item has been retired/removed from service.</summary>
+    Decommissioned
+}
+
+/// <summary>Function classification for hardware inventory items.</summary>
+public enum HardwareFunction
+{
+    /// <summary>Server (physical or virtual).</summary>
+    Server,
+
+    /// <summary>End-user workstation or laptop.</summary>
+    Workstation,
+
+    /// <summary>Network device (router, switch, firewall, load balancer).</summary>
+    NetworkDevice,
+
+    /// <summary>Storage device (SAN, NAS, disk array).</summary>
+    Storage,
+
+    /// <summary>Other hardware not classified above.</summary>
+    Other
+}
+
+/// <summary>Function classification for software inventory items.</summary>
+public enum SoftwareFunction
+{
+    /// <summary>Operating system.</summary>
+    OperatingSystem,
+
+    /// <summary>Database management system.</summary>
+    Database,
+
+    /// <summary>Middleware / application server.</summary>
+    Middleware,
+
+    /// <summary>Application software.</summary>
+    Application,
+
+    /// <summary>Security tool (AV, IDS, SIEM, etc.).</summary>
+    SecurityTool,
+
+    /// <summary>Other software not classified above.</summary>
+    Other
+}
+
+// ─── Entity ──────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// A single hardware or software component within a system's authorization boundary.
+/// Tracks eMASS-required fields for HW/SW inventory and SSP integration.
+/// </summary>
+public class InventoryItem
+{
+    /// <summary>Unique identifier (GUID string).</summary>
+    [Key]
+    [MaxLength(36)]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>FK to the registered system this item belongs to.</summary>
+    [Required]
+    [MaxLength(36)]
+    public string RegisteredSystemId { get; set; } = string.Empty;
+
+    /// <summary>Display name (e.g., "Web Server 01", "Red Hat Enterprise Linux 9").</summary>
+    [Required]
+    [MaxLength(300)]
+    public string ItemName { get; set; } = string.Empty;
+
+    /// <summary>Hardware or Software discriminator.</summary>
+    [Required]
+    public InventoryItemType Type { get; set; }
+
+    /// <summary>Function classification for hardware items. Null for software items.</summary>
+    public HardwareFunction? HardwareFunction { get; set; }
+
+    /// <summary>Function classification for software items. Null for hardware items.</summary>
+    public SoftwareFunction? SoftwareFunction { get; set; }
+
+    /// <summary>Hardware manufacturer (e.g., "Dell", "Cisco").</summary>
+    [MaxLength(300)]
+    public string? Manufacturer { get; set; }
+
+    /// <summary>Hardware model (e.g., "PowerEdge R740").</summary>
+    [MaxLength(300)]
+    public string? Model { get; set; }
+
+    /// <summary>Hardware serial number.</summary>
+    [MaxLength(200)]
+    public string? SerialNumber { get; set; }
+
+    /// <summary>IPv4 or IPv6 address (max length 45 covers full IPv6 notation).</summary>
+    [MaxLength(45)]
+    public string? IpAddress { get; set; }
+
+    /// <summary>MAC address in colon-separated hex (e.g., 00:1A:2B:3C:4D:5E).</summary>
+    [MaxLength(17)]
+    public string? MacAddress { get; set; }
+
+    /// <summary>Physical or logical location.</summary>
+    [MaxLength(500)]
+    public string? Location { get; set; }
+
+    /// <summary>Software vendor (e.g., "Microsoft", "Red Hat").</summary>
+    [MaxLength(300)]
+    public string? Vendor { get; set; }
+
+    /// <summary>Software version (e.g., "9.3", "2022 SP1").</summary>
+    [MaxLength(100)]
+    public string? Version { get; set; }
+
+    /// <summary>Current patch level or update identifier.</summary>
+    [MaxLength(200)]
+    public string? PatchLevel { get; set; }
+
+    /// <summary>License type (e.g., "Enterprise", "Open Source", "Government").</summary>
+    [MaxLength(200)]
+    public string? LicenseType { get; set; }
+
+    /// <summary>Lifecycle status (Active or Decommissioned).</summary>
+    [Required]
+    public InventoryItemStatus Status { get; set; } = InventoryItemStatus.Active;
+
+    /// <summary>
+    /// Optional FK to parent hardware item (for software installed on hardware).
+    /// Null for standalone/SaaS/PaaS software or hardware items.
+    /// </summary>
+    [MaxLength(36)]
+    public string? ParentHardwareId { get; set; }
+
+    /// <summary>
+    /// Optional FK to AuthorizationBoundary entry for auto-seed idempotency.
+    /// </summary>
+    [MaxLength(36)]
+    public string? BoundaryResourceId { get; set; }
+
+    /// <summary>UTC date when the item was decommissioned.</summary>
+    public DateTime? DecommissionDate { get; set; }
+
+    /// <summary>Reason for decommissioning.</summary>
+    [MaxLength(2000)]
+    public string? DecommissionRationale { get; set; }
+
+    /// <summary>User who created the item.</summary>
+    [Required]
+    [MaxLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    /// <summary>Creation timestamp (UTC).</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>User who last modified the item.</summary>
+    [MaxLength(200)]
+    public string? ModifiedBy { get; set; }
+
+    /// <summary>Last modification timestamp (UTC).</summary>
+    public DateTime? ModifiedAt { get; set; }
+
+    // ─── Navigation Properties ───────────────────────────────────────────────
+
+    /// <summary>The registered system this item belongs to.</summary>
+    public RegisteredSystem? RegisteredSystem { get; set; }
+
+    /// <summary>Parent hardware item (for software items installed on hardware).</summary>
+    public InventoryItem? ParentHardware { get; set; }
+
+    /// <summary>Software items installed on this hardware item (inverse of ParentHardware).</summary>
+    public ICollection<InventoryItem> InstalledSoftware { get; set; } = new List<InventoryItem>();
+
+    /// <summary>Optional linked authorization boundary resource.</summary>
+    public AuthorizationBoundary? BoundaryResource { get; set; }
+}
+
+// ─── Input Types ─────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Input DTO for adding or updating an inventory item.
+/// For updates, null fields are not changed.
+/// </summary>
+public class InventoryItemInput
+{
+    /// <summary>Display name.</summary>
+    public string? ItemName { get; set; }
+
+    /// <summary>Hardware or Software.</summary>
+    public InventoryItemType? Type { get; set; }
+
+    /// <summary>HW function classification.</summary>
+    public HardwareFunction? HardwareFunction { get; set; }
+
+    /// <summary>SW function classification.</summary>
+    public SoftwareFunction? SoftwareFunction { get; set; }
+
+    /// <summary>HW manufacturer.</summary>
+    public string? Manufacturer { get; set; }
+
+    /// <summary>HW model.</summary>
+    public string? Model { get; set; }
+
+    /// <summary>HW serial number.</summary>
+    public string? SerialNumber { get; set; }
+
+    /// <summary>IPv4/IPv6 address.</summary>
+    public string? IpAddress { get; set; }
+
+    /// <summary>MAC address.</summary>
+    public string? MacAddress { get; set; }
+
+    /// <summary>Physical/logical location.</summary>
+    public string? Location { get; set; }
+
+    /// <summary>SW vendor.</summary>
+    public string? Vendor { get; set; }
+
+    /// <summary>SW version.</summary>
+    public string? Version { get; set; }
+
+    /// <summary>SW patch level.</summary>
+    public string? PatchLevel { get; set; }
+
+    /// <summary>License type.</summary>
+    public string? LicenseType { get; set; }
+
+    /// <summary>Parent HW item ID (for SW).</summary>
+    public string? ParentHardwareId { get; set; }
+}
+
+/// <summary>
+/// Options for listing and filtering inventory items.
+/// </summary>
+public class InventoryListOptions
+{
+    /// <summary>Filter by item type (Hardware or Software).</summary>
+    public InventoryItemType? Type { get; set; }
+
+    /// <summary>Filter by function name (matches HardwareFunction or SoftwareFunction enum name).</summary>
+    public string? Function { get; set; }
+
+    /// <summary>Filter by vendor/manufacturer (contains match).</summary>
+    public string? Vendor { get; set; }
+
+    /// <summary>Filter by status. Default is Active. Null returns all.</summary>
+    public InventoryItemStatus? Status { get; set; } = InventoryItemStatus.Active;
+
+    /// <summary>Free-text search on item name (contains match).</summary>
+    public string? SearchText { get; set; }
+
+    /// <summary>Results per page (default 50).</summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>Page number (1-based, default 1).</summary>
+    public int PageNumber { get; set; } = 1;
+}
+
+/// <summary>
+/// Options for exporting inventory to eMASS-compatible Excel.
+/// </summary>
+public class InventoryExportOptions
+{
+    /// <summary>Export type: "hardware", "software", or "all" (default).</summary>
+    public string ExportType { get; set; } = "all";
+
+    /// <summary>Include decommissioned items (default false).</summary>
+    public bool IncludeDecommissioned { get; set; }
+}
+
+// ─── Computed Types (Not Persisted) ──────────────────────────────────────────
+
+/// <summary>
+/// Result of a completeness check on a system's inventory.
+/// Not stored in the database — computed on demand.
+/// </summary>
+public class InventoryCompleteness
+{
+    /// <summary>The system being checked.</summary>
+    public string SystemId { get; set; } = string.Empty;
+
+    /// <summary>Total active inventory items.</summary>
+    public int TotalItems { get; set; }
+
+    /// <summary>Total active hardware items.</summary>
+    public int HardwareCount { get; set; }
+
+    /// <summary>Total active software items.</summary>
+    public int SoftwareCount { get; set; }
+
+    /// <summary>Items missing required fields per FR-018.</summary>
+    public IReadOnlyList<InventoryIssue> ItemsWithMissingFields { get; set; } = [];
+
+    /// <summary>Boundary resources with no corresponding inventory item.</summary>
+    public IReadOnlyList<UnmatchedBoundaryResource> UnmatchedBoundaryResources { get; set; } = [];
+
+    /// <summary>IDs of hardware items with no installed software children.</summary>
+    public IReadOnlyList<string> HardwareWithoutSoftware { get; set; } = [];
+
+    /// <summary>Percentage: (items without issues) / total items × 100.</summary>
+    public double CompletenessScore { get; set; }
+
+    /// <summary>True if no issues found across all three dimensions.</summary>
+    public bool IsComplete { get; set; }
+}
+
+/// <summary>
+/// An inventory item that has missing required fields.
+/// </summary>
+public class InventoryIssue
+{
+    /// <summary>The inventory item ID.</summary>
+    public string ItemId { get; set; } = string.Empty;
+
+    /// <summary>The inventory item name.</summary>
+    public string ItemName { get; set; } = string.Empty;
+
+    /// <summary>List of field names that are missing.</summary>
+    public IReadOnlyList<string> MissingFields { get; set; } = [];
+}
+
+/// <summary>
+/// A boundary resource with no corresponding inventory item.
+/// </summary>
+public class UnmatchedBoundaryResource
+{
+    /// <summary>The AuthorizationBoundary.Id.</summary>
+    public string BoundaryResourceId { get; set; } = string.Empty;
+
+    /// <summary>The boundary resource display name.</summary>
+    public string? ResourceName { get; set; }
+
+    /// <summary>The Azure resource type string.</summary>
+    public string ResourceType { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Result of an Excel import operation.
+/// </summary>
+public class InventoryImportResult
+{
+    /// <summary>Target system ID.</summary>
+    public string SystemId { get; set; } = string.Empty;
+
+    /// <summary>Whether this was a dry-run (no data persisted).</summary>
+    public bool DryRun { get; set; }
+
+    /// <summary>Number of hardware items created.</summary>
+    public int HardwareCreated { get; set; }
+
+    /// <summary>Number of software items created.</summary>
+    public int SoftwareCreated { get; set; }
+
+    /// <summary>Number of rows skipped due to errors.</summary>
+    public int RowsSkipped { get; set; }
+
+    /// <summary>Per-row error details.</summary>
+    public IReadOnlyList<ImportRowError> Errors { get; set; } = [];
+}
+
+/// <summary>
+/// Error detail for a single row during Excel import.
+/// </summary>
+public class ImportRowError
+{
+    /// <summary>"Hardware" or "Software" worksheet name.</summary>
+    public string Worksheet { get; set; } = string.Empty;
+
+    /// <summary>1-based row number in the worksheet.</summary>
+    public int RowNumber { get; set; }
+
+    /// <summary>Human-readable error description.</summary>
+    public string Error { get; set; } = string.Empty;
+}

--- a/tests/Ato.Copilot.Tests.Integration/Tools/InventoryIntegrationTests.cs
+++ b/tests/Ato.Copilot.Tests.Integration/Tools/InventoryIntegrationTests.cs
@@ -1,0 +1,375 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Agents.Compliance.Tools;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Tests.Integration.Tools;
+
+/// <summary>
+/// Integration tests for Feature 025 — HW/SW Inventory.
+/// T028: Uses real InventoryService + in-memory EF Core.
+/// Tests all 9 MCP tools (add, update, decommission, list, get, export, import,
+/// completeness, auto_seed) covering happy-path and at least one error-path per tool.
+/// </summary>
+public class InventoryIntegrationTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly InventoryAddItemTool _addTool;
+    private readonly InventoryUpdateItemTool _updateTool;
+    private readonly InventoryDecommissionItemTool _decommissionTool;
+    private readonly InventoryListTool _listTool;
+    private readonly InventoryGetTool _getTool;
+    private readonly InventoryExportTool _exportTool;
+    private readonly InventoryImportTool _importTool;
+    private readonly InventoryCompletenessTool _completenessTool;
+    private readonly InventoryAutoSeedTool _autoSeedTool;
+
+    public InventoryIntegrationTests()
+    {
+        var dbName = $"InventoryIntTest_{Guid.NewGuid()}";
+        var services = new ServiceCollection();
+        services.AddDbContext<AtoCopilotContext>(opts =>
+            opts.UseInMemoryDatabase(dbName), ServiceLifetime.Scoped);
+        services.AddLogging();
+
+        _serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var inventorySvc = new InventoryService(scopeFactory, Mock.Of<ILogger<InventoryService>>());
+
+        // Seed test system
+        using var initScope = _serviceProvider.CreateScope();
+        var ctx = initScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        ctx.Database.EnsureCreated();
+        ctx.RegisteredSystems.Add(new RegisteredSystem
+        {
+            Id = "sys-1",
+            Name = "Test System",
+            Acronym = "TSYS",
+            CurrentRmfStep = RmfPhase.Implement
+        });
+        ctx.SaveChanges();
+
+        _addTool = new InventoryAddItemTool(inventorySvc, Mock.Of<ILogger<InventoryAddItemTool>>());
+        _updateTool = new InventoryUpdateItemTool(inventorySvc, Mock.Of<ILogger<InventoryUpdateItemTool>>());
+        _decommissionTool = new InventoryDecommissionItemTool(inventorySvc, Mock.Of<ILogger<InventoryDecommissionItemTool>>());
+        _listTool = new InventoryListTool(inventorySvc, Mock.Of<ILogger<InventoryListTool>>());
+        _getTool = new InventoryGetTool(inventorySvc, Mock.Of<ILogger<InventoryGetTool>>());
+        _exportTool = new InventoryExportTool(inventorySvc, Mock.Of<ILogger<InventoryExportTool>>());
+        _importTool = new InventoryImportTool(inventorySvc, Mock.Of<ILogger<InventoryImportTool>>());
+        _completenessTool = new InventoryCompletenessTool(inventorySvc, Mock.Of<ILogger<InventoryCompletenessTool>>());
+        _autoSeedTool = new InventoryAutoSeedTool(inventorySvc, Mock.Of<ILogger<InventoryAutoSeedTool>>());
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private static JsonElement ParseSuccess(string json)
+    {
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        return doc.RootElement.GetProperty("data");
+    }
+
+    private static void AssertError(string json, string? expectedCode = null)
+    {
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("error");
+        if (expectedCode != null)
+            doc.RootElement.GetProperty("errorCode").GetString().Should().Be(expectedCode);
+    }
+
+    // =========================================================================
+    // End-to-end: Add HW → Add SW → Update → List → Get → Export → Decommission
+    // =========================================================================
+
+    [Fact]
+    public async Task FullWorkflow_AddListGetExportDecommission()
+    {
+        // 1. Add hardware
+        var addHwResult = await _addTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "web-server-01",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "Dell",
+            ["ip_address"] = "10.0.0.1"
+        });
+        var hwData = ParseSuccess(addHwResult);
+        var hwId = hwData.GetProperty("id").GetString()!;
+
+        // 2. Add software installed on the hardware
+        var addSwResult = await _addTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "Apache HTTP Server",
+            ["type"] = "software",
+            ["function"] = "Application",
+            ["vendor"] = "Apache Foundation",
+            ["version"] = "2.4.57",
+            ["parent_hardware_id"] = hwId
+        });
+        var swData = ParseSuccess(addSwResult);
+        var swId = swData.GetProperty("id").GetString()!;
+
+        // 3. Update hardware location
+        var updateResult = await _updateTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = hwId,
+            ["location"] = "DC-East Rack A-12"
+        });
+        var updateData = ParseSuccess(updateResult);
+        updateData.GetProperty("item_name").GetString().Should().Be("web-server-01");
+
+        // 4. List items
+        var listResult = await _listTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+        var listData = ParseSuccess(listResult);
+        listData.GetProperty("count").GetInt32().Should().Be(2);
+
+        // 5. Get item with installed software
+        var getResult = await _getTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = hwId
+        });
+        var getData = ParseSuccess(getResult);
+        getData.GetProperty("item_name").GetString().Should().Be("web-server-01");
+
+        // 6. Export to Excel
+        var exportResult = await _exportTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+        var exportData = ParseSuccess(exportResult);
+        exportData.GetProperty("file_base64").GetString().Should().NotBeEmpty();
+
+        // 7. Decommission hardware (cascades to software)
+        var decomResult = await _decommissionTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = hwId,
+            ["rationale"] = "End of life"
+        });
+        ParseSuccess(decomResult);
+    }
+
+    // =========================================================================
+    // Error paths
+    // =========================================================================
+
+    [Fact]
+    public async Task AddItem_SystemNotFound_ReturnsError()
+    {
+        var result = await _addTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "nonexistent",
+            ["item_name"] = "test",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "Dell",
+            ["ip_address"] = "10.0.0.1"
+        });
+
+        AssertError(result, "SYSTEM_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task UpdateItem_NotFound_ReturnsError()
+    {
+        var result = await _updateTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "nonexistent",
+            ["location"] = "somewhere"
+        });
+
+        AssertError(result, "ITEM_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task DecommissionItem_NotFound_ReturnsError()
+    {
+        var result = await _decommissionTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "nonexistent",
+            ["rationale"] = "Testing"
+        });
+
+        AssertError(result, "ITEM_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task GetItem_NotFound_ReturnsError()
+    {
+        var result = await _getTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "nonexistent"
+        });
+
+        AssertError(result, "ITEM_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task ExportItem_NoData_ReturnsError()
+    {
+        var result = await _exportTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        AssertError(result, "NO_INVENTORY_DATA");
+    }
+
+    [Fact]
+    public async Task ImportItem_InvalidBase64_ReturnsError()
+    {
+        var result = await _importTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_base64"] = "totally-not-base64!!!"
+        });
+
+        AssertError(result, "INVALID_BASE64");
+    }
+
+    [Fact]
+    public async Task Completeness_SystemNotFound_ReturnsError()
+    {
+        var result = await _completenessTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "nonexistent"
+        });
+
+        AssertError(result, "SYSTEM_NOT_FOUND");
+    }
+
+    // =========================================================================
+    // Auto-seed with boundary resources
+    // =========================================================================
+
+    [Fact]
+    public async Task AutoSeed_CreatesFromBoundaryResources()
+    {
+        // Seed boundary resources
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+            ctx.AuthorizationBoundaries.Add(new AuthorizationBoundary
+            {
+                RegisteredSystemId = "sys-1",
+                ResourceId = "/sub/rg/vm1",
+                ResourceType = "Microsoft.Compute/virtualMachines",
+                ResourceName = "web-vm",
+                IsInBoundary = true,
+                AddedBy = "test"
+            });
+            ctx.AuthorizationBoundaries.Add(new AuthorizationBoundary
+            {
+                RegisteredSystemId = "sys-1",
+                ResourceId = "/sub/rg/nsg1",
+                ResourceType = "Microsoft.Network/networkSecurityGroups",
+                ResourceName = "web-nsg",
+                IsInBoundary = true,
+                AddedBy = "test"
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var result = await _autoSeedTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var data = ParseSuccess(result);
+        data.GetProperty("created_count").GetInt32().Should().Be(2);
+
+        // Verify idempotent re-run
+        var result2 = await _autoSeedTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+        var data2 = ParseSuccess(result2);
+        data2.GetProperty("created_count").GetInt32().Should().Be(0);
+    }
+
+    // =========================================================================
+    // Completeness check happy path
+    // =========================================================================
+
+    [Fact]
+    public async Task Completeness_DetectsHardwareWithoutSoftware()
+    {
+        // Add a hardware item with no software
+        var addResult = await _addTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "standalone-server",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "HP",
+            ["ip_address"] = "10.0.0.99"
+        });
+        ParseSuccess(addResult);
+
+        var result = await _completenessTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var data = ParseSuccess(result);
+        data.GetProperty("is_complete").GetBoolean().Should().BeFalse();
+        data.GetProperty("hardware_without_software").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    // =========================================================================
+    // Import after export round-trip
+    // =========================================================================
+
+    [Fact]
+    public async Task ImportExport_RoundTrip()
+    {
+        // Add items
+        var addResult = await _addTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "round-trip-server",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "Dell",
+            ["ip_address"] = "10.0.0.50"
+        });
+        ParseSuccess(addResult);
+
+        // Export
+        var exportResult = await _exportTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+        var exportData = ParseSuccess(exportResult);
+        var base64 = exportData.GetProperty("file_base64").GetString()!;
+
+        // Clear and re-import
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+            ctx.InventoryItems.RemoveRange(ctx.InventoryItems);
+            await ctx.SaveChangesAsync();
+        }
+
+        var importResult = await _importTool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_base64"] = base64
+        });
+
+        var importData = ParseSuccess(importResult);
+        importData.GetProperty("hardware_created").GetInt32().Should().BeGreaterThan(0);
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Services/InventoryServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/InventoryServiceTests.cs
@@ -1,0 +1,555 @@
+using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for InventoryService — Feature 025 HW/SW Inventory.
+/// T026: Covers AddItemAsync, UpdateItemAsync, DecommissionItemAsync, GetItemAsync,
+///       AutoSeedFromBoundaryAsync, ListItemsAsync, ExportToExcelAsync, ImportFromExcelAsync,
+///       CheckCompletenessAsync.
+/// </summary>
+public class InventoryServiceTests : IDisposable
+{
+    private const string TestSystemId = "sys-001";
+    private const string TestSystemName = "Test System";
+
+    private readonly ServiceProvider _serviceProvider;
+    private readonly InventoryService _service;
+
+    private readonly RegisteredSystem _testSystem = new()
+    {
+        Id = TestSystemId,
+        Name = TestSystemName,
+        Acronym = "TSYS",
+        CurrentRmfStep = RmfPhase.Implement
+    };
+
+    public InventoryServiceTests()
+    {
+        var services = new ServiceCollection();
+        var dbName = $"InventoryServiceTests_{Guid.NewGuid()}";
+        services.AddDbContext<AtoCopilotContext>(options =>
+            options.UseInMemoryDatabase(dbName));
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var initScope = _serviceProvider.CreateScope();
+        var ctx = initScope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        ctx.Database.EnsureCreated();
+        ctx.RegisteredSystems.Add(_testSystem);
+        ctx.SaveChanges();
+
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        _service = new InventoryService(scopeFactory, NullLogger<InventoryService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private AtoCopilotContext GetContext()
+    {
+        var scope = _serviceProvider.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+    }
+
+    private InventoryItemInput MakeHardwareInput(
+        string name = "web-server-01",
+        string? manufacturer = "Dell",
+        HardwareFunction function = HardwareFunction.Server,
+        string? ip = "10.0.0.1") => new()
+        {
+            ItemName = name,
+            Type = InventoryItemType.Hardware,
+            HardwareFunction = function,
+            Manufacturer = manufacturer,
+            IpAddress = ip
+        };
+
+    private InventoryItemInput MakeSoftwareInput(
+        string name = "Apache HTTP Server",
+        string? vendor = "Apache Foundation",
+        string? version = "2.4.57",
+        SoftwareFunction function = SoftwareFunction.Application,
+        string? parentId = null) => new()
+        {
+            ItemName = name,
+            Type = InventoryItemType.Software,
+            SoftwareFunction = function,
+            Vendor = vendor,
+            Version = version,
+            ParentHardwareId = parentId
+        };
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // AddItemAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task AddItemAsync_ValidHardware_CreatesItem()
+    {
+        var input = MakeHardwareInput();
+        var item = await _service.AddItemAsync(TestSystemId, input, "tester");
+
+        item.Should().NotBeNull();
+        item.ItemName.Should().Be("web-server-01");
+        item.Type.Should().Be(InventoryItemType.Hardware);
+        item.HardwareFunction.Should().Be(HardwareFunction.Server);
+        item.Status.Should().Be(InventoryItemStatus.Active);
+        item.CreatedBy.Should().Be("tester");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_ValidSoftware_CreatesItem()
+    {
+        var input = MakeSoftwareInput();
+        var item = await _service.AddItemAsync(TestSystemId, input, "tester");
+
+        item.Should().NotBeNull();
+        item.Type.Should().Be(InventoryItemType.Software);
+        item.Vendor.Should().Be("Apache Foundation");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_ServerWithoutIp_Throws()
+    {
+        var input = MakeHardwareInput(ip: null);
+
+        var act = async () => await _service.AddItemAsync(TestSystemId, input, "tester");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*VALIDATION_FAILED*ip_address*");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_DuplicateIp_Throws()
+    {
+        var input1 = MakeHardwareInput(name: "server-1", ip: "10.0.0.1");
+        await _service.AddItemAsync(TestSystemId, input1, "tester");
+
+        var input2 = MakeHardwareInput(name: "server-2", ip: "10.0.0.1");
+        var act = async () => await _service.AddItemAsync(TestSystemId, input2, "tester");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*DUPLICATE_IP*");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_SoftwareWithMissingParent_Throws()
+    {
+        var input = MakeSoftwareInput(parentId: "nonexistent");
+
+        var act = async () => await _service.AddItemAsync(TestSystemId, input, "tester");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*PARENT*");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_SystemNotFound_Throws()
+    {
+        var input = MakeHardwareInput();
+
+        var act = async () => await _service.AddItemAsync("bad-id", input, "tester");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*SYSTEM_NOT_FOUND*");
+    }
+
+    [Fact]
+    public async Task AddItemAsync_WorkstationWithoutIp_Succeeds()
+    {
+        var input = MakeHardwareInput(function: HardwareFunction.Workstation, ip: null);
+
+        var item = await _service.AddItemAsync(TestSystemId, input, "tester");
+
+        item.Should().NotBeNull();
+        item.HardwareFunction.Should().Be(HardwareFunction.Workstation);
+        item.IpAddress.Should().BeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // UpdateItemAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task UpdateItemAsync_PartialUpdate_OnlyChangesProvidedFields()
+    {
+        var created = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "tester");
+
+        var updates = new InventoryItemInput { Location = "Rack A-12" };
+        var updated = await _service.UpdateItemAsync(created.Id, updates, "updater");
+
+        updated.Location.Should().Be("Rack A-12");
+        updated.ItemName.Should().Be("web-server-01"); // unchanged
+        updated.ModifiedBy.Should().Be("updater");
+        updated.ModifiedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateItemAsync_DuplicateIp_Throws()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(name: "s1", ip: "10.0.0.1"), "t");
+        var s2 = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(name: "s2", ip: "10.0.0.2"), "t");
+
+        var updates = new InventoryItemInput { IpAddress = "10.0.0.1" };
+        var act = async () => await _service.UpdateItemAsync(s2.Id, updates, "t");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*DUPLICATE_IP*");
+    }
+
+    [Fact]
+    public async Task UpdateItemAsync_NotFound_Throws()
+    {
+        var act = async () => await _service.UpdateItemAsync("bad-id", new InventoryItemInput(), "t");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*ITEM_NOT_FOUND*");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // DecommissionItemAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task DecommissionItemAsync_SetsStatusAndCascadesToChildSoftware()
+    {
+        var hw = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "tester");
+        var sw = await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(parentId: hw.Id), "tester");
+
+        var result = await _service.DecommissionItemAsync(hw.Id, "End of life", "decom-user");
+
+        result.Status.Should().Be(InventoryItemStatus.Decommissioned);
+
+        // Child SW also decommissioned
+        var childSw = await _service.GetItemAsync(sw.Id);
+        childSw!.Status.Should().Be(InventoryItemStatus.Decommissioned);
+    }
+
+    [Fact]
+    public async Task DecommissionItemAsync_AlreadyDecommissioned_Throws()
+    {
+        var hw = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "tester");
+        await _service.DecommissionItemAsync(hw.Id, "EOL", "d");
+
+        var act = async () => await _service.DecommissionItemAsync(hw.Id, "EOL", "d");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*ALREADY_DECOMMISSIONED*");
+    }
+
+    [Fact]
+    public async Task DecommissionItemAsync_NotFound_Throws()
+    {
+        var act = async () => await _service.DecommissionItemAsync("bad-id", "EOL", "d");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*ITEM_NOT_FOUND*");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // GetItemAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetItemAsync_ExistingItem_ReturnsWithInstalledSoftware()
+    {
+        var hw = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "tester");
+        await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(parentId: hw.Id), "tester");
+
+        var result = await _service.GetItemAsync(hw.Id);
+
+        result.Should().NotBeNull();
+        result!.InstalledSoftware.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetItemAsync_NotFound_ReturnsNull()
+    {
+        var result = await _service.GetItemAsync("nonexistent");
+
+        result.Should().BeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ListItemsAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ListItemsAsync_FiltersByType()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+        await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(), "t");
+
+        var hwList = await _service.ListItemsAsync(TestSystemId,
+            new InventoryListOptions { Type = InventoryItemType.Hardware });
+
+        hwList.Should().HaveCount(1);
+        hwList[0].Type.Should().Be(InventoryItemType.Hardware);
+    }
+
+    [Fact]
+    public async Task ListItemsAsync_Pagination()
+    {
+        for (var i = 0; i < 5; i++)
+            await _service.AddItemAsync(TestSystemId, MakeHardwareInput(name: $"server-{i}", ip: $"10.0.0.{i}"), "t");
+
+        var page = await _service.ListItemsAsync(TestSystemId,
+            new InventoryListOptions { PageSize = 2, PageNumber = 2 });
+
+        page.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListItemsAsync_SearchText()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(name: "web-server-01"), "t");
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(name: "db-server-01", ip: "10.0.0.2"), "t");
+
+        var results = await _service.ListItemsAsync(TestSystemId,
+            new InventoryListOptions { SearchText = "web" });
+
+        results.Should().HaveCount(1);
+        results[0].ItemName.Should().Contain("web");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // AutoSeedFromBoundaryAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task AutoSeedFromBoundaryAsync_CreateFromBoundaryResources()
+    {
+        // Seed boundary resources
+        using (var ctx = GetContext())
+        {
+            ctx.AuthorizationBoundaries.Add(new AuthorizationBoundary
+            {
+                RegisteredSystemId = TestSystemId,
+                ResourceId = "/sub/rg/vm1",
+                ResourceType = "Microsoft.Compute/virtualMachines",
+                ResourceName = "web-vm",
+                IsInBoundary = true,
+                AddedBy = "test"
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var items = await _service.AutoSeedFromBoundaryAsync(TestSystemId, "seeder");
+
+        items.Should().HaveCount(1);
+        items[0].ItemName.Should().Be("web-vm");
+        items[0].HardwareFunction.Should().Be(HardwareFunction.Server);
+    }
+
+    [Fact]
+    public async Task AutoSeedFromBoundaryAsync_Idempotent()
+    {
+        using (var ctx = GetContext())
+        {
+            ctx.AuthorizationBoundaries.Add(new AuthorizationBoundary
+            {
+                Id = "br-1",
+                RegisteredSystemId = TestSystemId,
+                ResourceId = "/sub/rg/vm1",
+                ResourceType = "Microsoft.Compute/virtualMachines",
+                ResourceName = "web-vm",
+                IsInBoundary = true,
+                AddedBy = "test"
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var first = await _service.AutoSeedFromBoundaryAsync(TestSystemId, "seeder");
+        var second = await _service.AutoSeedFromBoundaryAsync(TestSystemId, "seeder");
+
+        first.Should().HaveCount(1);
+        second.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task AutoSeedFromBoundaryAsync_NoBoundary_Throws()
+    {
+        var act = async () => await _service.AutoSeedFromBoundaryAsync(TestSystemId, "seeder");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*NO_BOUNDARY_DATA*");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ExportToExcelAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ExportToExcelAsync_ReturnsWorkbookBytes()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+        await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(), "t");
+
+        var options = new InventoryExportOptions { ExportType = "all" };
+        var bytes = await _service.ExportToExcelAsync(TestSystemId, options);
+
+        bytes.Should().NotBeEmpty();
+        // Verify it's a valid XLSX (starts with PK zip header)
+        bytes[0].Should().Be(0x50);
+        bytes[1].Should().Be(0x4B);
+    }
+
+    [Fact]
+    public async Task ExportToExcelAsync_SystemNotFound_Throws()
+    {
+        var act = async () => await _service.ExportToExcelAsync("bad-id", new InventoryExportOptions());
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*SYSTEM_NOT_FOUND*");
+    }
+
+    [Fact]
+    public async Task ExportToExcelAsync_NoItems_Throws()
+    {
+        var act = async () => await _service.ExportToExcelAsync(TestSystemId, new InventoryExportOptions());
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*NO_INVENTORY_DATA*");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ImportFromExcelAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ImportFromExcelAsync_ValidWorkbook_ImportsItems()
+    {
+        // Generate a workbook to import
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+        await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(), "t");
+        var exportBytes = await _service.ExportToExcelAsync(TestSystemId, new InventoryExportOptions { ExportType = "all" });
+
+        // Clear inventory
+        using (var ctx = GetContext())
+        {
+            ctx.InventoryItems.RemoveRange(ctx.InventoryItems);
+            await ctx.SaveChangesAsync();
+        }
+
+        var result = await _service.ImportFromExcelAsync(exportBytes, TestSystemId, false, "importer");
+
+        result.HardwareCreated.Should().BeGreaterThan(0);
+        result.DryRun.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ImportFromExcelAsync_DryRun_DoesNotPersist()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+        var exportBytes = await _service.ExportToExcelAsync(TestSystemId, new InventoryExportOptions { ExportType = "hardware" });
+
+        using (var ctx = GetContext())
+        {
+            ctx.InventoryItems.RemoveRange(ctx.InventoryItems);
+            await ctx.SaveChangesAsync();
+        }
+
+        var result = await _service.ImportFromExcelAsync(exportBytes, TestSystemId, true, "importer");
+
+        result.HardwareCreated.Should().BeGreaterThan(0);
+        result.DryRun.Should().BeTrue();
+
+        using (var ctx = GetContext())
+        {
+            var count = await ctx.InventoryItems.CountAsync();
+            count.Should().Be(0);
+        }
+    }
+
+    [Fact]
+    public async Task ImportFromExcelAsync_SystemNotFound_Throws()
+    {
+        var act = async () => await _service.ImportFromExcelAsync(new byte[] { 0 }, "bad-id", false, "t");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*SYSTEM_NOT_FOUND*");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // CheckCompletenessAsync
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task CheckCompletenessAsync_CompleteInventory_ReturnsIsComplete()
+    {
+        var hw = await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+        await _service.AddItemAsync(TestSystemId, MakeSoftwareInput(parentId: hw.Id), "t");
+
+        var result = await _service.CheckCompletenessAsync(TestSystemId);
+
+        result.TotalItems.Should().Be(2);
+        result.HardwareCount.Should().Be(1);
+        result.SoftwareCount.Should().Be(1);
+        result.CompletenessScore.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task CheckCompletenessAsync_HardwareWithoutSoftware_ReportsIssue()
+    {
+        await _service.AddItemAsync(TestSystemId, MakeHardwareInput(), "t");
+
+        var result = await _service.CheckCompletenessAsync(TestSystemId);
+
+        result.HardwareWithoutSoftware.Should().HaveCount(1);
+        result.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckCompletenessAsync_UnmatchedBoundary_ReportsIssue()
+    {
+        using (var ctx = GetContext())
+        {
+            ctx.AuthorizationBoundaries.Add(new AuthorizationBoundary
+            {
+                RegisteredSystemId = TestSystemId,
+                ResourceId = "/sub/rg/vm1",
+                ResourceType = "Microsoft.Compute/virtualMachines",
+                ResourceName = "unmatched-vm",
+                IsInBoundary = true,
+                AddedBy = "test"
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var result = await _service.CheckCompletenessAsync(TestSystemId);
+
+        result.UnmatchedBoundaryResources.Should().HaveCount(1);
+        result.UnmatchedBoundaryResources[0].ResourceName.Should().Be("unmatched-vm");
+    }
+
+    [Fact]
+    public async Task CheckCompletenessAsync_SystemNotFound_Throws()
+    {
+        var act = async () => await _service.CheckCompletenessAsync("bad-id");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*SYSTEM_NOT_FOUND*");
+    }
+
+    [Fact]
+    public async Task CheckCompletenessAsync_EmptyInventory_Returns100Percent()
+    {
+        var result = await _service.CheckCompletenessAsync(TestSystemId);
+
+        result.TotalItems.Should().Be(0);
+        result.CompletenessScore.Should().Be(100.0);
+        result.IsComplete.Should().BeTrue();
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Services/SspServiceSectionTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/SspServiceSectionTests.cs
@@ -752,7 +752,7 @@ public class SspServiceSectionTests : IDisposable
             RegisteredSystemId = "sys-1", SectionTitle = "Authorization Boundary"
         };
 
-        var content = SspService.GenerateSection11Content(boundaries, section);
+        var content = SspService.GenerateSection11Content(boundaries, new List<InventoryItem>(), section);
 
         content.Should().Contain("### Boundary Description");
         content.Should().Contain("all Azure resources in RG-Web");
@@ -765,7 +765,7 @@ public class SspServiceSectionTests : IDisposable
     [Fact]
     public void Section11_NoBoundaries_ReturnsPlaceholder()
     {
-        var content = SspService.GenerateSection11Content([], null);
+        var content = SspService.GenerateSection11Content([], new List<InventoryItem>(), null);
 
         content.Should().Contain("not been defined");
     }

--- a/tests/Ato.Copilot.Tests.Unit/Tools/InventoryToolTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Tools/InventoryToolTests.cs
@@ -1,0 +1,354 @@
+using System.Text.Json;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Agents.Compliance.Tools;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Tests.Unit.Tools;
+
+/// <summary>
+/// Unit tests for Feature 025 — Inventory Tools.
+/// T027: Verifies parameter parsing, service delegation, response envelope format,
+///       and error propagation for all 9 MCP tools.
+/// </summary>
+public class InventoryToolTests
+{
+    private readonly Mock<IInventoryService> _svcMock = new();
+
+    private static readonly InventoryItem SampleHwItem = new()
+    {
+        Id = "hw-1",
+        RegisteredSystemId = "sys-1",
+        ItemName = "web-server-01",
+        Type = InventoryItemType.Hardware,
+        HardwareFunction = HardwareFunction.Server,
+        Manufacturer = "Dell",
+        IpAddress = "10.0.0.1",
+        Status = InventoryItemStatus.Active,
+        CreatedBy = "tester"
+    };
+
+    private static readonly InventoryItem SampleSwItem = new()
+    {
+        Id = "sw-1",
+        RegisteredSystemId = "sys-1",
+        ItemName = "Apache HTTP Server",
+        Type = InventoryItemType.Software,
+        Vendor = "Apache",
+        Version = "2.4.57",
+        Status = InventoryItemStatus.Active,
+        CreatedBy = "tester"
+    };
+
+    // =========================================================================
+    // inventory_add_item
+    // =========================================================================
+
+    [Fact]
+    public async Task AddItem_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.AddItemAsync(It.IsAny<string>(), It.IsAny<InventoryItemInput>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SampleHwItem);
+
+        var tool = new InventoryAddItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryAddItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "web-server-01",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "Dell",
+            ["ip_address"] = "10.0.0.1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("id").GetString().Should().Be("hw-1");
+    }
+
+    [Fact]
+    public async Task AddItem_MissingSystemId_ReturnsError()
+    {
+        var tool = new InventoryAddItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryAddItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_name"] = "test"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_INPUT");
+    }
+
+    [Fact]
+    public async Task AddItem_ServiceError_ReturnsErrorCode()
+    {
+        _svcMock
+            .Setup(s => s.AddItemAsync(It.IsAny<string>(), It.IsAny<InventoryItemInput>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DUPLICATE_IP: IP already in use"));
+
+        var tool = new InventoryAddItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryAddItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["item_name"] = "s1",
+            ["type"] = "hardware",
+            ["function"] = "Server",
+            ["manufacturer"] = "Dell",
+            ["ip_address"] = "10.0.0.1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("DUPLICATE_IP");
+    }
+
+    // =========================================================================
+    // inventory_update_item
+    // =========================================================================
+
+    [Fact]
+    public async Task UpdateItem_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.UpdateItemAsync(It.IsAny<string>(), It.IsAny<InventoryItemInput>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SampleHwItem);
+
+        var tool = new InventoryUpdateItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryUpdateItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "hw-1",
+            ["location"] = "Rack A"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    [Fact]
+    public async Task UpdateItem_MissingItemId_ReturnsError()
+    {
+        var tool = new InventoryUpdateItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryUpdateItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["location"] = "Rack A"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+    }
+
+    // =========================================================================
+    // inventory_decommission_item
+    // =========================================================================
+
+    [Fact]
+    public async Task DecommissionItem_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.DecommissionItemAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InventoryItem
+            {
+                Id = "hw-1", RegisteredSystemId = "sys-1", ItemName = "web-server-01",
+                Type = InventoryItemType.Hardware, Status = InventoryItemStatus.Decommissioned, CreatedBy = "tester"
+            });
+
+        var tool = new InventoryDecommissionItemTool(_svcMock.Object, Mock.Of<ILogger<InventoryDecommissionItemTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "hw-1",
+            ["rationale"] = "End of life"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    // =========================================================================
+    // inventory_list
+    // =========================================================================
+
+    [Fact]
+    public async Task ListItems_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.ListItemsAsync(It.IsAny<string>(), It.IsAny<InventoryListOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InventoryItem> { SampleHwItem, SampleSwItem });
+
+        var tool = new InventoryListTool(_svcMock.Object, Mock.Of<ILogger<InventoryListTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("count").GetInt32().Should().Be(2);
+    }
+
+    // =========================================================================
+    // inventory_get
+    // =========================================================================
+
+    [Fact]
+    public async Task GetItem_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.GetItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SampleHwItem);
+
+        var tool = new InventoryGetTool(_svcMock.Object, Mock.Of<ILogger<InventoryGetTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "hw-1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    [Fact]
+    public async Task GetItem_NotFound_ReturnsError()
+    {
+        _svcMock
+            .Setup(s => s.GetItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InventoryItem?)null);
+
+        var tool = new InventoryGetTool(_svcMock.Object, Mock.Of<ILogger<InventoryGetTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["item_id"] = "nonexistent"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("ITEM_NOT_FOUND");
+    }
+
+    // =========================================================================
+    // inventory_export
+    // =========================================================================
+
+    [Fact]
+    public async Task ExportItem_ReturnsBase64()
+    {
+        _svcMock
+            .Setup(s => s.ExportToExcelAsync(It.IsAny<string>(), It.IsAny<InventoryExportOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x50, 0x4B, 0x03, 0x04 });
+
+        var tool = new InventoryExportTool(_svcMock.Object, Mock.Of<ILogger<InventoryExportTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("file_base64").GetString().Should().NotBeEmpty();
+    }
+
+    // =========================================================================
+    // inventory_import
+    // =========================================================================
+
+    [Fact]
+    public async Task ImportItem_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.ImportFromExcelAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InventoryImportResult { HardwareCreated = 2, SoftwareCreated = 3, RowsSkipped = 0 });
+
+        var tool = new InventoryImportTool(_svcMock.Object, Mock.Of<ILogger<InventoryImportTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_base64"] = Convert.ToBase64String(new byte[] { 1, 2, 3 })
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("hardware_created").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ImportItem_InvalidBase64_ReturnsError()
+    {
+        var tool = new InventoryImportTool(_svcMock.Object, Mock.Of<ILogger<InventoryImportTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1",
+            ["file_base64"] = "not-valid-base64!!!"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+        json.RootElement.GetProperty("errorCode").GetString().Should().Be("INVALID_BASE64");
+    }
+
+    // =========================================================================
+    // inventory_completeness
+    // =========================================================================
+
+    [Fact]
+    public async Task Completeness_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.CheckCompletenessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InventoryCompleteness
+            {
+                SystemId = "sys-1",
+                TotalItems = 5,
+                HardwareCount = 3,
+                SoftwareCount = 2,
+                CompletenessScore = 80.0,
+                IsComplete = false,
+                HardwareWithoutSoftware = new List<string> { "hw-1" }
+            });
+
+        var tool = new InventoryCompletenessTool(_svcMock.Object, Mock.Of<ILogger<InventoryCompletenessTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("completeness_score").GetDouble().Should().Be(80.0);
+    }
+
+    // =========================================================================
+    // inventory_auto_seed
+    // =========================================================================
+
+    [Fact]
+    public async Task AutoSeed_ReturnsSuccess()
+    {
+        _svcMock
+            .Setup(s => s.AutoSeedFromBoundaryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InventoryItem> { SampleHwItem });
+
+        var tool = new InventoryAutoSeedTool(_svcMock.Object, Mock.Of<ILogger<InventoryAutoSeedTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["system_id"] = "sys-1"
+        });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("success");
+        json.RootElement.GetProperty("data").GetProperty("created_count").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AutoSeed_MissingSystemId_ReturnsError()
+    {
+        var tool = new InventoryAutoSeedTool(_svcMock.Object, Mock.Of<ILogger<InventoryAutoSeedTool>>());
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?> { });
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("status").GetString().Should().Be("error");
+    }
+}


### PR DESCRIPTION
Feature 024 - Narrative Governance:
- 8 new MCP tools: narrative history, diff, rollback, submit, review, batch review, approval progress, batch submit
- Enhanced compliance_write_narrative with expected_version and change_reason parameters
- NarrativeVersion + NarrativeReview entities with append-only version history and ISSM approval workflow
- Optimistic concurrency via expected_version parameter
- DiffPlex-powered line-level unified diffs

Feature 025 - HW/SW Inventory:
- 9 new MCP tools: add, update, list, remove, export, import, completeness, auto-seed, decommission
- InventoryItem entity with 22 fields (eMASS-required detail)
- eMASS-compatible Excel export/import (round-trip)
- Auto-seed from authorization boundary resources
- Completeness scoring with gap identification
- SSP S11 integration for auto-populated HW/SW tables
- 58 tests (47 unit + 11 integration)

Documentation:
- 20+ doc files updated across api, architecture, guides, getting-started, glossary, and persona test cases
- v1.22.0 release notes
- 4268 tests passing (4075 unit + 193 integration)