### PR TITLE
Handle partial Azure SQL server creation during region fallback

### DIFF
--- a/.github/workflows/bootstrap-azure-containerapp.yml
+++ b/.github/workflows/bootstrap-azure-containerapp.yml
@@ -135,9 +135,37 @@ jobs:
                 break
               fi
 
+              EXISTING_SERVER=$(az sql server show \
+                --resource-group "$RG" --name "$SQL_SERVER" \
+                --query fullyQualifiedDomainName -o tsv 2>/dev/null || true)
+              if [[ -n "$EXISTING_SERVER" ]]; then
+                FQDN="$EXISTING_SERVER"
+                SQL_LOCATION=$(az sql server show \
+                  --resource-group "$RG" --name "$SQL_SERVER" \
+                  --query location -o tsv 2>/dev/null || echo "$LOCATION")
+                CREATE_SQL_SUCCESS="true"
+                echo "SQL Server '$SQL_SERVER' became available at $FQDN in location '$SQL_LOCATION'. Reusing."
+                break
+              fi
+
               if grep -Eq "RegionDoesNotAllowProvisioning|is not accepting creation of new Windows Azure SQL Database servers" /tmp/sql-create.err; then
                 echo "Location '$CANDIDATE' is capacity blocked for SQL server creation. Trying next candidate..."
                 continue
+              fi
+
+              if grep -Eq "InvalidResourceLocation|already exists in location" /tmp/sql-create.err; then
+                EXISTING_SERVER=$(az sql server show \
+                  --resource-group "$RG" --name "$SQL_SERVER" \
+                  --query fullyQualifiedDomainName -o tsv 2>/dev/null || true)
+                if [[ -n "$EXISTING_SERVER" ]]; then
+                  FQDN="$EXISTING_SERVER"
+                  SQL_LOCATION=$(az sql server show \
+                    --resource-group "$RG" --name "$SQL_SERVER" \
+                    --query location -o tsv 2>/dev/null || echo "$LOCATION")
+                  CREATE_SQL_SUCCESS="true"
+                  echo "SQL Server '$SQL_SERVER' already exists after create attempt at $FQDN in location '$SQL_LOCATION'. Reusing."
+                  break
+                fi
               fi
 
               echo "::error::Failed to create SQL Server in '$CANDIDATE'."


### PR DESCRIPTION
This pull request improves the robustness of the Azure SQL Server creation logic in the `.github/workflows/bootstrap-azure-containerapp.yml` workflow. The changes ensure that if a SQL Server already exists (either before or after a creation attempt), the workflow will detect and reuse it instead of failing or unnecessarily retrying creation.

**Enhancements to SQL Server creation and reuse logic:**

* Added a check before attempting to create a SQL Server to see if it already exists, and if so, reuses the existing server and its location.
* Improved error handling after a failed creation attempt by detecting specific errors indicating the server already exists in a location, then retrieving and reusing the existing server details if found.