### PR TITLE
Fix SQL Server cascade path for POAM ticket syncs

### DIFF
--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -2629,7 +2629,7 @@ public class AtoCopilotContext : DbContext
             entity.HasOne(e => e.TicketingIntegration)
                 .WithMany()
                 .HasForeignKey(e => e.TicketingIntegrationId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.NoAction);
         });
 
         // ─── AuthorizationPackage (Feature 041) ─────────────────────────────────

--- a/src/Ato.Copilot.Core/Migrations/AtoCopilotContextModelSnapshot.cs
+++ b/src/Ato.Copilot.Core/Migrations/AtoCopilotContextModelSnapshot.cs
@@ -7572,7 +7572,7 @@ namespace Ato.Copilot.Core.Migrations
                     b.HasOne("Ato.Copilot.Core.Models.Poam.TicketingIntegration", "TicketingIntegration")
                         .WithMany()
                         .HasForeignKey("TicketingIntegrationId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
 
                     b.Navigation("PoamItem");


### PR DESCRIPTION
This pull request updates the foreign key relationship between `PoamItem` and `TicketingIntegration` to change the delete behavior from cascading deletes to no action. This means that deleting a `TicketingIntegration` will no longer automatically delete related `PoamItem` records. The change is reflected both in the Entity Framework model configuration and the migration snapshot.

**Database relationship changes:**

* Changed the `OnDelete` behavior for the foreign key from `PoamItem.TicketingIntegrationId` to `TicketingIntegration` from `Cascade` to `NoAction` in `AtoCopilotContext.cs` to prevent automatic deletion of related `PoamItem` records when a `TicketingIntegration` is deleted.
* Updated the model snapshot in `AtoCopilotContextModelSnapshot.cs` to reflect the new `OnDelete(DeleteBehavior.NoAction)` configuration for the same relationship.