### PR TITLE
fix: use consumption-only Container Apps env to avoid VM SKU restrict…

### DIFF
--- a/.github/workflows/bootstrap-azure-containerapp.yml
+++ b/.github/workflows/bootstrap-azure-containerapp.yml
@@ -64,7 +64,8 @@ jobs:
           az containerapp env create \
             --name "${{ github.event.inputs.containerapp_env_name }}" \
             --resource-group "${{ github.event.inputs.resource_group }}" \
-            --location "${{ github.event.inputs.location }}"
+            --location "${{ github.event.inputs.location }}" \
+            --enable-workload-profiles false
 
       - name: Create initial container app
         run: |


### PR DESCRIPTION
This pull request makes a minor change to the Azure Container Apps workflow configuration by explicitly disabling workload profiles when creating the container app environment.

- Workflow configuration:
  * Updated the `az containerapp env create` command in `.github/workflows/bootstrap-azure-containerapp.yml` to add the `--enable-workload-profiles false` flag, ensuring workload profiles are not enabled during environment creation.…ions