### PR TITLE
Poll ARM after InvalidResourceLocation to handle SQL server visibilit…

### DIFF
--- a/.github/workflows/bootstrap-azure-containerapp.yml
+++ b/.github/workflows/bootstrap-azure-containerapp.yml
@@ -31,7 +31,7 @@ on:
       sql_server_name:
         description: Azure SQL Server name (must be globally unique, e.g. sql-ato-copilot)
         required: true
-        default: sql-ato-copilot
+        default: azsql-ato-copilot
         type: string
       sql_database_name:
         description: Database name
@@ -135,37 +135,34 @@ jobs:
                 break
               fi
 
-              EXISTING_SERVER=$(az sql server show \
-                --resource-group "$RG" --name "$SQL_SERVER" \
-                --query fullyQualifiedDomainName -o tsv 2>/dev/null || true)
-              if [[ -n "$EXISTING_SERVER" ]]; then
-                FQDN="$EXISTING_SERVER"
-                SQL_LOCATION=$(az sql server show \
-                  --resource-group "$RG" --name "$SQL_SERVER" \
-                  --query location -o tsv 2>/dev/null || echo "$LOCATION")
-                CREATE_SQL_SUCCESS="true"
-                echo "SQL Server '$SQL_SERVER' became available at $FQDN in location '$SQL_LOCATION'. Reusing."
-                break
+              # InvalidResourceLocation means the server was already created in a prior
+              # attempt (possibly during the capacity-blocked region). ARM may not yet
+              # reflect it, so poll for up to 90s before giving up.
+              if grep -Eq "InvalidResourceLocation|already exists in location" /tmp/sql-create.err; then
+                echo "Server name already registered in Azure. Waiting for ARM visibility (up to 90s)..."
+                for _poll in 1 2 3 4 5 6; do
+                  sleep 15
+                  EXISTING_FQDN=$(az sql server show \
+                    --resource-group "$RG" --name "$SQL_SERVER" \
+                    --query fullyQualifiedDomainName -o tsv 2>/dev/null || true)
+                  if [[ -n "$EXISTING_FQDN" ]]; then
+                    FQDN="$EXISTING_FQDN"
+                    SQL_LOCATION=$(az sql server show \
+                      --resource-group "$RG" --name "$SQL_SERVER" \
+                      --query location -o tsv 2>/dev/null || echo "$LOCATION")
+                    CREATE_SQL_SUCCESS="true"
+                    echo "SQL Server '$SQL_SERVER' now visible at $FQDN in location '$SQL_LOCATION'. Reusing."
+                    break 2
+                  fi
+                  echo "  (poll ${_poll}/6 — not yet visible)"
+                done
+                echo "::error::SQL Server '$SQL_SERVER' reported as already existing but never became visible after 90s."
+                exit 1
               fi
 
               if grep -Eq "RegionDoesNotAllowProvisioning|is not accepting creation of new Windows Azure SQL Database servers" /tmp/sql-create.err; then
                 echo "Location '$CANDIDATE' is capacity blocked for SQL server creation. Trying next candidate..."
                 continue
-              fi
-
-              if grep -Eq "InvalidResourceLocation|already exists in location" /tmp/sql-create.err; then
-                EXISTING_SERVER=$(az sql server show \
-                  --resource-group "$RG" --name "$SQL_SERVER" \
-                  --query fullyQualifiedDomainName -o tsv 2>/dev/null || true)
-                if [[ -n "$EXISTING_SERVER" ]]; then
-                  FQDN="$EXISTING_SERVER"
-                  SQL_LOCATION=$(az sql server show \
-                    --resource-group "$RG" --name "$SQL_SERVER" \
-                    --query location -o tsv 2>/dev/null || echo "$LOCATION")
-                  CREATE_SQL_SUCCESS="true"
-                  echo "SQL Server '$SQL_SERVER' already exists after create attempt at $FQDN in location '$SQL_LOCATION'. Reusing."
-                  break
-                fi
               fi
 
               echo "::error::Failed to create SQL Server in '$CANDIDATE'."


### PR DESCRIPTION
This pull request makes improvements to the Azure SQL Server provisioning logic in the GitHub Actions workflow. The main changes are focused on handling edge cases where the server might already exist but is not immediately visible in Azure Resource Manager (ARM), and updating the default SQL Server name to avoid conflicts.

Key changes:

**Provisioning robustness improvements:**

* Enhanced the SQL Server creation script to handle cases where the server is reported as already existing but is not yet visible in ARM. The workflow now polls for up to 90 seconds for the server to become visible before failing, improving reliability in concurrent or capacity-constrained scenarios.

**Configuration update:**

* Changed the default value for the `sql_server_name` input from `sql-ato-copilot` to `azsql-ato-copilot` to ensure uniqueness and prevent naming conflicts.…y lag