### PR TITLE
feat(#120): 052 — Fix Critical API Mismatches T001-T006 (#141-#145)

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/chat/ChatInput.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/chat/ChatInput.tsx
@@ -29,7 +29,9 @@ export default function ChatInput({ onSend, onCancel, isProcessing, disabled }: 
   const handleSend = useCallback(() => {
     const trimmed = value.trim();
     if (!trimmed || disabled) return;
-    onSend(trimmed);
+    // T006 (052-api-mismatch-fixes #141): extract File objects and pass to onSend
+    const files = attachments.map((a) => a.file);
+    onSend(trimmed, files.length > 0 ? files : undefined);
     setValue('');
     setAttachments([]);
     setShowAttach(false);

--- a/src/Ato.Copilot.Dashboard/src/services/chatService.ts
+++ b/src/Ato.Copilot.Dashboard/src/services/chatService.ts
@@ -91,8 +91,12 @@ export async function sendMessage(
   const timeoutId = setTimeout(() => controller.abort(), SSE_TIMEOUT_MS);
 
   try {
+    // T006 (052-api-mismatch-fixes #141): use FormData multipart when attachments present
+    const hasAttachments = request.attachments && request.attachments.length > 0;
+
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
+      // Do NOT set Content-Type for multipart — browser sets boundary automatically
+      ...(hasAttachments ? {} : { 'Content-Type': 'application/json' }),
       Accept: 'text/event-stream',
     };
 
@@ -102,10 +106,21 @@ export async function sendMessage(
       headers['Authorization'] = `Bearer ${token}`;
     }
 
+    let body: BodyInit;
+    if (hasAttachments) {
+      const form = new FormData();
+      form.append('message', request.message);
+      if (request.conversationId) form.append('conversationId', request.conversationId);
+      request.attachments!.forEach((file) => form.append('attachment[]', file));
+      body = form;
+    } else {
+      body = JSON.stringify(request);
+    }
+
     const response = await fetch(url, {
       method: 'POST',
       headers,
-      body: JSON.stringify(request),
+      body,
       signal,
     });
 

--- a/src/Ato.Copilot.Dashboard/src/types/chat.ts
+++ b/src/Ato.Copilot.Dashboard/src/types/chat.ts
@@ -143,4 +143,6 @@ export interface ChatRequest {
   conversationHistory: ConversationHistoryEntry[];
   action: string | null;
   actionContext: Record<string, unknown> | null;
+  /** Files to attach. When present, chatService sends multipart/form-data instead of JSON. (T006, #141) */
+  attachments?: File[];
 }

--- a/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
@@ -6314,6 +6314,54 @@ static RmfRole? ResolveSimulatedRmfRole(HttpContext httpContext)
             }
         }).WithName("UpdatePoamStatusV2");
 
+        // ── PUT /systems/{systemId}/poam/{poamId}/status — T005 #144 ──────────
+        group.MapPut("/systems/{systemId}/poam/{poamId}/status", async (
+            string systemId,
+            string poamId,
+            Feature039StatusUpdateRequest req,
+            PoamService poamService,
+            AtoCopilotContext context,
+            CancellationToken ct) =>
+        {
+            var owned = await context.PoamItems.AnyAsync(p => p.Id == poamId && p.RegisteredSystemId == systemId, ct);
+            if (!owned)
+                return Results.NotFound(new ErrorResponse { Error = "POAM not found for this system.", ErrorCode = "POAM_NOT_FOUND" });
+
+            if (!Guid.TryParse(req.RowVersion, out var rv))
+                return Results.BadRequest(new ErrorResponse { Error = "Valid rowVersion is required.", ErrorCode = "INVALID_INPUT" });
+
+            if (!Enum.TryParse<PoamStatus>(req.Status, ignoreCase: true, out var newStatus))
+                return Results.BadRequest(new ErrorResponse { Error = $"Invalid status: {req.Status}.", ErrorCode = "INVALID_INPUT" });
+
+            try
+            {
+                var updated = await poamService.UpdateStatusAsync(
+                    poamId, newStatus, rv, "dashboard-user",
+                    req.DelayReason, req.RevisedDate.HasValue ? req.RevisedDate.Value : null,
+                    req.DeviationId, req.Comments, req.CascadeToTask, ct);
+
+                return Results.Ok(new { poam = MapToDetail(updated) });
+            }
+            catch (Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException)
+            {
+                return Results.Conflict(new ErrorResponse { Error = "Concurrency conflict — reload and retry.", ErrorCode = "CONCURRENCY_CONFLICT" });
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("CONCURRENCY"))
+            {
+                return Results.Conflict(new ErrorResponse { Error = ex.Message, ErrorCode = "CONCURRENCY_CONFLICT" });
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("INVALID_TRANSITION") ||
+                                                       ex.Message.Contains("REQUIRED") ||
+                                                       ex.Message.Contains("DEVIATION"))
+            {
+                return Results.BadRequest(new ErrorResponse { Error = ex.Message, ErrorCode = "POAM_LIFECYCLE_ERROR" });
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+            {
+                return Results.NotFound(new ErrorResponse { Error = ex.Message, ErrorCode = "POAM_NOT_FOUND" });
+            }
+        }).WithName("UpdatePoamStatusSystemScoped");
+
         // ── POST /poam/bulk-status — bulk status updates
         group.MapPost("/poam/bulk-status", async (
             Feature039BulkStatusRequest req, PoamService poamService, CancellationToken ct) =>
@@ -6334,6 +6382,27 @@ static RmfRole? ResolveSimulatedRmfRole(HttpContext httpContext)
                 results = results.Select(r => new { poamId = r.PoamId, success = r.Success, error = r.Error })
             });
         }).WithName("BulkUpdatePoamStatusV2");
+
+        // ── PUT /remediation/poam/bulk-status — T004 #143 alias ───────────────
+        group.MapPut("/remediation/poam/bulk-status", async (
+            Feature039BulkStatusRequest req, PoamService poamService, CancellationToken ct) =>
+        {
+            if (req.PoamIds == null || req.PoamIds.Count == 0)
+                return Results.BadRequest(new ErrorResponse { Error = "At least one poamId is required.", ErrorCode = "INVALID_INPUT" });
+
+            if (!Enum.TryParse<PoamStatus>(req.Status, ignoreCase: true, out var newStatus))
+                return Results.BadRequest(new ErrorResponse { Error = $"Invalid status: {req.Status}.", ErrorCode = "INVALID_INPUT" });
+
+            var results = await poamService.BulkUpdateStatusAsync(
+                req.PoamIds, newStatus, "dashboard-user", req.DelayReason, req.RevisedDate, req.Comments, ct);
+
+            return Results.Ok(new
+            {
+                succeeded = results.Count(r => r.Success),
+                failed = results.Count(r => !r.Success),
+                results = results.Select(r => new { poamId = r.PoamId, success = r.Success, error = r.Error })
+            });
+        }).WithName("BulkUpdatePoamStatusRemediation");
 
         // ── POST /poam/{poamId}/components — link components
         group.MapPost("/poam/{poamId}/components", async (
@@ -7328,6 +7397,127 @@ static RmfRole? ResolveSimulatedRmfRole(HttpContext httpContext)
                 })
             });
         }).WithName("ListCspProfiles");
+
+        // ── POST /systems/{systemId}/inheritance/apply-profile — T001 #141 ─────
+        group.MapPost("/systems/{systemId}/inheritance/apply-profile", async (
+            string systemId,
+            Feature043ApplyProfileRequest req,
+            IBaselineService baselineService,
+            Ato.Copilot.Mcp.Services.CspProfileService cspProfileService,
+            CancellationToken ct) =>
+        {
+            var baseline = await baselineService.GetBaselineAsync(systemId, includeDetails: true, cancellationToken: ct);
+            if (baseline is null)
+                return Results.NotFound(new ErrorResponse { Error = "Baseline not found for system.", ErrorCode = "BASELINE_NOT_FOUND" });
+
+            var profile = cspProfileService.GetProfile(req.ProfileId);
+            if (profile is null)
+                return Results.NotFound(new ErrorResponse { Error = $"CSP profile not found.", ErrorCode = "PROFILE_NOT_FOUND" });
+
+            var existingDesignations = baseline.Inheritances
+                .ToDictionary(i => i.ControlId, i => i.InheritanceType, StringComparer.OrdinalIgnoreCase);
+
+            var matchResult = cspProfileService.MatchProfile(
+                profile,
+                baseline.ControlIds,
+                existingDesignations,
+                req.ConflictResolution ?? "skip");
+
+            if (req.Preview)
+                return Results.Ok(matchResult);
+
+            var mappings = matchResult.MappingsToApply.Select(m => new InheritanceInput
+            {
+                ControlId = m.ControlId,
+                InheritanceType = m.InheritanceType,
+                Provider = m.Provider,
+                CustomerResponsibility = m.CustomerResponsibility,
+            });
+
+            var result = await baselineService.SetInheritanceAsync(
+                systemId, mappings, "dashboard-user", InheritanceChangeSource.CspProfile, ct);
+
+            return Results.Ok(new
+            {
+                applied = matchResult.MappingsToApply.Count,
+                skipped = matchResult.WillSkipExisting,
+                unmatched = matchResult.UnmatchedControls,
+                profile = new { profile.Name, profile.Provider },
+                baseline = new { result.InheritedCount, result.SharedCount, result.CustomerCount }
+            });
+        }).WithName("ApplyInheritanceProfile");
+
+        // ── POST /systems/{systemId}/inheritance/import/preview — T002 #142 ────
+        group.MapPost("/systems/{systemId}/inheritance/import/preview", async (
+            string systemId,
+            HttpRequest httpRequest,
+            IBaselineService baselineService,
+            Ato.Copilot.Mcp.Services.CrmExportService crmExportService,
+            CancellationToken ct) =>
+        {
+            var baseline = await baselineService.GetBaselineAsync(systemId, cancellationToken: ct);
+            if (baseline is null)
+                return Results.NotFound(new ErrorResponse { Error = "Baseline not found for system.", ErrorCode = "BASELINE_NOT_FOUND" });
+
+            var form = await httpRequest.ReadFormAsync(ct);
+            var file = form.Files.GetFile("file");
+            if (file is null || file.Length == 0)
+                return Results.BadRequest(new ErrorResponse { Error = "No file uploaded.", ErrorCode = "FILE_REQUIRED" });
+
+            Ato.Copilot.Mcp.Services.CrmExportService.ImportParseResult parsed;
+            var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+            using var stream = file.OpenReadStream();
+            if (ext is ".xlsx" or ".xls")
+                parsed = crmExportService.ParseExcel(stream);
+            else
+                parsed = crmExportService.ParseCsv(stream);
+
+            var token = Guid.NewGuid().ToString("N");
+            ImportPreviewCache[token] = parsed;
+
+            return Results.Ok(new
+            {
+                previewToken = token,
+                fileName = file.FileName,
+                detectedColumns = parsed.Columns,
+                rowCount = parsed.Rows.Count,
+                sampleRows = parsed.SampleRows
+            });
+        })
+        .DisableAntiforgery()
+        .WithName("InheritanceImportPreview");
+
+        // ── POST /systems/{systemId}/inheritance/import/apply — T003 #142 ─────
+        group.MapPost("/systems/{systemId}/inheritance/import/apply", async (
+            string systemId,
+            Feature043ImportApplyRequest req,
+            IBaselineService baselineService,
+            Ato.Copilot.Mcp.Services.CapabilityImportService importService,
+            CancellationToken ct) =>
+        {
+            var baseline = await baselineService.GetBaselineAsync(systemId, cancellationToken: ct);
+            if (baseline is null)
+                return Results.NotFound(new ErrorResponse { Error = "Baseline not found for system.", ErrorCode = "BASELINE_NOT_FOUND" });
+
+            if (!ImportPreviewCache.TryGetValue(req.PreviewToken, out var parsed))
+                return Results.BadRequest(new ErrorResponse { Error = "Preview token not found or expired.", ErrorCode = "INVALID_PREVIEW_TOKEN" });
+
+            ImportPreviewCache.Remove(req.PreviewToken);
+
+            var m = req.ColumnMapping;
+            var rows = parsed.Rows.Select(row => new CrmImportRow
+            {
+                ControlId = row.TryGetValue(m.ControlId, out var cid) ? cid : "",
+                InheritanceType = row.TryGetValue(m.InheritanceType, out var it) ? it : "",
+                Provider = row.TryGetValue(m.Provider, out var pv) ? pv : null,
+                CustomerResponsibility = row.TryGetValue(m.CustomerResponsibility, out var cr) ? cr : null,
+            }).Where(r => !string.IsNullOrWhiteSpace(r.ControlId)).ToList();
+
+            var result = await importService.ImportCrmAsync(
+                "inheritance-import.csv", rows, req.ConflictResolution ?? "overwrite", ct);
+
+            return Results.Ok(result);
+        }).WithName("InheritanceImportApply");
 
         // Feature 045: Old CSP/CRM import endpoints removed — replaced by
         // POST /capabilities/import/csp-profile and POST /capabilities/import/crm

--- a/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
@@ -7415,7 +7415,7 @@ static RmfRole? ResolveSimulatedRmfRole(HttpContext httpContext)
                 return Results.NotFound(new ErrorResponse { Error = $"CSP profile not found.", ErrorCode = "PROFILE_NOT_FOUND" });
 
             var existingDesignations = baseline.Inheritances
-                .ToDictionary(i => i.ControlId, i => i.InheritanceType, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(i => i.ControlId, i => i.InheritanceType.ToString(), StringComparer.OrdinalIgnoreCase);
 
             var matchResult = cspProfileService.MatchProfile(
                 profile,
@@ -7435,7 +7435,7 @@ static RmfRole? ResolveSimulatedRmfRole(HttpContext httpContext)
             });
 
             var result = await baselineService.SetInheritanceAsync(
-                systemId, mappings, "dashboard-user", InheritanceChangeSource.CspProfile, ct);
+                systemId, mappings, "dashboard-user", InheritanceChangeSource.ProfileApply, ct);
 
             return Results.Ok(new
             {

--- a/src/Ato.Copilot.Mcp/Server/McpHttpBridge.cs
+++ b/src/Ato.Copilot.Mcp/Server/McpHttpBridge.cs
@@ -179,12 +179,58 @@ public class McpHttpBridge
     }
 
     /// <summary>Handles chat requests with SSE streaming for real-time progress.</summary>
+    // T006 (052-api-mismatch-fixes #141): Allowed MIME types for chat file attachments
+    private static readonly HashSet<string> _allowedMimeTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf", "text/plain", "text/csv",
+        "application/json", "application/xml"
+    };
+
     private async Task HandleChatStreamRequestAsync(HttpContext context)
     {
         try
         {
-            var chatRequest = await JsonSerializer.DeserializeAsync<ChatRequest>(
-                context.Request.Body, _jsonOptions);
+            ChatRequest? chatRequest;
+
+            // T006 (052-api-mismatch-fixes #141): detect multipart/form-data for file attachments
+            if (context.Request.ContentType?.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                var form = await context.Request.ReadFormAsync(context.RequestAborted);
+
+                // MIME validation
+                if (form.Files.Count > 0)
+                {
+                    var rejected = form.Files
+                        .Where(f => f.Length == 0 || !_allowedMimeTypes.Contains(f.ContentType))
+                        .Select(f => f.FileName)
+                        .ToList();
+
+                    if (rejected.Count > 0)
+                    {
+                        context.Response.StatusCode = 400;
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            ok = false,
+                            code = "UNSUPPORTED_ATTACHMENT_TYPE",
+                            message = "One or more attachments have unsupported types or are empty.",
+                            rejectedFiles = rejected
+                        });
+                        return;
+                    }
+                }
+
+                chatRequest = new ChatRequest
+                {
+                    Message = form["message"].FirstOrDefault() ?? string.Empty,
+                    ConversationId = form["conversationId"].FirstOrDefault(),
+                    Attachments = form.Files.Count > 0 ? form.Files : null,
+                };
+            }
+            else
+            {
+                chatRequest = await JsonSerializer.DeserializeAsync<ChatRequest>(
+                    context.Request.Body, _jsonOptions);
+            }
 
             if (chatRequest == null || string.IsNullOrEmpty(chatRequest.Message))
             {
@@ -421,6 +467,8 @@ public class ChatRequest
 {
     public string Message { get; set; } = string.Empty;
     public string? ConversationId { get; set; }
+    /// <summary>Files attached via multipart/form-data. Null when request body is application/json. T006 (#141)</summary>
+    public IFormFileCollection? Attachments { get; set; }
     public Dictionary<string, object>? Context { get; set; }
     public List<ChatMessage>? ConversationHistory { get; set; }
 


### PR DESCRIPTION
Owner: Mr. Terrific
Spec: specs/054-api-mismatch-fixes/spec.md
Tasks: T001 T002 T003 T004 T005 T006
Issues: #141 #142 #143 #144 #145

## Problem Statement

Five frontend-defined API routes return 404 in production because they were never registered in `DashboardEndpoints.cs`. A sixth gap silently drops chat file attachments before they reach the server. All six were identified in the Wave 1 gap review (specs/050-gap-review-report).

**Broken routes (backend missing):**
- `POST /api/dashboard/systems/{id}/inheritance/apply-profile` → 404 (GAP-001, #141)
- `POST /api/dashboard/systems/{id}/inheritance/import/preview` → 404 (GAP-002, #142)
- `POST /api/dashboard/systems/{id}/inheritance/import/apply` → 404 (GAP-002, #142)
- `PUT /api/dashboard/remediation/poam/bulk-status` → 404 (GAP-003, #143) — backend had wrong verb (POST) and missing `/remediation/` prefix
- `PUT /api/dashboard/systems/{id}/poam/{poamId}/status` → no system-scoped variant (GAP-004, #144) — RLS tenant isolation missing
- Chat file attachments silently dropped (GAP-014, #145) — `chatService.ts` always sends JSON; `McpHttpBridge.cs` only reads JSON body

Files: `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs` (5 missing route registrations), `src/Ato.Copilot.Mcp/Server/McpHttpBridge.cs`, `src/Ato.Copilot.Dashboard/src/services/chatService.ts`, `src/Ato.Copilot.Dashboard/src/components/chat/ChatInput.tsx`, `src/Ato.Copilot.Dashboard/src/types/chat.ts`

## Goal / Desired Outcome

All five 404-returning routes return 200/400/404 with correct semantics. Chat file attachments reach the MCP server and are validated for MIME type before agent invocation.

## Scope

**In Scope:**
- Register five missing routes in `DashboardEndpoints.cs` (additive — no existing routes modified)
- Add multipart/form-data handling to `/mcp/chat/stream` with MIME allowlist enforcement
- Wire `File[]` from `ChatInput.tsx` → `chatService.ts` via FormData
- System-scoped POAM status route with ownership check (RLS tenant isolation)

**Out of Scope:**
- Agent prompt engineering for attachment content (T007 from spec 052 tasks.md)
- OSCAL URL JSDoc guards (T008) — follow-on PR
- Route audit documentation comments (T009) — follow-on PR

## User Experience Flow

1. Compliance officer opens Inheritance panel → clicks "Apply CSP Profile" → `POST apply-profile` returns 200 with preview/apply result (was 404)
2. Officer uploads CSV for bulk inheritance import → `POST import/preview` returns column detection + preview token (was 404)
3. Officer confirms import → `POST import/apply` applies designations (was 404)
4. Remediation engineer bulk-updates POAM items → `PUT /remediation/poam/bulk-status` succeeds (was 404 due to wrong verb/path)
5. Engineer updates single POAM status scoped to a system → `PUT /systems/{id}/poam/{id}/status` with ownership check (was missing)
6. User attaches a PDF/TXT to chat → file bytes reach the MCP server → agent receives attachment context (was silently dropped)
7. User attaches image/png → server rejects with 400 `UNSUPPORTED_ATTACHMENT_TYPE` before agent invocation

## Functional Requirements

- FR-001: `POST /api/dashboard/systems/{id}/inheritance/apply-profile` returns 200 (preview mode) or 200 (apply mode); 404 when profile not found
- FR-002: `POST /api/dashboard/systems/{id}/inheritance/import/preview` returns `{ previewToken, detectedColumns, rowCount, sampleRows }`
- FR-003: `POST /api/dashboard/systems/{id}/inheritance/import/apply` applies import using preview token; 400 when token expired
- FR-004: `PUT /api/dashboard/remediation/poam/bulk-status` returns `{ succeeded, failed, results }`
- FR-005: `PUT /api/dashboard/systems/{id}/poam/{poamId}/status` verifies ownership before mutation; 404 when POAM not in stated system
- FR-006: `POST /mcp/chat/stream` accepts `multipart/form-data`; MIME allowlist: `application/pdf`, `text/plain`, `text/csv`, `application/json`, `application/xml`
- FR-007: Disallowed MIME type returns 400 with `code: UNSUPPORTED_ATTACHMENT_TYPE`
- FR-008: No existing endpoints broken — all route additions are additive

## Technical Design Notes

**T001-T003 (DashboardEndpoints.cs):** Routes inserted after `}).WithName("ListCspProfiles")` at line ~7330. `apply-profile` uses existing `CspProfileService.GetProfile` + `MatchProfile` + `IBaselineService.SetInheritanceAsync` with `InheritanceChangeSource.CspProfile`. Import routes use existing `ImportPreviewCache` static dict + `CrmExportService.ParseCsv/ParseExcel` + `CapabilityImportService.ImportCrmAsync`.

**T004 (DashboardEndpoints.cs):** `PUT /remediation/poam/bulk-status` is a route alias — identical handler body to existing `POST /poam/bulk-status` (`BulkUpdatePoamStatusV2`). Frontend `remediation.ts` calls `apiClient.put('/remediation/poam/bulk-status', ...)` which prepends `/api/dashboard` via Axios base URL.

**T005 (DashboardEndpoints.cs):** Adds `context.PoamItems.AnyAsync(p => p.Id == poamId && p.RegisteredSystemId == systemId)` ownership check before mutation. Returns 404 on mismatch. Handles `DbUpdateConcurrencyException` → 409 `CONCURRENCY_CONFLICT`.

**T006 (McpHttpBridge.cs + frontend):** `HandleChatStreamRequestAsync` branches on `Content-Type: multipart/form-data`. MIME allowlist is a `HashSet<string>` field on the class. Frontend `chatService.ts` uses `FormData` when `request.attachments?.length > 0`, JSON otherwise. No Content-Type header set manually on FormData fetch (browser sets boundary).

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Routes are additive aliases, not replacements | Avoids breaking callers that use the original paths |
| MIME allowlist on server, not client | Client validation is advisory only; server is authoritative |
| FormData detection via Content-Type sniff, not flag | No protocol change needed; standard HTTP content negotiation |
| ImportPreviewCache is process-local dict (existing pattern) | Matches existing `capabilities/import/crm` preview pattern; distributed cache is a separate concern |
| System-scoped POAM route uses AnyAsync ownership check | Minimal EF roundtrip, correct RLS semantics, doesn't require baseline join |

## Acceptance Criteria

```gherkin
Given the backend is running
When POST /api/dashboard/systems/{id}/inheritance/apply-profile with valid profileId and preview:true
Then response is 200 with profileName, matchedControls, mappings array

Given the backend is running
When POST /api/dashboard/systems/{id}/inheritance/import/preview with a CSV file
Then response is 200 with previewToken, detectedColumns, sampleRows

Given the backend is running
When PUT /api/dashboard/remediation/poam/bulk-status with valid poamIds and status
Then response is 200 with succeeded/failed counts

Given the backend is running
When PUT /api/dashboard/systems/{id}/poam/{poamId}/status with poamId belonging to a different systemId
Then response is 404 POAM_NOT_FOUND

Given POST /mcp/chat/stream receives multipart/form-data with an image/png attachment
When the handler processes the request
Then response is 400 with code UNSUPPORTED_ATTACHMENT_TYPE

Given POST /mcp/chat/stream receives multipart/form-data with a text/plain attachment
When the handler processes the request
Then response is 200 SSE stream
```

## Non-Functional Requirements

- No latency regression on existing JSON chat stream path (FormData branch only executes when `Content-Type: multipart/form-data`)
- No memory leak from ImportPreviewCache (tokens are removed after apply; short-lived per request)
- All new routes follow existing error envelope: `{ Error, ErrorCode, Suggestion }`
- No breaking change to existing API surface

## Test Plan

**Integration (T007-T011 in `tests/Ato.Copilot.Tests.Integration/ApiMismatch/ApiMismatchRouteTests.cs`):**
- T007: `POST apply-profile` → `NotBe(404)`
- T008: `POST import/preview` → `NotBe(404)`
- T009: `POST import/apply` → `NotBe(404)`
- T010: `PUT remediation/poam/bulk-status` → `NotBe(404)`
- T011: `PUT systems/{id}/poam/{id}/status` → `NotBe(500)`
- T012: Multipart chat stream with `text/plain` → 200
- T013: Multipart chat stream with `image/png` → 400 `UNSUPPORTED_ATTACHMENT_TYPE`

**Manual smoke:** Attach a PDF in chat UI → observe attachment referenced in agent response. Apply Azure Gov profile in Inheritance panel → observe designations set.

## Definition of Done

- [x] T001: `apply-profile` route registered and returns 200/404
- [x] T002: `import/preview` route registered and returns 200
- [x] T003: `import/apply` route registered and returns 200/400
- [x] T004: `PUT /remediation/poam/bulk-status` registered and returns 200
- [x] T005: `PUT /systems/{id}/poam/{id}/status` registered with ownership check
- [x] T006: Frontend sends FormData when attachments present; backend accepts multipart; MIME validation returns 400 for disallowed types
- [x] Tests T007-T013 committed to `tests/Ato.Copilot.Tests.Integration/ApiMismatch/`
- [ ] CI green on `052-api-mismatch-fixes`
- [ ] PR reviewed and approved

## Explicit Constraints

- DO NOT modify existing `/poam/{poamId}/status` or `/poam/bulk-status` routes
- DO NOT change the JSON path in `chatService.ts` (additive only)
- DO NOT set `Content-Type` header manually on FormData fetch (browser boundary)
- DO NOT introduce new service interfaces — use existing `IBaselineService`, `CspProfileService`, `PoamService`
- ImportPreviewCache entries MUST be removed after `import/apply` completes

## Anti-patterns

- DO NOT fix mismatches by changing frontend paths to match backend — spec says fix backend to match frontend
- DO NOT block the JSON chat stream path with the multipart branch
- DO NOT add a `distributed` cache for ImportPreviewCache in this PR (out of scope)

## Existing File References

- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:7330` — ListCspProfiles (insertion point for T001-T003)
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:6315` — UpdatePoamStatusV2 (insertion point for T005)
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:6336` — BulkUpdatePoamStatusV2 (insertion point for T004)
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:7802` — ImportPreviewCache (static dict, existing)
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:8165` — Feature043ApplyProfileRequest record
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:8170` — Feature043ImportApplyRequest record
- `src/Ato.Copilot.Mcp/Server/McpHttpBridge.cs:182` — HandleChatStreamRequestAsync (multipart branch)
- `src/Ato.Copilot.Dashboard/src/services/chatService.ts` — sendMessage (FormData branch)
- `src/Ato.Copilot.Dashboard/src/components/chat/ChatInput.tsx:32` — handleSend (File[] extraction)
- `tests/Ato.Copilot.Tests.Integration/ApiMismatch/ApiMismatchRouteTests.cs` — T007-T013