### PR TITLE
Fix Container App secretref deployment ordering

### DIFF
--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -124,26 +124,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ENV_ARGS="ASPNETCORE_URLS=http://+:3001 ATO_RUN_MODE=http"
-          ENV_ARGS="${ENV_ARGS} ATO_GATEWAY__AZURE__CLOUDENVIRONMENT=${{ vars.ATO_GATEWAY_AZURE_CLOUDENVIRONMENT || 'AzureGovernment' }}"
-          ENV_ARGS="${ENV_ARGS} ATO_AZUREAI__ENABLED=${{ vars.ATO_AZUREAI_ENABLED || 'false' }}"
-          ENV_ARGS="${ENV_ARGS} ATO_AZUREAI__PROVIDER=${{ vars.ATO_AZUREAI_PROVIDER || 'OpenAi' }}"
-          ENV_ARGS="${ENV_ARGS} ATO_AZUREAI__ENDPOINT=${{ vars.ATO_AZUREAI_ENDPOINT || '' }}"
-          ENV_ARGS="${ENV_ARGS} ATO_AZUREAI__DEPLOYMENTNAME=${{ vars.ATO_AZUREAI_DEPLOYMENTNAME || 'gpt-4o' }}"
+          ENV_ARGS_BASE="ASPNETCORE_URLS=http://+:3001 ATO_RUN_MODE=http"
+          ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_GATEWAY__AZURE__CLOUDENVIRONMENT=${{ vars.ATO_GATEWAY_AZURE_CLOUDENVIRONMENT || 'AzureGovernment' }}"
+          ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENABLED=${{ vars.ATO_AZUREAI_ENABLED || 'false' }}"
+          ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__PROVIDER=${{ vars.ATO_AZUREAI_PROVIDER || 'OpenAi' }}"
+          ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENDPOINT=${{ vars.ATO_AZUREAI_ENDPOINT || '' }}"
+          ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__DEPLOYMENTNAME=${{ vars.ATO_AZUREAI_DEPLOYMENTNAME || 'gpt-4o' }}"
+
+          SECRETREF_ARGS=""
 
           if [ "${{ inputs.inject_runtime_secrets }}" = "true" ]; then
             if [ -n "${{ secrets.ATO_DB_CONNECTION_STRING || '' }}" ]; then
-              ENV_ARGS="${ENV_ARGS} ATO_CONNECTIONSTRINGS__DEFAULTCONNECTION=secretref:db-connection-string"
+              SECRETREF_ARGS="${SECRETREF_ARGS} ATO_CONNECTIONSTRINGS__DEFAULTCONNECTION=secretref:db-connection-string"
             fi
             if [ -n "${{ secrets.ATO_AZUREAI_APIKEY || '' }}" ]; then
-              ENV_ARGS="${ENV_ARGS} ATO_AZUREAI__APIKEY=secretref:azureai-apikey"
+              SECRETREF_ARGS="${SECRETREF_ARGS} ATO_AZUREAI__APIKEY=secretref:azureai-apikey"
             fi
             if [ -n "${{ secrets.ATO_AZUREAD_CLIENTSECRET || '' }}" ]; then
-              ENV_ARGS="${ENV_ARGS} ATO_AZUREAD__CLIENTSECRET=secretref:azuread-client-secret"
+              SECRETREF_ARGS="${SECRETREF_ARGS} ATO_AZUREAD__CLIENTSECRET=secretref:azuread-client-secret"
             fi
           fi
 
-          echo "value=${ENV_ARGS}" >> "$GITHUB_OUTPUT"
+          ENV_ARGS_WITH_SECRETS="${ENV_ARGS_BASE}${SECRETREF_ARGS}"
+          echo "base=${ENV_ARGS_BASE}" >> "$GITHUB_OUTPUT"
+          echo "with_secrets=${ENV_ARGS_WITH_SECRETS}" >> "$GITHUB_OUTPUT"
 
       - name: Create/update container app
         shell: bash
@@ -153,7 +157,7 @@ jobs:
           APP="${{ vars.AZURE_CONTAINERAPP_NAME }}"
           ENV_NAME="${{ vars.AZURE_CONTAINERAPP_ENV_NAME }}"
           IMAGE="${{ inputs.image }}"
-          ENV_ARGS="${{ steps.envargs.outputs.value }}"
+          ENV_ARGS="${{ steps.envargs.outputs.base }}"
 
           if az containerapp show -g "${RG}" -n "${APP}" >/dev/null 2>&1; then
             # shellcheck disable=SC2086
@@ -202,7 +206,7 @@ jobs:
           set -euo pipefail
           RG="${{ vars.AZURE_RESOURCE_GROUP }}"
           APP="${{ vars.AZURE_CONTAINERAPP_NAME }}"
-          ENV_ARGS="${{ steps.envargs.outputs.value }}"
+          ENV_ARGS="${{ steps.envargs.outputs.with_secrets }}"
 
           # shellcheck disable=SC2086
           az containerapp update \


### PR DESCRIPTION
This pull request refactors how environment variables and secrets are handled in the deployment workflow for the container app. The main improvement is separating base environment variables from secret references, making the deployment process more flexible and secure.

**Environment variable handling:**

* Refactored the environment variable setup in `.github/workflows/deploy-containerapp-stage.yml` by splitting them into `ENV_ARGS_BASE` (base variables) and `SECRETREF_ARGS` (secret references), then combining them as needed. This makes it easier to manage secrets separately from non-secret configuration.

**Deployment steps update:**

* Updated the container app creation step to use only base environment variables (`ENV_ARGS_BASE`) when secrets are not injected.
* Updated the container app update step to use the combined environment variables with secrets (`ENV_ARGS_BASE` + `SECRETREF_ARGS`) when secrets are injected.