### PR TITLE
Assign managed identity in Container App deploy workflow

### DIFF
--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -181,6 +181,25 @@ jobs:
               --env-vars ${ENV_ARGS}
           fi
 
+      - name: Ensure ingress target port
+        shell: bash
+        run: |
+          set -euo pipefail
+          az containerapp ingress update \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --name "${{ vars.AZURE_CONTAINERAPP_NAME }}" \
+            --type external \
+            --target-port 3001 >/dev/null
+
+      - name: Ensure system-assigned managed identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          az containerapp identity assign \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --name "${{ vars.AZURE_CONTAINERAPP_NAME }}" \
+            --system-assigned >/dev/null
+
       - name: Set optional runtime secrets
         if: inputs.inject_runtime_secrets
         shell: bash


### PR DESCRIPTION
This pull request updates the deployment workflow for the staging environment to ensure the Azure Container App is configured correctly for ingress and identity. The main changes add steps to explicitly set the ingress target port and assign a system-managed identity before setting runtime secrets.

**Deployment workflow improvements:**

* Added a step to explicitly set the ingress type to `external` and the target port to `3001` for the Azure Container App, ensuring correct routing and accessibility.
* Added a step to assign a system-assigned managed identity to the Azure Container App, improving security and enabling the app to access Azure resources securely.