### PR TITLE
feat(059,060): orphaned endpoints + VS Code extension specs

### DIFF
--- a/specs/057-rls-isolation-044-050/checklists/requirements.md
+++ b/specs/057-rls-isolation-044-050/checklists/requirements.md
@@ -1,0 +1,49 @@
+# Requirements Checklist: RLS Multi-Tenant Isolation for Features 044–050
+
+## Functional Requirements
+
+### FR-RLS-01: Coverage matrix is complete and accurate
+- [ ] Every entity introduced in Features 044–050 appears in `contracts/rls-predicates.md`
+- [ ] Each entity has exactly one of `[TenantScoped]` or `[GlobalReference]`
+- [ ] `[GlobalReference]` entities have documented rationale
+
+### FR-RLS-02: HasQueryFilter applied to all [TenantScoped] entities
+- [ ] `ApplyTenantQueryFilters` reflection loop covers all 8 tenant-scoped entities
+- [ ] Confirmed by `RlsCoverageMatrix` test (reflection, not manual)
+
+### FR-RLS-03: FR-026 role gate implemented
+- [ ] `PUT /systems/{systemId}/inheritance` returns `403` for non-AO/non-Engineer
+- [ ] `TODO(FR-026)` comment removed from `DashboardEndpoints.cs`
+- [ ] Error response uses existing `ErrorResponse` shape with `ErrorCode = "FORBIDDEN"`
+
+### FR-RLS-04: No query-path raw SQL bypasses HasQueryFilter
+- [ ] All `ExecuteSqlRawAsync` / `FromSqlRaw` calls are DDL-only (confirmed)
+- [ ] CI lint step enforces this for future PRs
+
+## Test Requirements
+
+### TR-01: RlsCoverageMatrix (US1)
+- [ ] xUnit test in `Ato.Copilot.Core.Tests`
+- [ ] Passes CI
+
+### TR-02: RBAC gate integration tests (US2)
+- [ ] AO token → 200
+- [ ] Engineer token → 200
+- [ ] Read-only token → 403
+
+### TR-03: CrossTenantIsolationTests (US3)
+- [ ] 8 rows, one per tenant-scoped 044–050 entity
+- [ ] Uses SQLite in-memory provider
+- [ ] All pass CI
+
+## Non-Functional Requirements
+
+- [ ] No new database migrations (all TenantId columns exist)
+- [ ] No performance regression — `HasQueryFilter` is a compiled filter, no runtime overhead
+- [ ] Lint step adds < 5 seconds to CI pipeline
+
+## Out of Scope
+
+- Adding new entity types (this epic only audits/validates existing)
+- Row-level security at the SQL Server engine layer (EF filter layer is sufficient)
+- Global CSP-Admin cross-tenant reads (correct by design via `[GlobalReference]`)

--- a/specs/057-rls-isolation-044-050/contracts/internal-services.md
+++ b/specs/057-rls-isolation-044-050/contracts/internal-services.md
@@ -1,0 +1,67 @@
+# Internal Service Contracts: RLS Multi-Tenant Isolation
+
+## ITenantContext
+
+Provides the current tenant identity to `AtoCopilotContext`.
+
+```csharp
+public interface ITenantContext
+{
+    Guid CurrentTenantId { get; }
+    bool IsGlobalAdmin { get; }  // CSP-Admin: bypasses HasQueryFilter via IgnoreQueryFilters()
+}
+```
+
+**Consumers**: `AtoCopilotContext` (query filter closure), `TenantStampingSaveChangesInterceptor`.
+
+## TenantStampingSaveChangesInterceptor
+
+Intercepts `SaveChanges`/`SaveChangesAsync`. For every `Added` entity with a
+`TenantId` property, stamps `TenantId = ITenantContext.CurrentTenantId`.
+
+**Contract**: Must run before EF sends INSERT to database. Registered as
+`IInterceptor` in `AddDbContext`.
+
+## ApplyTenantQueryFilters (AtoCopilotContext)
+
+Called from `OnModelCreating`. Reflects every `DbSet<T>` type:
+
+```
+for each entity type T in context:
+  if T has [TenantScoped]:
+    apply HasQueryFilter(e => e.TenantId == _currentTenantId)
+  if T has [GlobalReference]:
+    skip (no filter)
+  if T has neither:
+    FAIL CI (RlsCoverageMatrix test catches this)
+```
+
+## Role Authorization (FR-026)
+
+Endpoints gated by `Compliance.AuthorizingOfficial` or `Compliance.Engineer`:
+
+| Endpoint | Method | Gate added by |
+|----------|--------|---------------|
+| `/systems/{systemId}/inheritance` | PUT | This epic (US2) |
+
+Role check pattern (match existing gated endpoints):
+
+```csharp
+var authResult = await authService.AuthorizeAsync(
+    user, null, new RolesAuthorizationRequirement(
+        new[] { "Compliance.AuthorizingOfficial", "Compliance.Engineer" }));
+if (!authResult.Succeeded)
+    return Results.Forbid();
+```
+
+## CrossTenant Test Fixture Contract
+
+```csharp
+// Two isolated tenants; each test seeds under tenantA, queries via tenantB
+public class TwoTenantFixture
+{
+    public AtoCopilotContext TenantAContext { get; }
+    public AtoCopilotContext TenantBContext { get; }
+}
+// Both use SQLite in-memory with separate TenantId GUIDs
+```

--- a/specs/057-rls-isolation-044-050/contracts/rls-predicates.md
+++ b/specs/057-rls-isolation-044-050/contracts/rls-predicates.md
@@ -1,0 +1,59 @@
+# RLS Predicates: Feature 044–050 Entity Coverage Matrix
+
+**Last verified**: 2026-06-03 against `main` branch at `/tmp/ato-copilot`
+
+## Legend
+
+| Column | Meaning |
+|--------|---------|
+| `[TenantScoped]` | Entity has the attribute; `HasQueryFilter` auto-applied |
+| `[GlobalReference]` | Entity is intentionally cross-tenant (CSP-owned) |
+| `TenantId col` | `Guid TenantId` property present on entity |
+| `HasQueryFilter` | Filter confirmed applied via `ApplyTenantQueryFilters` |
+| Action | What this epic does |
+
+## Coverage Matrix
+
+| Entity | Feature | `[TenantScoped]` | `[GlobalReference]` | TenantId col | HasQueryFilter | Action |
+|--------|---------|:----------------:|:-------------------:|:------------:|:--------------:|--------|
+| `OrgInheritanceDefault` | 044 | ✅ | — | ✅ | ✅ | None — already correct |
+| `InheritanceAuditEntry` | 044 | ✅ | — | ✅ | ✅ | None — already correct |
+| `SecurityCapability` | 045 | ✅ | — | ✅ | ✅ | None — already correct |
+| `CspInheritedComponent` | 046 | — | ✅ | — | N/A (intentional) | None — GlobalReference correct |
+| `CspInheritedCapability` | 046 | — | ✅ | — | N/A (intentional) | None — GlobalReference correct |
+| `CspProfile` | 046/047 | — | ✅ | — | N/A (intentional) | None — GlobalReference correct |
+| `GlobalBaseline` | 047 | — | ✅ | — | N/A (intentional) | None — GlobalReference correct |
+| `CapabilityHistoryEvent` | 048 | ✅ | — | ✅ | ✅ | None — already correct |
+| `SystemRoleAssignment` | 049 | ✅ | — | ✅ | ✅ | None — already correct |
+| `OrganizationRoleAssignment` | 049 | ✅ | — | ✅ | ✅ | None — already correct |
+| `TenantOnboardingState` | 050 | ✅ | — | ✅ | ✅ | None — already correct |
+| `OnboardingStepCompletion` | 050 | ✅ | — | ✅ | ✅ | None — already correct |
+
+## Summary
+
+- **8 tenant-scoped entities** — all correctly attributed, `TenantId` present,
+  `HasQueryFilter` auto-applied.
+- **4 global-reference entities** — intentionally cross-tenant, no filter needed.
+- **0 unattributed entities** in the 044–050 surface area.
+- **0 schema migrations** required.
+
+## RLS Predicate (applied by ApplyTenantQueryFilters)
+
+For every `[TenantScoped]` entity `T`:
+
+```csharp
+modelBuilder.Entity<T>().HasQueryFilter(e => e.TenantId == _currentTenantId);
+```
+
+`_currentTenantId` is resolved per HTTP request from `ITenantContext`,
+populated by `TenantStampingSaveChangesInterceptor` on all write paths.
+
+## GlobalReference Rationale
+
+| Entity | Why cross-tenant is correct |
+|--------|----------------------------|
+| `CspInheritedComponent` | Published once by CSP-Admin; all tenants read the same catalog |
+| `CspInheritedCapability` | Same as above — capability is attached to the shared component |
+| `CspProfile` | A compliance profile template applied across tenants |
+| `GlobalBaseline` | Published NIST/FedRAMP baseline consumed by all tenant systems |
+| `Tenant` | Root identity record — must be readable for tenant resolution itself |

--- a/specs/057-rls-isolation-044-050/data-model.md
+++ b/specs/057-rls-isolation-044-050/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: RLS Multi-Tenant Isolation for Features 044–050
+
+## Overview
+
+No new tables or columns are required by this epic. The audit confirms all
+044–050 entities are correctly attributed. This document describes the existing
+data model for the relevant entities and their isolation mechanism.
+
+## Isolation Mechanism
+
+```
+AtoCopilotContext.OnModelCreating
+  └── ApplyTenantQueryFilters()        ← reflection-driven, Feature 048
+        iterates every DbSet<T>
+        if T has [TenantScoped] → modelBuilder.Entity<T>()
+                                           .HasQueryFilter(e => e.TenantId == _currentTenantId)
+        if T has [GlobalReference] → no filter (intentional cross-tenant read)
+```
+
+`_currentTenantId` is injected per-request via `IHttpContextAccessor` /
+`ITenantContext` and stamped on writes by `TenantStampingSaveChangesInterceptor`.
+
+## Entity Classification (044–050)
+
+### [TenantScoped] Entities
+
+| Entity | File | TenantId column |
+|--------|------|-----------------|
+| `OrgInheritanceDefault` | `Models/Compliance/RmfModels.cs:718` | `Guid TenantId` |
+| `InheritanceAuditEntry` | `Models/Compliance/RmfModels.cs:789` | `Guid TenantId` |
+| `SecurityCapability` | `Models/Compliance/SecurityCapability.cs` | `Guid TenantId` |
+| `CapabilityHistoryEvent` | `Models/Tenancy/CapabilityHistoryEvent.cs` | `Guid TenantId` |
+| `SystemRoleAssignment` | `Models/Onboarding/SystemRoleAssignment.cs` | `Guid TenantId` |
+| `OrganizationRoleAssignment` | `Models/Onboarding/OrganizationRoleAssignment.cs` | `Guid TenantId` |
+| `TenantOnboardingState` | `Models/Onboarding/TenantOnboardingState.cs` | `Guid TenantId` |
+| `OnboardingStepCompletion` | `Models/Onboarding/OnboardingStepCompletion.cs` | `Guid TenantId` |
+
+### [GlobalReference] Entities (intentionally cross-tenant)
+
+| Entity | File | Rationale |
+|--------|------|-----------|
+| `CspInheritedComponent` | `Models/Tenancy/CspInheritedComponent.cs` | CSP-Admin owned; shared catalog |
+| `CspInheritedCapability` | `Models/Tenancy/CspInheritedCapability.cs` | CSP-Admin owned; shared catalog |
+| `CspProfile` | (Tenancy) | CSP-Admin owned profile |
+| `GlobalBaseline` | (Tenancy) | Published by CSP-Admin for all tenants |
+| `Tenant` | (Tenancy) | Root tenant identity record |
+
+## No Schema Changes Required
+
+All `TenantId` columns exist. No EF migration is needed for this epic.
+The `EnsureSchemaAdditions` DDL scripts that use `ExecuteSqlRawAsync` are
+schema-creation helpers, not query paths, and are not affected by `HasQueryFilter`.

--- a/specs/057-rls-isolation-044-050/plan.md
+++ b/specs/057-rls-isolation-044-050/plan.md
@@ -1,0 +1,41 @@
+# Plan: RLS Multi-Tenant Isolation for Features 044–050
+
+## Sequencing
+
+```
+Week 1
+├── T1.1  Verify coverage matrix + update contracts/rls-predicates.md     [0.5d]
+├── T1.2  RlsCoverageMatrix xUnit test                                     [1d]
+├── T1.3  CI raw-SQL lint step                                             [0.5d]
+├── T2.1  FR-026 grep sweep to confirm scope                               [0.25d]
+└── T2.2  Implement role gate on PUT /inheritance                          [1d]
+
+Week 2
+├── T2.3  Integration tests for FR-026 RBAC gate                          [1d]
+├── T3.1  Test fixture setup (two-tenant WebApplicationFactory)            [1d]
+├── T3.2  CrossTenantIsolationTests (8 entity rows)                        [2d]
+└── T4.1  PR review                                                        [0.5d]
+```
+
+## Dependencies
+
+- `RlsCoverageMatrix` test (T1.2) depends on T1.1 being complete so the
+  expected entity list is finalized.
+- `CrossTenantIsolationTests` (T3.2) depend on T3.1 fixture setup.
+- All tests must pass before PR merge (T4.1).
+
+## Risk
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| New entity added during sprint without `[TenantScoped]` | Low | T1.2 CI test catches it |
+| Role-check pattern differs per endpoint | Low | Grep existing AO-gated endpoints first |
+| SQLite in-memory doesn't reflect `HasQueryFilter` | Very Low | Pattern proven in existing tests |
+
+## Success Criteria
+
+- [ ] `contracts/rls-predicates.md` committed and accurate
+- [ ] `RlsCoverageMatrix` test passes CI
+- [ ] `TODO(FR-026)` removed; `PUT /inheritance` returns 403 for unauth users
+- [ ] 8-row `CrossTenantIsolationTests` pass CI
+- [ ] Raw SQL lint step added to CI

--- a/specs/057-rls-isolation-044-050/quickstart.md
+++ b/specs/057-rls-isolation-044-050/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: RLS Multi-Tenant Isolation for Features 044–050
+
+## Prerequisites
+
+- .NET 8 SDK
+- Access to `/tmp/ato-copilot` repo (already cloned)
+- Existing test project: `Ato.Copilot.Core.Tests`
+
+## Run existing tests
+
+```bash
+cd /tmp/ato-copilot
+dotnet test src/Ato.Copilot.Core.Tests/ --no-build --logger "console;verbosity=minimal"
+```
+
+## Verify RLS attribute coverage (manual)
+
+```bash
+# Should show [TenantScoped] for all 8 entities listed in data-model.md
+grep -rn '\[TenantScoped\]\|\[GlobalReference\]' \
+  src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs \
+  src/Ato.Copilot.Core/Models/Compliance/SecurityCapability.cs \
+  src/Ato.Copilot.Core/Models/Onboarding/ \
+  src/Ato.Copilot.Core/Models/Tenancy/CapabilityHistoryEvent.cs
+```
+
+## Verify no query-path raw SQL
+
+```bash
+grep -rn 'FromSqlRaw\|ExecuteSqlRaw\|FromSqlInterpolated' \
+  src/Ato.Copilot.Core/ | grep -v 'Migrations/'
+# Expected: no output
+```
+
+## Find the FR-026 TODO
+
+```bash
+grep -rn 'TODO(FR-026)' src/
+# Expected: DashboardEndpoints.cs:7098
+```
+
+## Add the role gate (US2)
+
+1. Find existing role-check pattern:
+   ```bash
+   grep -n 'AuthorizingOfficial' src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs | head -5
+   ```
+2. Replicate that pattern at line 7098, before the `MapPut` handler body.
+3. Remove the `TODO(FR-026)` comment.
+4. Run integration tests to verify 403 behavior.
+
+## Add cross-tenant isolation tests (US3)
+
+Create `src/Ato.Copilot.Integration.Tests/CrossTenantIsolationTests.cs`:
+
+```csharp
+[Theory]
+[InlineData(typeof(OrgInheritanceDefault))]
+[InlineData(typeof(SecurityCapability))]
+// ... 6 more entity types
+public async Task Entity_IsNotVisibleAcrossTenants(Type entityType)
+{
+    // Arrange: seed one record under TenantA
+    // Act: query via TenantB context
+    // Assert: result is empty
+}
+```
+
+## Run all tests
+
+```bash
+dotnet test src/ --filter "Category=RLS" --logger "console;verbosity=normal"
+```

--- a/specs/057-rls-isolation-044-050/research.md
+++ b/specs/057-rls-isolation-044-050/research.md
@@ -1,0 +1,96 @@
+# Research: RLS Multi-Tenant Isolation for Features 044–050
+
+## Methodology
+
+All findings below were obtained by grep/sed against the current `main` branch
+at `/tmp/ato-copilot/src/`. No assumptions were made beyond the verified facts
+enumerated here.
+
+## Entity Attribute Audit
+
+### Commands run
+
+```bash
+# OrgInheritanceDefault
+grep -n 'TenantScoped\|GlobalReference\|class OrgInheritanceDefault' \
+  src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs
+# → Line 718: [TenantScoped] immediately precedes class OrgInheritanceDefault
+
+# SecurityCapability
+grep -n '\[TenantScoped\]\|\[GlobalReference\]' \
+  src/Ato.Copilot.Core/Models/Compliance/SecurityCapability.cs
+# → Line 10: [TenantScoped]
+
+# SystemRoleAssignment
+grep -n '\[TenantScoped\]\|\[GlobalReference\]' \
+  src/Ato.Copilot.Core/Models/Onboarding/SystemRoleAssignment.cs
+# → Line 11: [TenantScoped]
+
+# OrganizationRoleAssignment
+grep -n '\[TenantScoped\]\|\[GlobalReference\]' \
+  src/Ato.Copilot.Core/Models/Onboarding/OrganizationRoleAssignment.cs
+# → Line 9: [TenantScoped]
+
+# CapabilityHistoryEvent
+grep -n '\[TenantScoped\]\|\[GlobalReference\]' \
+  src/Ato.Copilot.Core/Models/Tenancy/CapabilityHistoryEvent.cs
+# → Line 27: [TenantScoped]
+```
+
+**Result: All 044–050 entities correctly attributed. Zero gaps found.**
+
+## Raw SQL Audit
+
+### Command run
+
+```bash
+grep -rn 'FromSqlRaw\|ExecuteSqlRaw\|FromSqlInterpolated' \
+  src/Ato.Copilot.Core/ 2>/dev/null | grep -v '/obj/'
+```
+
+### Results
+
+All occurrences are in `EnsureSchemaAdditions` migration helpers:
+
+| File | Context |
+|------|---------|
+| `AuditLogTenantAttributionAdditions.cs` | DDL: CREATE TABLE / ALTER TABLE |
+| `CapabilityHistoryEventsSchemaAdditions.cs` | DDL: CREATE TABLE |
+| `GlobalBaselineSchemaAdditions.cs` | DDL: CREATE TABLE |
+
+**Conclusion**: Zero `FromSqlRaw`/`FromSqlInterpolated` calls in query paths.
+`HasQueryFilter` is not bypassed anywhere in non-DDL code.
+
+## TODO(FR-026) Analysis
+
+```bash
+sed -n '7090,7110p' src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+```
+
+Output (line 7098):
+```
+// TODO(FR-026): Add role validation — restrict writes to AO and Security Engineer roles
+//   when auth context is available. Return 403 Forbidden for unauthorized users.
+group.MapPut("/systems/{systemId}/inheritance", async (
+    string systemId,
+    Feature043SetInheritanceRequest req,
+    IBaselineService baselineService,
+    AtoCopilotContext context,
+    CancellationToken ct) =>
+```
+
+This is the `PUT /systems/{systemId}/inheritance` endpoint. It lacks role gate.
+The comment documents the intended fix. No other FR-026 TODOs were found.
+
+## Role Gate Pattern (existing)
+
+To be consistent, the FR-026 fix should follow the role-check pattern used by
+other protected endpoints. The implementer should search for
+`Compliance.AuthorizingOfficial` in `DashboardEndpoints.cs` to find the
+existing pattern to replicate.
+
+## References
+
+- Feature 048 spec: `specs/048-tenant-isolation/`
+- `AtoCopilotContext.cs`: `src/Ato.Copilot.Core/Data/AtoCopilotContext.cs`
+- `TenantStampingSaveChangesInterceptor`: search codebase for class name

--- a/specs/057-rls-isolation-044-050/spec.md
+++ b/specs/057-rls-isolation-044-050/spec.md
@@ -1,0 +1,188 @@
+# Feature Specification: RLS Multi-Tenant Isolation for Features 044–050
+
+**Feature Branch**: `057-rls-isolation-044-050`
+**Created**: 2026-06-03
+**Status**: Draft
+**GitHub Issue**: #125
+**Builds on**: Feature 048 (Tenant Isolation) — which established the
+`[TenantScoped]` / `[GlobalReference]` attribute pattern and the reflection-driven
+`ApplyTenantQueryFilters` method in `AtoCopilotContext.cs`.
+
+## Background
+
+Feature 048 delivered a reflection-driven, zero-boilerplate RLS mechanism:
+`AtoCopilotContext.ApplyTenantQueryFilters` iterates every EF entity type at
+startup and auto-attaches a `HasQueryFilter(e => e.TenantId == _currentTenantId)`
+predicate to any entity marked `[TenantScoped]`. As of today 109 entities carry
+that attribute. `[GlobalReference]` marks entities that are intentionally
+cross-tenant (CSP-owned shared data: `CspInheritedComponent`,
+`CspInheritedCapability`, `CspProfile`, `GlobalBaseline`, `Tenant`).
+
+Features 044–050 shipped new entities after Feature 048 landed. This epic closes
+the gap: audit every entity introduced by those features, confirm correct
+attribution, fix any omissions, and add RBAC gates that were left as `TODO`.
+
+### Verified state of the code (current `main`)
+
+1. **Feature 044 — Org-Level Inheritance Defaults**
+   - `OrgInheritanceDefault` (RmfModels.cs:718): **`[TenantScoped]` ✅** —
+     has `TenantId` property populated by `TenantStampingSaveChangesInterceptor`.
+   - `InheritanceAuditEntry` (RmfModels.cs:789): **`[TenantScoped]` ✅**
+
+2. **Feature 045 — Security Capabilities**
+   - `SecurityCapability` (SecurityCapability.cs:10): **`[TenantScoped]` ✅**
+
+3. **Feature 046 — CSP-Inherited Components/Capabilities (read surface)**
+   - `CspInheritedComponent`: **`[GlobalReference]` ✅** — intentional, CSP-Admin owned
+   - `CspInheritedCapability`: **`[GlobalReference]` ✅** — intentional
+
+4. **Feature 047 — Global Baseline**
+   - `GlobalBaseline`: **`[GlobalReference]` ✅** — shared across tenants by design
+
+5. **Feature 048 — Tenant Isolation & Capability History**
+   - `CapabilityHistoryEvent` (Tenancy/CapabilityHistoryEvent.cs:27):
+     **`[TenantScoped]` ✅**
+
+6. **Feature 049 — System Role Assignments**
+   - `SystemRoleAssignment` (Onboarding/SystemRoleAssignment.cs:11):
+     **`[TenantScoped]` ✅**
+   - `OrganizationRoleAssignment` (Onboarding/OrganizationRoleAssignment.cs:9):
+     **`[TenantScoped]` ✅**
+
+7. **Feature 050 — Onboarding**
+   - `TenantOnboardingState`: **`[TenantScoped]` ✅**
+   - `OnboardingStepCompletion`: **`[TenantScoped]` ✅**
+
+8. **Raw SQL** — `ExecuteSqlRawAsync` calls appear only in
+   `EnsureSchemaAdditions` migration helpers (DDL schema creation scripts), not
+   in query paths. These do not bypass `HasQueryFilter` because they are DDL,
+   not read queries. **No query-path raw SQL found.**
+
+9. **TODO(FR-026) RBAC gap** — `DashboardEndpoints.cs` line 7098:
+   `PUT /systems/{systemId}/inheritance` lacks AO/Engineer role gate.
+   Comment reads: _"Add role validation — restrict writes to AO and Security
+   Engineer roles when auth context is available. Return 403 Forbidden for
+   unauthorized users."_ This is the sole verified RBAC gap for this wave.
+
+### Summary
+
+The `[TenantScoped]` audit across 044–050 finds **zero missing annotations**.
+All new entities are correctly attributed. The only actionable work is:
+
+- **US2**: Close the FR-026 RBAC gap on inheritance write endpoints.
+- **US3**: Codify the existing isolation as integration tests so regressions are
+  caught automatically.
+- **US4**: Document and confirm that raw SQL is DDL-only (no query bypass risk).
+
+## Clarifications
+
+- **Q: Does any Feature 044–050 entity need a new `[TenantScoped]` annotation?**
+  **A:** No. All entities verified correct per current `main`. No migration needed.
+
+- **Q: What roles should guard inheritance write endpoints (FR-026)?**
+  **A:** `Compliance.AuthorizingOfficial` and `Compliance.Engineer` — consistent
+  with other write-path role gates in the codebase.
+
+- **Q: Should raw SQL migration helpers be wrapped with TenantId predicates?**
+  **A:** No. They are DDL schema additions (CREATE TABLE / ALTER TABLE), not data
+  reads. HasQueryFilter operates at the EF query layer and is not relevant to DDL.
+
+- **Q: What is the test contract for cross-tenant isolation?**
+  **A:** Two tenants (A, B) created in test setup; tenant A creates a record;
+  tenant B's DbContext must return empty when querying the same entity type.
+  Tests use `WebApplicationFactory` with per-request tenant injection.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Verified RLS coverage matrix for 044–050 (Priority: P1)
+
+**As a** Security Engineer or auditor reviewing the ATO Copilot codebase
+**I want** a machine-verifiable record of every entity's isolation classification
+for Features 044–050
+**So that** I can confirm compliance requirements are met without reading raw source.
+
+**Why this priority**: P1 because the audit is a prerequisite for all other
+stories and for the ATO package. It closes the loop on the Feature 048
+gap-assessment promise.
+
+**Independent Test**: `RlsCoverageMatrixTest` — a reflection-based xUnit test
+that loads every `DbSet<T>` from `AtoCopilotContext`, asserts that every entity
+listed in `contracts/rls-predicates.md` as `[TenantScoped]` carries that
+attribute, and asserts that every entity listed as `[GlobalReference]` carries
+that attribute. Test fails CI if a future PR adds a new entity without one of
+the two attributes.
+
+**Acceptance**
+- `contracts/rls-predicates.md` is committed and contains every 044–050 entity.
+- A reflection-based xUnit test (`RlsCoverageMatrix`) in
+  `Ato.Copilot.Core.Tests` passes on CI.
+- The test asserts: every entity in `AtoCopilotContext` must have exactly one of
+  `[TenantScoped]` or `[GlobalReference]` (no unattributed entities).
+
+### User Story 2 — FR-026 RBAC gate on inheritance write endpoints (Priority: P1)
+
+**As an** ATO Copilot platform operator
+**I want** `PUT /systems/{systemId}/inheritance` (and any other 044–050 write
+endpoints lacking role gates) restricted to `Compliance.AuthorizingOfficial` and
+`Compliance.Engineer`
+**So that** only authorised roles can modify compliance-critical inheritance
+designations.
+
+**Why this priority**: P1 — this is a verified open TODO in the codebase with a
+clear security implication: any authenticated user can currently write
+inheritance designations.
+
+**Independent Test**: Integration test with three token scenarios:
+1. AO token → `200 OK`
+2. Engineer token → `200 OK`
+3. Read-only user token → `403 Forbidden`
+
+**Acceptance**
+- The `TODO(FR-026)` comment is removed and replaced with the role-check
+  implementation.
+- `PUT /systems/{systemId}/inheritance` returns `403` for users without
+  `Compliance.AuthorizingOfficial` or `Compliance.Engineer`.
+- No other 044–050 write endpoints have analogous TODOs (confirmed by grep
+  sweep in `tasks.md`).
+
+### User Story 3 — Cross-tenant isolation integration tests for 044–050 entities (Priority: P2)
+
+**As a** developer shipping new features
+**I want** integration tests that assert User A cannot read User B's tenant data
+for each 044–050 entity type
+**So that** regressions in the `HasQueryFilter` pipeline are caught by CI before
+they reach production.
+
+**Why this priority**: P2 — isolation is already implemented; tests formalise the
+guarantee. Standalone value: tests can be added without touching production code.
+
+**Independent Test**: Each entity has its own `[Theory]` row; all run in CI.
+If `ApplyTenantQueryFilters` reflection is broken for one type, only that row
+fails, making root-cause obvious.
+
+**Acceptance**
+- One integration test project (`Ato.Copilot.Integration.Tests`) test class
+  `CrossTenantIsolationTests` with one `[Theory]` row per 044–050 entity type.
+- Each row: (1) seed a record under Tenant A, (2) query via Tenant B's
+  `AtoCopilotContext`, (3) assert empty result set.
+- All rows pass on CI (SQLite in-memory provider).
+
+### User Story 4 — Raw SQL audit and documentation (Priority: P2)
+
+**As a** Security Engineer
+**I want** a documented audit confirming that no query-path `ExecuteSqlRaw`/
+`FromSqlRaw`/`FromSqlInterpolated` calls bypass `HasQueryFilter`
+**So that** the RLS guarantee is complete and auditors have evidence.
+
+**Why this priority**: P2 — no bypass found; the work is documentation and a
+lint rule to keep it that way.
+
+**Independent Test**: A Roslyn analyser rule (or grep-based CI step) fails the
+build if any new `FromSqlRaw`/`FromSqlInterpolated` is added outside the
+`Migrations` namespace without a `// rls-exempt:` comment explaining why.
+
+**Acceptance**
+- `research.md` documents the full grep results confirming DDL-only raw SQL.
+- A CI lint step (shell script or Roslyn) is added to `azure-pipelines.yml`
+  (or equivalent) that enforces the exempt-comment convention.
+- Existing migration uses are whitelisted.

--- a/specs/057-rls-isolation-044-050/tasks.md
+++ b/specs/057-rls-isolation-044-050/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: RLS Multi-Tenant Isolation for Features 044–050
+
+## Phase 1 — Audit & Documentation (US1, US4)
+
+### T1.1 — Verify RLS coverage matrix
+- [ ] Run reflection-grep script across all `Models/` dirs for 044–050 features
+- [ ] Confirm each entity in `contracts/rls-predicates.md` is correct
+- [ ] Document raw SQL audit in `research.md`
+- **Owner**: Backend engineer
+- **Estimate**: 0.5d
+
+### T1.2 — Write `RlsCoverageMatrix` xUnit test
+- [ ] Add `RlsCoverageMatrixTest.cs` to `Ato.Copilot.Core.Tests`
+- [ ] Use reflection to iterate `AtoCopilotContext` `DbSet<T>` types
+- [ ] Assert every type has exactly one of `[TenantScoped]` or `[GlobalReference]`
+- [ ] Run `dotnet test` to confirm green
+- **Owner**: Backend engineer
+- **Estimate**: 1d
+
+### T1.3 — Add CI raw-SQL lint step (US4)
+- [ ] Add grep-based script to CI pipeline: fail if `FromSqlRaw|FromSqlInterpolated`
+  appears outside `Migrations` namespace without `// rls-exempt:` comment
+- [ ] Whitelist existing migration uses
+- **Owner**: DevOps / backend engineer
+- **Estimate**: 0.5d
+
+## Phase 2 — FR-026 RBAC Gate (US2)
+
+### T2.1 — Grep sweep for any remaining FR-026 TODOs
+- [ ] `grep -rn 'TODO(FR-026)' /tmp/ato-copilot/src/` — confirm scope
+- **Owner**: Backend engineer
+- **Estimate**: 0.25d
+
+### T2.2 — Implement role gate on `PUT /systems/{systemId}/inheritance`
+- [ ] Resolve `IAuthorizationService` or middleware pattern used by other gated
+  endpoints (search for `Compliance.AuthorizingOfficial` usage in codebase)
+- [ ] Add role check before the handler body; return `403` with `ErrorResponse`
+  shape on failure
+- [ ] Remove `TODO(FR-026)` comment
+- **Owner**: Backend engineer
+- **Estimate**: 1d
+
+### T2.3 — Integration tests for FR-026 gate (US2)
+- [ ] Add `InheritanceRbacTests.cs` to integration test project
+- [ ] Three scenarios: AO → 200, Engineer → 200, read-only → 403
+- **Owner**: Backend engineer
+- **Estimate**: 1d
+
+## Phase 3 — Cross-Tenant Isolation Tests (US3)
+
+### T3.1 — Set up test infrastructure
+- [ ] Confirm `WebApplicationFactory` pattern in existing integration tests
+- [ ] Create `TenantScopedTestFixture` that provisions two in-memory tenants
+- **Owner**: Backend engineer
+- **Estimate**: 1d
+
+### T3.2 — Write `CrossTenantIsolationTests`
+- [ ] One `[Theory]` row per entity in the 044–050 coverage matrix that is `[TenantScoped]`:
+  - `OrgInheritanceDefault`
+  - `InheritanceAuditEntry`
+  - `SecurityCapability`
+  - `CapabilityHistoryEvent`
+  - `SystemRoleAssignment`
+  - `OrganizationRoleAssignment`
+  - `TenantOnboardingState`
+  - `OnboardingStepCompletion`
+- [ ] Each row: seed under Tenant A, query via Tenant B, assert empty
+- **Owner**: Backend engineer
+- **Estimate**: 2d
+
+## Phase 4 — Review & Merge
+
+### T4.1 — PR review checklist
+- [ ] All tests pass CI
+- [ ] `contracts/rls-predicates.md` accurately reflects final state
+- [ ] `TODO(FR-026)` removed from codebase
+- [ ] `research.md` documents raw SQL audit findings
+- **Owner**: Lead / reviewer
+- **Estimate**: 0.5d
+
+## Total Estimate: ~7 days

--- a/specs/058-dead-routes-fix/checklists/requirements.md
+++ b/specs/058-dead-routes-fix/checklists/requirements.md
@@ -1,0 +1,56 @@
+# Requirements Checklist: Fix Dead Routes
+
+## Functional Requirements
+
+### FR-DR-01: Catch-all 404 page
+- [ ] `<Route path="*">` is the last route in `App.tsx`
+- [ ] `NotFoundPage` component exists and renders within authenticated shell
+- [ ] Page includes navigation back to dashboard (`/`)
+- [ ] Unauthenticated users hitting unknown routes are redirected to `/login`
+  (handled by `RequireAuth`, no additional change needed)
+
+### FR-DR-02: `/csp-dashboard` redirect
+- [ ] `<Route path="/csp-dashboard">` redirects to `/csp/inherited-components`
+- [ ] Redirect uses `replace` (no extra browser history entry)
+- [ ] `TenantPickerPage.tsx` CSP-Admin navigation updated to correct path
+
+### FR-DR-03: `/systems/:id/gaps` route
+- [ ] `<Route path="gaps">` inside `/systems/:id` block
+- [ ] `GapsPage` component fetches from backend and renders gap data
+- [ ] Chat context `'gap-analysis'` suggestions active on this route
+- [ ] Loading and empty states handled
+
+### FR-DR-04: No remaining hardcoded stale routes
+- [ ] No live `navigate('/csp-dashboard')` in codebase
+- [ ] No live `navigate('/csp/dashboard')` (incorrect path) in codebase
+- [ ] No `<Link to="/csp-dashboard">` in codebase
+- [ ] CI grep assertion added
+
+## Test Requirements
+
+### TR-01: NotFoundPage test
+- [ ] Browser/Playwright test: unknown URL → NotFoundPage renders
+- [ ] "Go to Dashboard" link navigates to `/`
+
+### TR-02: Redirect test
+- [ ] Browser test: `/csp-dashboard` → final URL is `/csp/inherited-components`
+
+### TR-03: GapsPage test
+- [ ] Unit test: GapsPage renders with mocked API response
+- [ ] Chat context test: `useChatContext` returns `'gap-analysis'` on `/systems/x/gaps`
+
+### TR-04: CI lint test
+- [ ] Grep assertion for stale routes passes after fixes
+- [ ] Grep assertion would have caught TenantPickerPage.tsx:88 bug (verified manually)
+
+## Non-Functional Requirements
+
+- [ ] No backend changes required
+- [ ] No new npm packages (use existing `react-router-dom` `Navigate` component)
+- [ ] GapsPage bundle size impact acceptable (lazy-load if needed)
+
+## Out of Scope
+
+- Full gap-analysis page design/polish (US3 delivers basic functional page)
+- Portfolio legacy API migration (`/systems` endpoint, `getPortfolioLegacy`)
+- Backend route changes

--- a/specs/058-dead-routes-fix/contracts/router-contracts.md
+++ b/specs/058-dead-routes-fix/contracts/router-contracts.md
@@ -1,0 +1,78 @@
+# Router Contracts: Fix Dead Routes
+
+**Last updated**: 2026-06-03
+**Source of truth**: `App.tsx` in `src/Ato.Copilot.Dashboard/src/`
+
+## Complete Route Table (post-fix)
+
+| Path | Component | Auth | Notes |
+|------|-----------|------|-------|
+| `/login` | `LoginPage` | Public | |
+| `/login/callback` | `LoginCallbackPage` | Public | OAuth callback |
+| `/login/error` | Login error view | Public | |
+| `/login/select-tenant` | `TenantPickerPage` | RequireAuth | |
+| `/` | `PortfolioRoute` | RequireAuth | CSP-Admins see CSP surface |
+| `/systems` | `SystemsRoute` | RequireAuth | |
+| `/systems/:id` | `SystemLayout` | RequireAuth | Nested routes below |
+| `/systems/:id/` (index) | `SystemDetail` | RequireAuth | |
+| `/systems/:id/roadmap` | `Roadmap` | RequireAuth | |
+| `/systems/:id/boundaries` | `BoundaryManagement` | RequireAuth | |
+| `/systems/:id/legal` | `LegalRegulatory` | RequireAuth | |
+| `/systems/:id/documents` | `Documents` | RequireAuth | |
+| `/systems/:id/conmon` | `ConMon` | RequireAuth | |
+| `/systems/:id/narratives` | `Narratives` | RequireAuth | |
+| `/systems/:id/deviations` | `DeviationsPage` | RequireAuth | |
+| `/systems/:id/assessments` | `Assessments` | RequireAuth | |
+| `/systems/:id/remediation` | `Remediation` | RequireAuth | |
+| `/systems/:id/evidence` | `EvidenceRepository` | RequireAuth | |
+| `/systems/:id/components` | `ComponentInventory` | RequireAuth | |
+| `/systems/:id/poam` | `PoamManagement` | RequireAuth | |
+| `/systems/:id/capability-coverage` | `CapabilityCoverage` | RequireAuth | |
+| `/systems/:id/inheritance` | `ControlInheritance` | RequireAuth | |
+| `/systems/:id/baseline` | `BaselineManagement` | RequireAuth | |
+| `/systems/:id/profile/:sectionType` | `SystemProfile` | RequireAuth | |
+| `/systems/:id/gaps` | `GapsPage` | RequireAuth | **NEW — US3** |
+| `/capabilities` | `CapabilitiesRoute` | RequireAuth | |
+| `/components` | `ComponentsRoute` | RequireAuth | |
+| `/onboarding` | `OnboardingShell` | RequireAuth | |
+| `/onboarding/tenant` | `TenantWizard` | RequireAuth | |
+| `/onboarding/csp` | `CspWizard` | RequireAuth | |
+| `/csp/inherited-components` | `CspInheritedComponentsPage` | RequireAuth | Current CSP-Admin surface |
+| `/admin/imported-documents` | `ImportedDocumentsView` | RequireAuth | |
+| `/controls` | `ControlsRoute` | RequireAuth | |
+| `/csp-dashboard` | `Navigate` → `/csp/inherited-components` | — | **NEW — US2 (retired route redirect)** |
+| `*` | `NotFoundPage` | RequireAuth | **NEW — US1 (catch-all, MUST be last)** |
+
+## Redirects
+
+| From | To | Type | Reason |
+|------|----|------|--------|
+| `/csp-dashboard` | `/csp/inherited-components` | `replace` (no history entry) | Route retired in Feature 048 |
+
+## Retired Routes
+
+| Path | Retired in | Replacement |
+|------|------------|-------------|
+| `/csp-dashboard` | Feature 048 | `/csp/inherited-components` |
+
+## Chat Context Mappings (useChatContext.ts)
+
+| URL pattern (pathname.includes) | Chat page key | Suggestions source |
+|----------------------------------|--------------|-------------------|
+| `/gaps` | `gap-analysis` | `phasePageSuggestions.ts:265` |
+| _(others unchanged)_ | | |
+
+## 404 Page Contract
+
+- Component: `NotFoundPage`
+- Renders: within authenticated shell (RequireAuth)
+- Content: "Page not found" `<h1>`, brief message, `<Link to="/">Go to Dashboard</Link>`
+- Unauthenticated access: `RequireAuth` redirects to `/login` before `NotFoundPage` renders
+
+## CSP-Admin Navigation (TenantPickerPage)
+
+After fix:
+```tsx
+// Line 88 — CSP-Admin post-login navigation
+navigate('/csp/inherited-components', { replace: true });
+```

--- a/specs/058-dead-routes-fix/data-model.md
+++ b/specs/058-dead-routes-fix/data-model.md
@@ -1,0 +1,101 @@
+# Data Model: Fix Dead Routes
+
+## Overview
+
+This epic introduces no database schema changes. All changes are in the React
+frontend router configuration and component tree.
+
+## Router Changes
+
+### Current Route Tree (App.tsx, simplified)
+
+```
+<Routes>
+  /login                          → LoginPage
+  /login/callback                 → LoginCallbackPage
+  /login/error                    → LoginErrorPage
+  /login/select-tenant            → TenantPickerPage
+  /                               → PortfolioRoute
+  /systems                        → SystemsRoute
+  /systems/:id                    → SystemLayout
+    index                         → SystemDetail
+    roadmap                       → Roadmap
+    boundaries                    → BoundaryManagement
+    legal                         → LegalRegulatory
+    documents                     → Documents
+    conmon                        → ConMon
+    narratives                    → Narratives
+    deviations                    → DeviationsPage
+    assessments                   → Assessments
+    remediation                   → Remediation
+    evidence                      → EvidenceRepository
+    components                    → ComponentInventory
+    poam                          → PoamManagement
+    capability-coverage           → CapabilityCoverage
+    inheritance                   → ControlInheritance
+    baseline                      → BaselineManagement
+    profile/:sectionType          → SystemProfile
+  /capabilities                   → CapabilitiesRoute
+  /components                     → ComponentsRoute
+  /onboarding                     → OnboardingShell
+  /onboarding/tenant              → TenantWizard
+  /onboarding/csp                 → CspWizard
+  /csp/inherited-components       → CspInheritedComponentsPage
+  /admin/imported-documents       → ImportedDocumentsView
+  /controls                       → ControlsRoute
+  [NO CATCH-ALL — blank screen]
+</Routes>
+```
+
+### Target Route Tree (after this epic)
+
+```
+<Routes>
+  ... (all existing routes unchanged) ...
+  /systems/:id
+    ... (existing nested routes) ...
+    gaps                          → GapsPage              ← NEW (US3)
+  /csp-dashboard                  → Navigate /csp/inherited-components  ← NEW (US2)
+  /csp/inherited-components       → CspInheritedComponentsPage
+  ... (other existing routes) ...
+  *                               → NotFoundPage          ← NEW (US1, MUST BE LAST)
+</Routes>
+```
+
+## New Components
+
+### `NotFoundPage`
+
+```
+src/pages/NotFoundPage.tsx
+  - Renders inside authenticated shell (RequireAuth wraps it in App.tsx)
+  - Props: none
+  - State: none
+  - Links to: /
+```
+
+### `GapsPage`
+
+```
+src/features/gaps/GapsPage.tsx   (or src/pages/GapsPage.tsx)
+  - Reads systemId from useParams()
+  - Calls: GET /api/dashboard/systems/:systemId/gaps
+  - Renders: list of control gaps with status/severity
+  - Chat context: 'gap-analysis' key automatically mapped by useChatContext.ts
+```
+
+## Navigation Fix: TenantPickerPage
+
+```
+src/features/auth/TenantPickerPage.tsx
+  Line 88: navigate('/csp/dashboard') → navigate('/csp/inherited-components')
+  Line 20: update comment to reflect correct path
+```
+
+## Backend Endpoints Referenced (no changes)
+
+| Endpoint | Method | Handler |
+|----------|--------|---------|
+| `/api/dashboard/systems/{systemId}/gaps` | GET | `GetGapAnalysis` (DashboardEndpoints.cs:404) |
+
+Backend requires no changes.

--- a/specs/058-dead-routes-fix/plan.md
+++ b/specs/058-dead-routes-fix/plan.md
@@ -1,0 +1,49 @@
+# Plan: Fix Dead Routes
+
+## Sequencing
+
+US1 (404 page) and US2 (CSP redirect) are independent and can be done in parallel.
+US3 (gaps route) requires a new component; more work but also independent.
+US4 (stale audit) should complete after US2 fixes the main instances.
+
+```
+Day 1
+├── T1.1  Create NotFoundPage component                 [0.5d]
+├── T1.2  Wire catch-all in App.tsx                     [0.25d]
+├── T2.1  Add /csp-dashboard redirect in App.tsx        [0.25d]
+└── T2.2  Fix TenantPickerPage.tsx:88                   [0.25d]
+
+Day 2
+├── T1.3  Test 404 page                                  [0.5d]
+├── T2.3  Grep sweep for remaining stale links           [0.25d]
+├── T2.4  Test redirect                                  [0.25d]
+└── T3.1  Begin GapsPage component (backend call + UI)  [2d starts]
+
+Day 3–4
+├── T3.1  GapsPage component (continued)
+├── T3.2  Wire gaps route                                [0.25d]
+└── T3.3  Verify chat context integration                [0.25d]
+
+Day 5
+├── T3.4  Test GapsPage                                  [0.5d]
+├── T4.1  Update contracts/router-contracts.md           [0.5d]
+├── T4.2  CI grep assertion for stale links              [0.25d]
+└── T5.1  PR review                                      [0.5d]
+```
+
+## Risk
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| GapsPage design unclear | Medium | Use existing system sub-page layout pattern |
+| Other stale links found in grep sweep | Low | Fix in T2.3 before PR merge |
+| RequireAuth wrapping for 404 shows login for public URLs | Low | Confirm RequireAuth redirect behavior; unauthenticated users already redirect to /login |
+
+## Success Criteria
+
+- [ ] Navigating to any unknown URL shows NotFoundPage, not blank screen
+- [ ] Navigating to `/csp-dashboard` lands on `/csp/inherited-components`
+- [ ] `TenantPickerPage` CSP-Admin flow navigates to `/csp/inherited-components`
+- [ ] `/systems/:id/gaps` renders GapsPage with backend data
+- [ ] No live `navigate('/csp-dashboard')` or `navigate('/csp/dashboard')` in codebase
+- [ ] `contracts/router-contracts.md` is authoritative and current

--- a/specs/058-dead-routes-fix/quickstart.md
+++ b/specs/058-dead-routes-fix/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart: Fix Dead Routes
+
+## Prerequisites
+
+- Node.js 20+, pnpm (or npm)
+- Repo at `/tmp/ato-copilot`
+
+## Install & run frontend
+
+```bash
+cd /tmp/ato-copilot/src/Ato.Copilot.Dashboard
+pnpm install
+pnpm dev
+# App at http://localhost:5173
+```
+
+## Verify dead routes (before fix)
+
+```bash
+# Open browser to http://localhost:5173/csp-dashboard
+# Expected BEFORE fix: blank white screen
+# Expected AFTER fix:  redirects to /csp/inherited-components
+
+# Open browser to http://localhost:5173/this-does-not-exist
+# Expected BEFORE fix: blank white screen
+# Expected AFTER fix:  NotFoundPage rendered
+
+# Open browser to http://localhost:5173/systems/any-id/gaps
+# Expected BEFORE fix: blank white screen
+# Expected AFTER fix:  GapsPage rendered (or loading state)
+```
+
+## Implement US1 — 404 page
+
+1. Create `src/pages/NotFoundPage.tsx`:
+   ```tsx
+   import { Link } from 'react-router-dom';
+   export default function NotFoundPage() {
+     return (
+       <div>
+         <h1>Page not found</h1>
+         <p>The page you're looking for doesn't exist.</p>
+         <Link to="/">Go to Dashboard</Link>
+       </div>
+     );
+   }
+   ```
+2. In `App.tsx`, add as last route:
+   ```tsx
+   <Route path="*" element={<RequireAuth><NotFoundPage /></RequireAuth>} />
+   ```
+
+## Implement US2 — CSP redirect
+
+In `App.tsx`, add before the catch-all:
+```tsx
+import { Navigate } from 'react-router-dom'; // already imported
+<Route path="/csp-dashboard" element={<Navigate to="/csp/inherited-components" replace />} />
+```
+
+In `TenantPickerPage.tsx` line 88:
+```tsx
+// Before:
+navigate('/csp/dashboard', { replace: true });
+// After:
+navigate('/csp/inherited-components', { replace: true });
+```
+
+## Implement US3 — Gaps route
+
+1. Create `src/features/gaps/GapsPage.tsx` (fetch from `/api/dashboard/systems/:id/gaps`)
+2. Add in App.tsx inside `/systems/:id` block:
+   ```tsx
+   <Route path="gaps" element={<GapsPage />} />
+   ```
+
+## Run tests
+
+```bash
+pnpm test        # unit tests
+pnpm test:e2e    # Playwright (if configured)
+```
+
+## Verify no stale references after fix
+
+```bash
+grep -rn "'/csp-dashboard'\|navigate.*csp.dashboard" src/
+# Expected: no output (only comments are OK)
+```

--- a/specs/058-dead-routes-fix/research.md
+++ b/specs/058-dead-routes-fix/research.md
@@ -1,0 +1,84 @@
+# Research: Fix Dead Routes
+
+## Methodology
+
+All findings are from direct inspection of the repo at `/tmp/ato-copilot`.
+
+## App.tsx Route Inventory
+
+```bash
+grep -n 'Route\|path\|csp-dashboard\|gap-analysis' \
+  src/Ato.Copilot.Dashboard/src/App.tsx
+```
+
+**Key findings:**
+- Line 110 comment: `"The standalone /csp-dashboard route has been retired."`
+- No `<Route path="/csp-dashboard">` and no `<Navigate>` for it
+- No `<Route path="gaps">` inside the `/systems/:id` block
+- No `<Route path="*">` catch-all
+- `/csp/inherited-components` is a valid route (line 111)
+
+## gap-analysis References
+
+```bash
+grep -rn 'gap-analysis\|gap_analysis' src/Ato.Copilot.Dashboard/src/
+```
+
+Results:
+```
+components/chat/phasePageSuggestions.ts:265:  if (page === 'gap-analysis') {
+hooks/useChatContext.ts:17:  if (pathname.includes('/gaps')) return 'gap-analysis';
+```
+
+**`useChatContext.ts:17`** maps URL pathname `/gaps` → chat page key `gap-analysis`.
+**`phasePageSuggestions.ts:265`** serves gap suggestions when key is `gap-analysis`.
+The wiring is complete except for the missing route.
+
+## Backend Gaps Endpoint
+
+```bash
+grep -n 'gaps\|gap' src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs | head -10
+```
+
+Results:
+```
+404: group.MapGet("/systems/{systemId}/gaps", async (
+420: .WithName("GetGapAnalysis");
+4332: actionLink = $"/systems/{systemId}/gaps";
+```
+
+Backend: `GET /api/dashboard/systems/{systemId}/gaps` — **exists and works**.
+Frontend: no route wired. Fix: add `<Route path="gaps" element={<GapsPage />} />`.
+
+## Hardcoded /csp-dashboard References (outside App.tsx)
+
+```bash
+grep -rn 'csp-dashboard\|/csp/dashboard' src/Ato.Copilot.Dashboard/src/ | grep -v App.tsx
+```
+
+Results:
+- `PageLayout.tsx:127`: Comment only — no live link
+- `useCspDashboardAvailable.ts:2,6`: Imports from `features/csp-dashboard/api` —
+  this is the module directory name, not a UI route
+- `TenantPickerPage.tsx:20,88`: Line 20 is a comment; **line 88 is a live
+  `navigate('/csp/dashboard')` call** — this navigates to `/csp/dashboard`
+  (a path that does NOT exist in App.tsx). Needs to be
+  `navigate('/csp/inherited-components')`.
+- `csp-dashboard/api.ts:3,6,105,267,276`: All reference the API path
+  `/api/csp/dashboard/*` — backend API, not UI routes. No change needed.
+
+## 404 Page Check
+
+```bash
+find src/Ato.Copilot.Dashboard/src -name '*404*' -o -name '*NotFound*'
+```
+**Result: No files found.** No 404/NotFound page exists.
+
+## Impact Summary
+
+| Problem | Location | Severity |
+|---------|----------|----------|
+| No catch-all route | App.tsx | High — blank screen on any unknown URL |
+| `/csp-dashboard` not redirected | App.tsx | High — retired route silently fails |
+| `navigate('/csp/dashboard')` stale | TenantPickerPage.tsx:88 | High — CSP-Admin login broken for this path |
+| No `/systems/:id/gaps` route | App.tsx | Medium — backend + chat wiring ready, route missing |

--- a/specs/058-dead-routes-fix/spec.md
+++ b/specs/058-dead-routes-fix/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Fix Dead Routes — Gap-Analysis, Portfolio, CSP Redirect
+
+**Feature Branch**: `058-dead-routes-fix`
+**Created**: 2026-06-03
+**Status**: Draft
+**GitHub Issue**: #126
+**Builds on**: Feature 048 (retired `/csp-dashboard`), Feature 043 (gaps surface)
+
+## Background
+
+As features shipped and routes were reorganised, three classes of dead-route
+problems accumulated in the React frontend:
+
+1. **No catch-all / 404 page** — unrecognised URLs render a blank white screen
+   with no user feedback.
+2. **`/csp-dashboard` retired but not redirected** — the comment in `App.tsx`
+   line 109 says _"The standalone `/csp-dashboard` route has been retired"_ but
+   there is no `<Navigate>` guard. Any existing bookmark or hardcoded link to
+   `/csp-dashboard` silently falls through to the blank-screen case.
+3. **`gap-analysis` page key referenced in chat logic but not routed** —
+   `useChatContext.ts:17` maps `/gaps` pathname to the key `'gap-analysis'`,
+   and `phasePageSuggestions.ts:265` branches on `page === 'gap-analysis'` to
+   serve gap-related chat suggestions. The backend endpoint is
+   `GET /systems/{systemId}/gaps` (DashboardEndpoints.cs:404), the frontend
+   route is `/systems/:id/gaps` — but there is **no `/systems/:id/gaps` route in
+   App.tsx**. The backend exists; the route was never wired.
+
+### Verified state of the code (current `main`)
+
+1. **`App.tsx` routes** (lines 71–114):
+   - Routes defined: `/login`, `/login/callback`, `/login/error`,
+     `/login/select-tenant`, `/`, `/systems`, `/systems/:id/*` (nested),
+     `/capabilities`, `/components`, `/onboarding`, `/onboarding/tenant`,
+     `/onboarding/csp`, `/csp/inherited-components`, `/admin/imported-documents`,
+     `/controls`
+   - **Missing**: `/csp-dashboard` redirect, `/systems/:id/gaps` route,
+     catch-all `path="*"` 404 route
+
+2. **`/csp-dashboard` hardcoded links** (outside App.tsx):
+   - `PageLayout.tsx:127`: comment mentions `CspInheritedComponentsPage` and
+     `/csp-dashboard` — documentation only, no live `<Link>` or `navigate()`
+   - `useCspDashboardAvailable.ts`: calls `/api/csp/dashboard/summary` — this is
+     the **API** path, not the UI route; unaffected
+   - `TenantPickerPage.tsx:88`: `navigate('/csp/dashboard', { replace: true })`
+     — **this navigates to `/csp/dashboard`** (with slash after csp), which IS
+     the valid route (`/csp/inherited-components` for the page, but the comment
+     on line 20 says `/csp/dashboard`). **Action**: verify whether
+     `/csp/dashboard` resolves or falls through.
+   - `csp-dashboard/api.ts`: API base path `/api/csp/dashboard/*` — backend API,
+     not frontend route
+
+3. **`gap-analysis` references**:
+   - `useChatContext.ts:17`: `if (pathname.includes('/gaps')) return 'gap-analysis'`
+   - `phasePageSuggestions.ts:265`: `if (page === 'gap-analysis') { ... suggestions }`
+   - Backend: `DashboardEndpoints.cs:404` — `GET /systems/{systemId}/gaps`
+     with `.WithName("GetGapAnalysis")`
+   - Frontend API client: not verified to have a `getGapAnalysis` call — check
+     during implementation
+   - **No `/systems/:id/gaps` or `/gaps` route in App.tsx**
+
+4. **No 404 page**: `find src/ -name '*404*' -o -name '*NotFound*'` → no results
+
+### Why this matters
+
+- Blank white screens on bad URLs are a poor UX and suggest a broken app.
+- The gaps page is partially wired (chat context, backend endpoint) but users
+  cannot navigate to it — a complete feature is invisible.
+- Stale `/csp-dashboard` links in any external document or email will silently
+  fail.
+
+## Clarifications
+
+- **Q: Should `/systems/:id/gaps` be a new page or a redirect to an existing
+  page that shows gap data?**
+  **A:** The backend endpoint exists and returns structured gap-analysis data.
+  Add a proper `GapsPage` component and route. The chat suggestions are already
+  correctly keyed — wiring the route will activate them automatically.
+
+- **Q: Where should `/csp-dashboard` redirect?**
+  **A:** `/csp/inherited-components` — the current post-048 URL for the CSP
+  admin surface (confirmed from App.tsx line 111).
+
+- **Q: Does `TenantPickerPage.tsx:88` navigate to the correct path?**
+  **A:** It navigates to `/csp/dashboard` (with trailing `/dashboard`), not
+  `/csp/inherited-components`. This is a separate dead link — fix as part of US4.
+
+- **Q: What should the 404 page look like?**
+  **A:** Minimal: ATO Copilot navigation chrome, "Page not found" heading,
+  "Go to dashboard" button. No design system blocker — use existing layout
+  components.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Catch-all 404 page (Priority: P1)
+
+**As a** user who follows a stale link or miskeys a URL
+**I want** to see a clear "Page not found" message with a way back to the dashboard
+**So that** I know the problem is the URL, not the application.
+
+**Why this priority**: P1 because blank white screens signal a broken app and
+erode trust. Every unmatched route hits this case.
+
+**Independent Test**: Navigate to `/this-does-not-exist` in the test browser;
+assert the 404 page renders with the expected heading and a working dashboard
+link. Test is standalone — no backend required.
+
+**Acceptance**
+- A `<Route path="*" element={<NotFoundPage />} />` is the last route inside
+  `<Routes>` in `App.tsx`.
+- `NotFoundPage` renders within the authenticated shell (nav sidebar visible).
+- `NotFoundPage` includes a `<Link to="/">` or `<button onClick={() => navigate('/')}>`.
+- Public/unauthenticated users hitting an unmatched route see the login page
+  (handled by existing `RequireAuth` redirect, no change needed).
+
+### User Story 2 — Redirect `/csp-dashboard` → `/csp/inherited-components` (Priority: P1)
+
+**As a** CSP-Admin with a bookmark or email link to the old `/csp-dashboard` URL
+**I want** to be redirected to the correct current page
+**So that** I reach my destination without knowing the URL changed.
+
+**Why this priority**: P1 because the route is explicitly documented as
+"retired" in the codebase but no redirect was added; any existing link is
+silently broken.
+
+**Independent Test**: Navigate to `/csp-dashboard`; assert the final URL is
+`/csp/inherited-components` (React Router replace navigation, no extra history
+entry). Test verifies `window.location.pathname` after render.
+
+**Acceptance**
+- `App.tsx` adds `<Route path="/csp-dashboard" element={<Navigate to="/csp/inherited-components" replace />} />` before the catch-all.
+- `TenantPickerPage.tsx:88` is updated from `navigate('/csp/dashboard')` to
+  `navigate('/csp/inherited-components')`.
+- Any other hardcoded `'/csp-dashboard'` or `'/csp/dashboard'` (incorrect)
+  occurrences in the frontend are updated.
+
+### User Story 3 — Wire `/systems/:id/gaps` route (Priority: P2)
+
+**As a** compliance engineer using the gap-analysis chat suggestions
+**I want** to navigate to the gaps view for a system
+**So that** the chat suggestions for gap analysis are reachable and meaningful.
+
+**Why this priority**: P2 because the backend and chat-context wiring exist; the
+missing route is the only gap. Adds immediate value: gap-analysis chat
+suggestions become live.
+
+**Independent Test**: Navigate to `/systems/test-system-id/gaps`; assert the
+`GapsPage` component renders and a network request to
+`GET /api/dashboard/systems/test-system-id/gaps` is made. Standalone — chat
+suggestions are not required to confirm the route works.
+
+**Acceptance**
+- A `<Route path="gaps" element={<GapsPage />} />` is added inside the
+  `/systems/:id` nested route block in `App.tsx`.
+- `GapsPage` is a new component that calls the existing backend endpoint and
+  renders the gap data (or a loading/empty state).
+- `useChatContext.ts:17` mapping continues to work unchanged.
+- `phasePageSuggestions.ts:265` gap-analysis suggestions appear when on
+  `/systems/:id/gaps`.
+
+### User Story 4 — Audit and fix all remaining hardcoded stale route references (Priority: P2)
+
+**As a** developer maintaining the frontend
+**I want** a complete list of all stale route references and confirmation they
+are fixed or intentional
+**So that** this class of bug does not silently re-accumulate.
+
+**Why this priority**: P2 — clean-up work. US2 fixes the most user-visible
+instance; US4 sweeps for others.
+
+**Independent Test**: After fixes, `grep -rn 'csp-dashboard\|/csp/dashboard'
+src/` returns only comments (no live `navigate()` or `<Link>` calls). Verifiable
+in CI as a grep assertion.
+
+**Acceptance**
+- All live `navigate('/csp-dashboard')`, `navigate('/csp/dashboard')`,
+  `<Link to="/csp-dashboard">` occurrences replaced with correct paths.
+- `PageLayout.tsx` comment updated to not reference the retired route (optional,
+  doc-only).
+- `contracts/router-contracts.md` reflects the final authoritative route table.

--- a/specs/058-dead-routes-fix/tasks.md
+++ b/specs/058-dead-routes-fix/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: Fix Dead Routes
+
+## Phase 1 — 404 Page (US1)
+
+### T1.1 — Create NotFoundPage component
+- [ ] Create `src/pages/NotFoundPage.tsx`
+- [ ] Use existing layout shell (authenticated chrome: nav sidebar)
+- [ ] Render "Page not found" `<h1>`, subtitle, `<Link to="/">Go to Dashboard</Link>`
+- [ ] Export as default
+- **Estimate**: 0.5d
+
+### T1.2 — Wire catch-all route in App.tsx
+- [ ] Import `NotFoundPage` in `App.tsx`
+- [ ] Add `<Route path="*" element={<RequireAuth><NotFoundPage /></RequireAuth>} />`
+  as the **last** route inside `<Routes>`
+- **Estimate**: 0.25d
+
+### T1.3 — Test 404 page
+- [ ] Write Playwright/Vitest browser test: navigate to `/xyz-does-not-exist`,
+  assert heading contains "not found", assert link to `/` exists
+- **Estimate**: 0.5d
+
+## Phase 2 — CSP Redirect (US2)
+
+### T2.1 — Add redirect route in App.tsx
+- [ ] Add `<Route path="/csp-dashboard" element={<Navigate to="/csp/inherited-components" replace />} />`
+  before the catch-all
+- [ ] Import `Navigate` from `react-router-dom` (likely already imported)
+- **Estimate**: 0.25d
+
+### T2.2 — Fix TenantPickerPage.tsx
+- [ ] Line 88: change `navigate('/csp/dashboard', { replace: true })` to
+  `navigate('/csp/inherited-components', { replace: true })`
+- [ ] Verify line 20 comment is updated to match
+- **Estimate**: 0.25d
+
+### T2.3 — Grep sweep for remaining stale links
+- [ ] `grep -rn "csp-dashboard\|'/csp/dashboard'" src/`
+- [ ] Fix any live `<Link>` or `navigate()` calls found
+- **Estimate**: 0.25d
+
+### T2.4 — Test redirect
+- [ ] Playwright test: navigate to `/csp-dashboard`, assert final URL is `/csp/inherited-components`
+- **Estimate**: 0.25d
+
+## Phase 3 — Gaps Route (US3)
+
+### T3.1 — Create GapsPage component
+- [ ] Create `src/pages/GapsPage.tsx` (or `src/features/gaps/GapsPage.tsx`)
+- [ ] Call `GET /api/dashboard/systems/:id/gaps` using existing `apiClient`
+- [ ] Render gap items or loading/empty state
+- **Estimate**: 2d (includes basic UI; not fully polished)
+
+### T3.2 — Wire gaps route in App.tsx
+- [ ] Inside `/systems/:id` nested `<Route>` block, add:
+  `<Route path="gaps" element={<GapsPage />} />`
+- [ ] Import `GapsPage`
+- **Estimate**: 0.25d
+
+### T3.3 — Verify chat context
+- [ ] Confirm `useChatContext.ts:17` mapping `/gaps` → `'gap-analysis'` still
+  works after route is wired
+- [ ] Confirm gap-analysis suggestions appear in chat panel when on gaps route
+- **Estimate**: 0.25d
+
+### T3.4 — Test gaps route
+- [ ] Unit test: render `GapsPage` with mocked API response, assert content renders
+- **Estimate**: 0.5d
+
+## Phase 4 — Stale Route Audit (US4)
+
+### T4.1 — Document final route table
+- [ ] Update `contracts/router-contracts.md` with complete authoritative route list
+- **Estimate**: 0.5d
+
+### T4.2 — Add CI grep assertion
+- [ ] Add CI step: `grep -rn "'/csp-dashboard'\|navigate.*csp.dashboard" src/ && exit 1 || exit 0`
+  (fail if live stale references exist)
+- **Estimate**: 0.25d
+
+## Phase 5 — Review
+
+### T5.1 — PR review checklist
+- [ ] All tests pass
+- [ ] `contracts/router-contracts.md` is current
+- [ ] No blank-screen routes remain
+- **Estimate**: 0.5d
+
+## Total Estimate: ~6 days

--- a/specs/059-orphaned-endpoints/checklists/requirements.md
+++ b/specs/059-orphaned-endpoints/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Requirements Checklist — 059 Orphaned Endpoints
+
+## Functional Requirements
+
+### Audit Log (US1)
+- [ ] FR-059-01: `/admin/audit` route exists and renders `AuditLogPage`.
+- [ ] FR-059-02: Page is accessible only to CSP-Admin users; non-admins receive 403.
+- [ ] FR-059-03: Page calls `GET /api/audit` with filter params.
+- [ ] FR-059-04: Table columns: Timestamp, Actor, Tenant, Action, Entity, Details.
+- [ ] FR-059-05: Date range filter (`from` / `to`) serialised to URL and forwarded to API.
+- [ ] FR-059-06: Actor OID text filter, action dropdown filter, tenant selector — all URL-persisted.
+- [ ] FR-059-07: Page size selector supports 25 / 50 / 100; default 50.
+- [ ] FR-059-08: Total result count displayed above the table.
+- [ ] FR-059-09: Loading skeleton shown while API call is in-flight.
+- [ ] FR-059-10: Empty-state message when no results match filters.
+
+### Admin Migration (US2)
+- [ ] FR-059-11: `/admin/migrations` route exists and renders `MigrationPage`.
+- [ ] FR-059-12: Route is CSP-Admin only; non-admins receive 403.
+- [ ] FR-059-13: Preview step calls `GET /api/admin/migrate-to-multitenant/preview` and renders table list.
+- [ ] FR-059-14: Execute step is gated by a confirmation modal.
+- [ ] FR-059-15: Confirmation modal requires user to type the string `MIGRATE` before submit enables.
+- [ ] FR-059-16: On success, the form is replaced by a permanent success banner with timestamp.
+- [ ] FR-059-17: Success state persists in `sessionStorage`; page reload shows success banner, not the form.
+- [ ] FR-059-18: API errors displayed inline beneath the action button.
+
+### Notification Preferences (US3)
+- [ ] FR-059-19: `NotificationPreferencesPanel` accessible from user settings → Notifications tab.
+- [ ] FR-059-20: Panel renders a toggle for each key in the `preferences` object.
+- [ ] FR-059-21: Save calls `PUT /api/notifications/preferences` with updated values.
+- [ ] FR-059-22: Optimistic update reverts on API error.
+- [ ] FR-059-23: Success toast shown after save.
+
+### Deployment About (US4)
+- [ ] FR-059-24: `/admin/about` route exists and renders `AboutPage`.
+- [ ] FR-059-25: Page displays deployment mode badge.
+- [ ] FR-059-26: When mode is SingleTenant, `defaultTenantId` is displayed.
+- [ ] FR-059-27: Build version displayed (env var or "dev" fallback).
+
+## Non-Functional Requirements
+
+- [ ] NFR-059-01: All API calls typed — no `any` in new files.
+- [ ] NFR-059-02: All new `.tsx` files have companion `.test.tsx` files with ≥ 80% branch coverage.
+- [ ] NFR-059-03: Audit log table handles 200 rows without visible layout overflow.
+- [ ] NFR-059-04: Filter API call debounced ≥ 300 ms on text inputs.
+- [ ] NFR-059-05: New routes included in Playwright smoke test suite.
+- [ ] NFR-059-06: No new ESLint warnings in CI.

--- a/specs/059-orphaned-endpoints/contracts/frontend-types.md
+++ b/specs/059-orphaned-endpoints/contracts/frontend-types.md
@@ -1,0 +1,126 @@
+# Frontend TypeScript Types — 059 Orphaned Endpoints
+
+All types below live in
+`src/Ato.Copilot.Dashboard/src/features/<domain>/types.ts`.
+
+---
+
+## Shared
+
+```typescript
+/** Standard paginated response envelope used across all list endpoints. */
+export interface PagedResult<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+/** Standard API response envelope. */
+export interface ApiEnvelope<T> {
+  status: 'success' | 'error';
+  data: T;
+  metadata: {
+    executionTimeMs: number;
+    timestamp: string; // ISO 8601
+  };
+}
+```
+
+---
+
+## Audit (`features/audit/types.ts`)
+
+```typescript
+export interface AuditLogEntry {
+  id: string;           // Guid
+  tenantId: string;     // Guid
+  actorTenantId: string;
+  userId: string;       // AAD OID
+  action: string;       // e.g. "Capability.Create"
+  entityType: string;
+  entityId: string;
+  timestamp: string;    // ISO 8601
+  metadataJson: string | null;
+}
+
+export interface AuditQueryParams {
+  tenantId?: string;
+  actorTenantId?: string;
+  actorOid?: string;
+  action?: string;
+  from?: string;        // ISO 8601
+  to?: string;          // ISO 8601
+  page?: number;
+  pageSize?: number;
+}
+```
+
+---
+
+## Admin Migration (`features/admin/types.ts`)
+
+```typescript
+export interface MigrationTablePreview {
+  tableName: string;
+  rowCount: number;
+  requiresOverride: boolean;
+}
+
+export interface MigrationPreviewResult {
+  tables: MigrationTablePreview[];
+}
+
+export interface TenantOverrideDto {
+  tableName: string;
+  rowIdPrefix?: string;
+  tenantId: string; // Guid
+}
+
+export interface ExecuteMigrationRequest {
+  defaultTenantId: string; // Guid
+  installRls: boolean;
+  overrides?: TenantOverrideDto[];
+}
+```
+
+---
+
+## Notifications (`features/notifications/types.ts`)
+
+```typescript
+export interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  isRead: boolean;
+  createdAt: string; // ISO 8601
+}
+
+export interface NotificationSummary {
+  unreadCount: number;
+}
+
+/** Preferences is a free-form key→boolean map to stay resilient
+ *  to new server-side preference keys without a frontend deploy. */
+export type NotificationPreferences = Record<string, boolean>;
+
+export interface NotificationPreferencesResponse {
+  preferences: NotificationPreferences;
+}
+```
+
+---
+
+## Deployment (`features/tenancy/types.ts` — already partially exists)
+
+```typescript
+// Already defined in features/tenancy/api.ts — reproduced here for reference.
+export type DeploymentMode = 'SingleTenant' | 'MultiTenant';
+
+export interface DeploymentModeResponse {
+  mode: DeploymentMode;
+  defaultTenantId: string | null;
+}
+```

--- a/specs/059-orphaned-endpoints/contracts/http-api.md
+++ b/specs/059-orphaned-endpoints/contracts/http-api.md
@@ -1,0 +1,214 @@
+# HTTP API Contract — 059 Orphaned Endpoints
+
+All endpoints below are already implemented in `Ato.Copilot.Mcp`. This document
+catalogues them for frontend consumers. No new backend endpoints are introduced
+by this epic.
+
+---
+
+## Audit Query — `AuditQueryEndpoints`
+
+### `GET /api/audit`
+
+**Auth**: CSP-Admin only. Returns `403 FORBIDDEN_NOT_CSP_ADMIN` for all other roles.
+
+**Query parameters**
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `tenantId` | `Guid` | No | — | Filter by target tenant |
+| `actorTenantId` | `Guid` | No | — | Filter by actor's home tenant |
+| `actorOid` | `string` | No | — | Filter by actor OID (exact match) |
+| `action` | `string` | No | — | Filter by action string (exact match) |
+| `from` | `DateTime` (ISO 8601) | No | — | Inclusive lower timestamp bound |
+| `to` | `DateTime` (ISO 8601) | No | — | Inclusive upper timestamp bound |
+| `page` | `int` | No | `1` | Must be ≥ 1 |
+| `pageSize` | `int` | No | `50` | Clamped to `[1, 200]` |
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "items": [
+      {
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "tenantId": "...",
+        "actorTenantId": "...",
+        "userId": "aad-oid-string",
+        "action": "Capability.Create",
+        "entityType": "CspInheritedCapability",
+        "entityId": "...",
+        "timestamp": "2026-06-01T12:34:56Z",
+        "metadataJson": "{}"
+      }
+    ],
+    "page": 1,
+    "pageSize": 50,
+    "total": 142
+  },
+  "metadata": { "executionTimeMs": 12, "timestamp": "2026-06-01T12:34:56Z" }
+}
+```
+
+**Error responses**
+
+| Code | `code` field | Condition |
+|------|-------------|-----------|
+| `400` | `INVALID_PAGINATION` | `page < 1` or `pageSize < 1` |
+| `403` | `FORBIDDEN_NOT_CSP_ADMIN` | Caller is not CSP-Admin |
+
+---
+
+## Admin Migration — `AdminMigrationEndpoints`
+
+### `GET /api/admin/migrate-to-multitenant/preview`
+
+**Auth**: CSP-Admin only.
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "tables": [
+      { "tableName": "Systems", "rowCount": 14, "requiresOverride": false },
+      { "tableName": "Capabilities", "rowCount": 203, "requiresOverride": false }
+    ]
+  },
+  "metadata": { "executionTimeMs": 45, "timestamp": "..." }
+}
+```
+
+---
+
+### `POST /api/admin/migrate-to-multitenant`
+
+**Auth**: CSP-Admin only.
+
+**Request body**
+
+```json
+{
+  "defaultTenantId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "installRls": true,
+  "overrides": [
+    {
+      "tableName": "Systems",
+      "rowIdPrefix": "legacy-",
+      "tenantId": "..."
+    }
+  ]
+}
+```
+
+**Response `200 OK`** — migration applied.
+
+**Error responses**
+
+| Code | `code` field | Condition |
+|------|-------------|-----------|
+| `400` | `INVALID_REQUEST` | `defaultTenantId` is empty or missing |
+| `403` | `FORBIDDEN_NOT_CSP_ADMIN` | Caller is not CSP-Admin |
+
+---
+
+## Notifications — `NotificationEndpoints`
+
+### `GET /api/notifications`
+
+**Auth**: Authenticated user. Returns notifications for the current user.
+
+**Query parameters**: `page`, `pageSize` (same pagination contract as audit).
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "items": [
+      {
+        "id": "...",
+        "type": "capabilityReview",
+        "title": "Capability needs review",
+        "body": "...",
+        "isRead": false,
+        "createdAt": "2026-06-01T10:00:00Z"
+      }
+    ],
+    "page": 1, "pageSize": 50, "total": 3
+  }
+}
+```
+
+---
+
+### `GET /api/notifications/summary`
+
+**Response `200 OK`**: `{ "unreadCount": 3 }`
+
+---
+
+### `POST /api/notifications/mark-read`
+
+**Body**: `{ "ids": ["guid1", "guid2"] }`
+**Response**: `204 No Content`
+
+---
+
+### `POST /api/notifications/mark-all-read`
+
+**Body**: `{}` (empty)
+**Response**: `204 No Content`
+
+---
+
+### `GET /api/notifications/preferences`
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "preferences": {
+      "capabilityReview": true,
+      "systemAlerts": true,
+      "weeklyDigest": false
+    }
+  }
+}
+```
+
+---
+
+### `PUT /api/notifications/preferences`
+
+**Body**: same shape as preferences `data` object above.
+**Response**: `200 OK` with updated preferences.
+
+---
+
+## Deployment — `DeploymentEndpoints`
+
+### `GET /api/deployment/mode`
+
+**Auth**: Anonymous (intentionally — called before login to determine login surface).
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "mode": "SingleTenant",
+    "defaultTenantId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  },
+  "metadata": { "executionTimeMs": 1, "timestamp": "..." }
+}
+```
+
+`defaultTenantId` is `null` when `mode` is `"MultiTenant"`.

--- a/specs/059-orphaned-endpoints/data-model.md
+++ b/specs/059-orphaned-endpoints/data-model.md
@@ -1,0 +1,47 @@
+# Data Model — 059 Orphaned Endpoints
+
+## No New Database Entities
+
+This epic introduces **no new backend entities, migrations, or schema changes**.
+All persistence objects already exist from Feature 048.
+
+## Existing entities referenced
+
+### `AuditLogEntry` (table: `AuditLogs`)
+Defined in `Ato.Copilot.Core.Models.Compliance.AuditLogEntry`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `Id` | `Guid` | PK |
+| `TenantId` | `Guid` | FK → Tenant |
+| `ActorTenantId` | `Guid` | Tenant the actor belongs to (differs from TenantId during impersonation) |
+| `UserId` | `string` | Actor OID |
+| `Action` | `string` | e.g. `"Capability.Create"`, `"Capability.Move"` |
+| `EntityType` | `string` | e.g. `"CspInheritedCapability"` |
+| `EntityId` | `string` | |
+| `Timestamp` | `DateTime` | UTC; indexed via `IX_AuditLogs_TenantId_Timestamp` |
+| `MetadataJson` | `string?` | Arbitrary JSON blob |
+
+### `NotificationPreference` (existing service model)
+Managed by `NotificationEndpoints` / `PUT /api/notifications/preferences`.
+Shape returned by `GET /api/notifications/preferences`:
+```json
+{
+  "preferences": {
+    "capabilityReview": true,
+    "systemAlerts": true,
+    "weeklyDigest": false
+  }
+}
+```
+
+### `DeploymentOptions` (config, not DB)
+`Ato.Copilot.Mcp.Configuration.DeploymentOptions`:
+- `Mode`: `SingleTenant | MultiTenant`
+- `DefaultTenantId`: `Guid?` (SingleTenant only)
+
+## Frontend-only state
+
+All UI state for filters, pagination cursor, and session-level "migration
+already executed" flag is stored in URL query params and `sessionStorage`
+respectively — no new backend persistence.

--- a/specs/059-orphaned-endpoints/plan.md
+++ b/specs/059-orphaned-endpoints/plan.md
@@ -1,0 +1,49 @@
+# Plan — 059 Orphaned Endpoints
+
+## Delivery order
+
+```
+Week 1 (P1 stories)
+├── T03  auditApi.ts                     ← pure data layer, no UI dependency
+├── T06  adminMigrationApi.ts            ← pure data layer
+├── T01  AuditLogPage.tsx                ← depends on T03
+├── T02  Route + sidebar (audit)         ← depends on T01
+├── T04  MigrationPage.tsx               ← depends on T06
+└── T05  Route + sidebar (migration)     ← depends on T04
+
+Week 2 (P2 stories + integration)
+├── T09  notificationsApi.ts
+├── T07  NotificationPreferencesPanel    ← depends on T09
+├── T08  Settings wire-up               ← depends on T07
+├── T10  AboutPage.tsx                  ← reuses existing getDeploymentMode()
+├── T11  Route + sidebar (about)
+└── T12  Integration smoke tests
+```
+
+## Branch strategy
+
+Feature branch: `feat/059-orphaned-endpoints` off `main`.
+
+Each milestone (audit, migration, notifications, about) should be a separate
+commit so reviewers can read the diff cleanly. Squash-merge to `main` after
+all four milestones pass CI.
+
+## Testing strategy
+
+- **Unit**: each `*Api.ts` module gets a co-located `.test.ts` with mocked axios.
+- **Component**: each `*Page.tsx` gets a `*.test.tsx` using React Testing Library
+  with MSW handlers for the API routes.
+- **Integration (T12)**: Playwright tests in `e2e/admin-orphaned-endpoints.spec.ts`
+  covering the four routes under CSP-Admin and non-admin sessions.
+
+## Definition of Done
+
+- [ ] All four routes exist and are reachable.
+- [ ] All four routes 403 for non-authorized roles.
+- [ ] Audit log page shows paginated data with working filters.
+- [ ] Migration page cannot execute without typing `MIGRATE` in confirm dialog.
+- [ ] Notification preferences persist across page reload.
+- [ ] About page correctly reflects single-tenant vs multi-tenant mode.
+- [ ] No new TypeScript `any` types — all API calls are fully typed.
+- [ ] CI passes (lint + unit + component tests).
+- [ ] Playwright integration smoke passes on CI.

--- a/specs/059-orphaned-endpoints/quickstart.md
+++ b/specs/059-orphaned-endpoints/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart — 059 Orphaned Endpoints
+
+## Prerequisites
+
+- Node ≥ 20, npm ≥ 10
+- .NET 8 SDK (to run the MCP server locally)
+- Repo cloned at `/tmp/ato-copilot` (or equivalent)
+
+## Run the MCP server
+
+```bash
+cd src/Ato.Copilot.Mcp
+dotnet run
+# Server listens on http://localhost:3001
+```
+
+## Run the dashboard
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm install
+npm run dev
+# Dashboard at http://localhost:5173
+```
+
+## Verify orphaned endpoints are reachable
+
+```bash
+# Audit log (CSP-Admin token required)
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:3001/api/audit?page=1&pageSize=10"
+
+# Migration preview
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:3001/api/admin/migrate-to-multitenant/preview"
+
+# Notification preferences
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:3001/api/notifications/preferences"
+
+# Deployment mode (anonymous)
+curl "http://localhost:3001/api/deployment/mode"
+```
+
+## Navigate to the new pages
+
+| URL | Required role |
+|-----|---------------|
+| `http://localhost:5173/admin/audit` | CSP-Admin |
+| `http://localhost:5173/admin/migrations` | CSP-Admin |
+| `http://localhost:5173/admin/about` | CSP-Admin |
+| User menu → Settings → Notifications | Any authenticated user |
+
+## Run unit tests
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm test -- --testPathPattern="audit|migration|notification|about"
+```
+
+## Run Playwright integration tests
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npx playwright test e2e/admin-orphaned-endpoints.spec.ts
+```

--- a/specs/059-orphaned-endpoints/research.md
+++ b/specs/059-orphaned-endpoints/research.md
@@ -1,0 +1,55 @@
+# Research — 059 Orphaned Endpoints
+
+## Discovery: What is orphaned and why
+
+Four endpoint groups are registered in `Program.cs` (lines 648, 659, 661) and
+confirmed mounted:
+
+```
+app.MapDeploymentEndpoints();      // line 648
+app.MapAuditQueryEndpoints();      // line 659
+app.MapAdminMigrationEndpoints();  // line 661
+```
+
+A grep across `src/Ato.Copilot.Dashboard/src/` for `AuditQuery`, `AuditLog`,
+`AdminMigration` returns **zero hits** on actual API calls — only component badge
+labels like `{ AuditLog: 'bg-gray-100' }` for styling evidence-type chips.
+
+`NotificationEndpoints` is mounted (not in Program.cs grep above because it was
+not searched by name) with six routes; no dashboard file calls any of them.
+
+`DeploymentEndpoints` is the most complete: `getDeploymentMode()` in
+`features/tenancy/api.ts:163` consumes `GET /api/deployment/mode` during tenant
+picker init. However, the result is used only for routing logic — never displayed
+in an admin-readable page.
+
+## Risk: Admin Migration is live with no UI guard
+
+`POST /api/admin/migrate-to-multitenant` is a **destructive, idempotent-on-success**
+operation. The only guard today is the `tenant.IsCspAdmin` role check. Any
+CSP-Admin with cURL access to the API can trigger it. The spec mandates a
+preview-first confirm flow to prevent accidents.
+
+## Existing patterns to follow
+
+- Pagination: `{ items[], page, pageSize, total }` — matches `AuditQueryEndpoints`
+  contract and the spec 048 house style.
+- Role guard component: `<CspAdminGuard>` — used in existing admin pages.
+- Axios client: `features/tenancy/api.ts` uses `tenancyClient` (axios instance).
+  Audit and migration APIs should use the same base client from `apiClient.ts`.
+- URL-persisted filters: `SystemBoundaryPage.tsx` demonstrates the pattern using
+  `useSearchParams`.
+
+## Notification preferences shape
+
+`GET /api/notifications/preferences` returns a free-form `preferences` object.
+The frontend must render toggles generically (key → boolean) rather than
+hard-coding keys, so adding new preference keys server-side does not require a
+frontend deploy.
+
+## No OSCAL orphan in this batch
+
+The issue title mentions "OSCAL" but inspection of the codebase shows no
+`OscalEndpoints.cs` or unlinked OSCAL route. OSCAL is served through existing
+documented endpoints. The "OSCAL" reference in issue #127 was superseded by the
+four endpoint groups identified above.

--- a/specs/059-orphaned-endpoints/spec.md
+++ b/specs/059-orphaned-endpoints/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Surface Orphaned Backend Endpoints (Audit Log, Admin, Notifications, Deployment)
+
+**Feature Branch**: `059-orphaned-endpoints`
+**Created**: 2026-06-03
+**Status**: Draft
+**GitHub Issue**: #127
+**Builds on**: Feature 048 (Tenant Isolation) — all four orphaned endpoint groups
+were introduced or wired in 048/T084/T116/T117/T124.
+
+## Background
+
+Feature 048 shipped four backend endpoint groups that are registered and serving
+traffic in `Program.cs` but have **no corresponding frontend surface**:
+
+| Endpoint group | Route prefix | Registered? | Dashboard page? |
+|---|---|---|---|
+| `AuditQueryEndpoints` | `GET /api/audit` | ✅ line 659 | ❌ none |
+| `AdminMigrationEndpoints` | `GET /api/admin/migrate-to-multitenant/preview`, `POST /api/admin/migrate-to-multitenant` | ✅ line 661 | ❌ none |
+| `NotificationEndpoints` | `GET /api/notifications`, `GET /api/notifications/summary`, `POST /api/notifications/mark-read`, `POST /api/notifications/mark-all-read`, `GET /api/notifications/preferences`, `PUT /api/notifications/preferences` | ✅ (mounted) | ❌ none |
+| `DeploymentEndpoints` | `GET /api/deployment/mode` | ✅ line 648 | ⚠️ called only inside `TenantPicker` init — no admin visibility |
+
+The audit endpoint specifically was designed for a "dashboard audit explorer" (per
+its own XML doc comment) but that explorer was never built. The migration endpoint
+was built for a one-time CSP-Admin operation and has no UI guard. Notification
+preferences are returned but never shown to users.
+
+### Verified state of the code
+
+1. **`AuditQueryEndpoints`** — single `GET /api/audit` with query params
+   (`tenantId`, `actorTenantId`, `actorOid`, `action`, `from`, `to`, `page`,
+   `pageSize`). CSP-Admin only. Returns paginated `{ items, page, pageSize, total }`.
+   Backed by composite indexes `IX_AuditLogs_TenantId_Timestamp` and
+   `IX_AuditLogs_ActorTenantId_Timestamp`.
+
+2. **`AdminMigrationEndpoints`** — `GET /api/admin/migrate-to-multitenant/preview`
+   returns a table list; `POST /api/admin/migrate-to-multitenant` executes the
+   migration. CSP-Admin only. Accepts `{ defaultTenantId, overrides[], installRls }`.
+   This is a **destructive, one-time** operation; a UI guard is mandatory.
+
+3. **`NotificationEndpoints`** — six routes covering list, summary, mark-read,
+   mark-all-read, and preferences GET/PUT. Not yet called by any dashboard code.
+
+4. **`DeploymentEndpoints`** — anonymous `GET /api/deployment/mode`. Called in
+   `TenantPicker.tsx` to determine deployment mode but never surfaced in an
+   admin-visible health/about page.
+
+## Clarifications
+
+- **Q: Should the Audit Log page be restricted to CSP-Admins or also available to
+  org-level admins?**
+  **A:** CSP-Admin only, matching the backend role check (`tenant.IsCspAdmin`). An
+  org-level read-only view is out of scope for this epic.
+
+- **Q: Must the Migration UI prevent re-running after a successful migration?**
+  **A:** Yes. Show a permanent warning banner if the backend returns a state
+  indicating migration has already been applied. The UI must not render a "Run"
+  button in that state.
+
+- **Q: Where does the Notification preferences panel live?**
+  **A:** User settings panel, accessible from the top-nav user menu, visible to all
+  authenticated users.
+
+- **Q: Should `GET /api/deployment/mode` be surfaced in an existing page or a new
+  one?**
+  **A:** Surface it in a new `/admin/about` page alongside build/version metadata.
+  No new backend endpoint needed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Audit Log page (Priority: P1)
+
+**As a** CSP-Admin
+**I want** a paginated audit trail page at `/admin/audit`
+**So that** I can investigate who did what across all tenants without reading raw
+database logs.
+
+**Why this priority**: The audit infrastructure (indexes, endpoint, OpenAPI spec)
+already exists. The missing UI is the last mile that makes this capability
+accessible to non-engineers. Compliance auditors require this surface.
+
+**Independent Test**: Navigate to `/admin/audit` as a CSP-Admin; assert the table
+loads with at least one row (seed data); page to the second page; apply a `from`
+date filter; assert the URL reflects the filter. Repeat as a non-CSP-Admin and
+assert redirect to 403/home.
+
+**Acceptance**
+- New file `src/pages/admin/AuditLogPage.tsx` registered at route `/admin/audit`.
+- Route is listed in the admin sidebar nav (CSP-Admin role gate).
+- Page renders a sortable, filterable table with columns: Timestamp, Actor,
+  Tenant, Action, Entity, Details.
+- Filters: date-range picker (`from`/`to`), actor OID text, action dropdown,
+  tenant selector. All filters persist to URL query params.
+- Pagination: page size selector (25 / 50 / 100); prev/next controls;
+  total count displayed.
+- Non-CSP-Admin users receive a 403 page (no 404 that leaks route existence).
+- Loading, error, and empty-state skeletons implemented.
+
+### User Story 2 — Admin Migration UI (Priority: P1)
+
+**As a** CSP-Admin performing a one-time migration from single-tenant to
+multi-tenant
+**I want** a protected UI that previews the migration plan and requires explicit
+confirmation before executing
+**So that** I never accidentally run a destructive migration operation.
+
+**Why this priority**: The endpoint is live with no UI guard. Any CSP-Admin who
+discovers the route via DevTools or API docs can POST to it from cURL. Providing
+a UI with a preview-first, confirm-second flow prevents accidents.
+
+**Independent Test**: Load `/admin/migrations` as CSP-Admin; click "Preview";
+assert the table of affected tables is shown; click "Execute"; confirm the dialog;
+assert the success banner appears. Attempt as non-CSP-Admin; assert redirect.
+
+**Acceptance**
+- New page `src/pages/admin/MigrationPage.tsx` at route `/admin/migrations`.
+- Route is admin-sidebar listed under "Danger Zone" section with a warning icon.
+- Page shows a **Preview step**: calls `GET /api/admin/migrate-to-multitenant/preview`
+  and renders an affected-tables list.
+- **Execute step** is gated behind a confirmation modal that requires the user to
+  type `MIGRATE` before the submit button enables.
+- On success, replaces the form with a permanent success banner showing timestamp
+  and suppresses the "Run" button for the remainder of the session.
+- On failure, surfaces the API error message inline.
+- Route is 403-gated for non-CSP-Admin users.
+
+### User Story 3 — Notification preferences panel (Priority: P2)
+
+**As an** authenticated user
+**I want** to view and edit my notification preferences from the user settings
+panel
+**So that** I can control which system events generate notifications for me.
+
+**Why this priority**: P2 because the backend is complete and the feature gap is
+purely cosmetic — the preferences exist in the DB but users have no way to see
+or change them through the UI.
+
+**Independent Test**: Open user settings; navigate to "Notifications" tab; toggle
+a preference off; save; reload; assert the toggle is still off.
+
+**Acceptance**
+- New component `src/components/settings/NotificationPreferencesPanel.tsx`.
+- Accessible from the user settings panel (top-nav user menu → Settings →
+  Notifications tab).
+- Renders toggles for each preference key returned by
+  `GET /api/notifications/preferences`.
+- "Save" calls `PUT /api/notifications/preferences` with the changed keys.
+- Shows optimistic update with rollback on error.
+
+### User Story 4 — Deployment metadata about page (Priority: P2)
+
+**As a** CSP-Admin
+**I want** an `/admin/about` page that shows deployment mode and version metadata
+**So that** I can confirm what environment I am operating in without reading
+environment variables.
+
+**Why this priority**: P2 — `GET /api/deployment/mode` is already called during
+boot; adding a dedicated read-only page costs minimal effort and prevents
+support confusion between single-tenant and multi-tenant deployments.
+
+**Independent Test**: Navigate to `/admin/about`; assert mode badge ("SingleTenant"
+or "MultiTenant") matches the value returned by the deployment API.
+
+**Acceptance**
+- New page `src/pages/admin/AboutPage.tsx` at route `/admin/about`.
+- Calls `GET /api/deployment/mode` (reuses existing `getDeploymentMode()` in
+  `features/tenancy/api.ts`).
+- Displays: deployment mode badge, `defaultTenantId` (SingleTenant only),
+  frontend build version (from `import.meta.env.VITE_BUILD_VERSION` or fallback
+  "dev").
+- Route visible in admin sidebar to CSP-Admins; read-only for all admins.

--- a/specs/059-orphaned-endpoints/tasks.md
+++ b/specs/059-orphaned-endpoints/tasks.md
@@ -1,0 +1,162 @@
+# Tasks — 059 Orphaned Endpoints
+
+## Milestone 1 — Audit Log Page (US1, P1)
+
+### T01 — Create `AuditLogPage.tsx`
+**File**: `src/Ato.Copilot.Dashboard/src/pages/admin/AuditLogPage.tsx`
+**Work**:
+- Define `AuditLogEntry` TS type (import from `contracts/frontend-types.md`).
+- Implement URL-sync hook for filters (`useAuditFilters`).
+- `useQuery` against `GET /api/audit` via `auditApi.ts`.
+- Render `<AuditTable>` with columns: Timestamp, Actor, Tenant, Action, Entity, Details.
+- Implement `<AuditFilters>` sub-component: date-range, actor OID input, action
+  dropdown, tenant selector.
+- Pagination controls + page-size selector.
+- Empty-state and loading skeleton.
+
+**Test**: `AuditLogPage.test.tsx` — mock API, assert table renders rows, filter
+params serialised to URL, non-admin redirected.
+
+**Estimate**: 5 pts
+
+---
+
+### T02 — Wire `/admin/audit` route + sidebar entry
+**File**: `src/Ato.Copilot.Dashboard/src/App.tsx` (or router file),
+`src/components/layout/AdminLayout.tsx`
+**Work**:
+- Add `<Route path="/admin/audit" element={<CspAdminGuard><AuditLogPage /></CspAdminGuard>} />`.
+- Add sidebar nav item under "Admin" group (icon: `ClipboardDocumentListIcon`).
+- Sidebar item visible only when `tenant.isCspAdmin`.
+
+**Estimate**: 1 pt
+
+---
+
+### T03 — Create `auditApi.ts`
+**File**: `src/Ato.Copilot.Dashboard/src/features/audit/auditApi.ts`
+**Work**:
+- Typed function `queryAudit(params: AuditQueryParams): Promise<PagedResult<AuditLogEntry>>`.
+- Wraps the existing MCP axios client; maps query object to URLSearchParams.
+- Unit test: mock axios, assert params forwarded correctly.
+
+**Estimate**: 2 pts
+
+---
+
+## Milestone 2 — Admin Migration UI (US2, P1)
+
+### T04 — Create `MigrationPage.tsx`
+**File**: `src/Ato.Copilot.Dashboard/src/pages/admin/MigrationPage.tsx`
+**Work**:
+- Step 1 — Preview: call `GET /api/admin/migrate-to-multitenant/preview` and
+  render `tables[]` in a read-only list.
+- Step 2 — Confirm: modal with a type-to-confirm text field (`MIGRATE`).
+- Step 3 — Execute: `POST /api/admin/migrate-to-multitenant`; success banner
+  replaces form; persist "already migrated" flag to `sessionStorage` to suppress
+  re-run within the session.
+- Error inline display.
+- `CspAdminGuard` wrapping.
+
+**Test**: `MigrationPage.test.tsx` — mock preview, assert table shown; mock
+execute success, assert banner rendered; assert button disabled unless `MIGRATE`
+typed.
+
+**Estimate**: 4 pts
+
+---
+
+### T05 — Wire `/admin/migrations` route + sidebar
+**Work**: same pattern as T02. Sidebar item under "Danger Zone" section with a
+`ExclamationTriangleIcon` and amber text color.
+
+**Estimate**: 1 pt
+
+---
+
+### T06 — Create `adminMigrationApi.ts`
+**File**: `src/Ato.Copilot.Dashboard/src/features/admin/adminMigrationApi.ts`
+**Work**: `previewMigration()` and `executeMigration(body)` typed functions.
+Unit test.
+
+**Estimate**: 1 pt
+
+---
+
+## Milestone 3 — Notification Preferences (US3, P2)
+
+### T07 — Create `NotificationPreferencesPanel.tsx`
+**File**: `src/Ato.Copilot.Dashboard/src/components/settings/NotificationPreferencesPanel.tsx`
+**Work**:
+- `useQuery` on `GET /api/notifications/preferences`.
+- Render toggle list (one per preference key).
+- On "Save" call `PUT /api/notifications/preferences` with changed keys.
+- Optimistic update + rollback via `useMutation`.
+
+**Estimate**: 3 pts
+
+---
+
+### T08 — Wire into user settings panel
+**Work**: Add "Notifications" tab to existing settings panel.
+Wire in `NotificationPreferencesPanel`.
+
+**Estimate**: 1 pt
+
+---
+
+### T09 — Create `notificationsApi.ts`
+**File**: `src/Ato.Copilot.Dashboard/src/features/notifications/notificationsApi.ts`
+**Work**: `getPreferences()`, `updatePreferences(prefs)`, `getNotifications(params)`,
+`getSummary()`, `markRead(ids)`, `markAllRead()` typed functions.
+
+**Estimate**: 2 pts
+
+---
+
+## Milestone 4 — Deployment About Page (US4, P2)
+
+### T10 — Create `AboutPage.tsx`
+**File**: `src/Ato.Copilot.Dashboard/src/pages/admin/AboutPage.tsx`
+**Work**:
+- Reuse `getDeploymentMode()` from `features/tenancy/api.ts`.
+- Render mode badge (green = SingleTenant, blue = MultiTenant).
+- Show `defaultTenantId` when mode = SingleTenant.
+- Show `VITE_BUILD_VERSION` env var (fallback "dev").
+
+**Estimate**: 2 pts
+
+---
+
+### T11 — Wire `/admin/about` route + sidebar
+**Estimate**: 1 pt
+
+---
+
+## Cross-cutting
+
+### T12 — Integration smoke tests
+Add Playwright tests covering the four new routes: assert table/page renders for
+CSP-Admin, assert redirect for non-admin on guarded routes.
+
+**Estimate**: 3 pts
+
+---
+
+## Summary
+
+| Task | US | Points | Priority |
+|------|----|--------|----------|
+| T01 AuditLogPage | US1 | 5 | P1 |
+| T02 Route/sidebar audit | US1 | 1 | P1 |
+| T03 auditApi | US1 | 2 | P1 |
+| T04 MigrationPage | US2 | 4 | P1 |
+| T05 Route/sidebar migration | US2 | 1 | P1 |
+| T06 adminMigrationApi | US2 | 1 | P1 |
+| T07 NotificationPreferencesPanel | US3 | 3 | P2 |
+| T08 Settings wire-up | US3 | 1 | P2 |
+| T09 notificationsApi | US3 | 2 | P2 |
+| T10 AboutPage | US4 | 2 | P2 |
+| T11 Route/sidebar about | US4 | 1 | P2 |
+| T12 Integration smoke | all | 3 | P2 |
+| **Total** | | **26** | |

--- a/specs/060-vscode-extension-v1/checklists/requirements.md
+++ b/specs/060-vscode-extension-v1/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Requirements Checklist — 060 VS Code Extension v1.0
+
+## Functional Requirements
+
+### Tests (US1)
+- [ ] FR-060-01: All 17 `.test.ts` files in `src/` compile without TypeScript errors.
+- [ ] FR-060-02: `npm test` exits 0 in the local developer environment.
+- [ ] FR-060-03: `npm test` exits 0 in the CI `vscode-extension-compile` job.
+- [ ] FR-060-04: All 17 test suites are reported in test output; none are skipped.
+- [ ] FR-060-05: No test file is deleted as a fix strategy; failing tests are repaired.
+
+### Marketplace Packaging (US2)
+- [ ] FR-060-06: `media/icon.png` exists and is ≥ 128×128 pixels.
+- [ ] FR-060-07: `package.json` sets `"icon": "media/icon.png"`.
+- [ ] FR-060-08: `CHANGELOG.md` exists with a `## [0.1.0]` section listing shipped features.
+- [ ] FR-060-09: `package.json` sets `"publisher": "ato-copilot"` matching a claimed Marketplace account.
+- [ ] FR-060-10: `package.json` includes `"license"` and `"repository"` fields.
+- [ ] FR-060-11: `vsce package --no-dependencies` exits 0 with no warnings.
+- [ ] FR-060-12: The `.vsix` artifact is uploaded as a CI artifact in the extension CI job.
+
+### Command Coverage (US3)
+- [ ] FR-060-13: All nine command IDs from `contributes.commands` are registered via `vscode.commands.registerCommand`.
+- [ ] FR-060-14: `ato.checkHealth` has a test asserting `mcpClient.getHealth()` is called.
+- [ ] FR-060-15: `ato.configure` has a test asserting the settings UI is opened.
+- [ ] FR-060-16: `ato.signIn` has a test asserting the MSAL device-code flow is initiated.
+- [ ] FR-060-17: `ato.signOut` has a test asserting the cached token is cleared.
+- [ ] FR-060-18: `ato.switchTenant` has a test asserting tenant selection flow.
+- [ ] FR-060-19: `ato.analyzeCurrentFile` has a test asserting editor document is read and MCP called.
+- [ ] FR-060-20: `ato.analyzeWorkspace` has a test asserting workspace file enumeration.
+- [ ] FR-060-21: `ato.followUpSuggestion` has a test asserting chat panel is opened.
+- [ ] FR-060-22: `ato.requestFalsePositive` has a test asserting editor selection is read.
+
+### Configurable MCP URL (US4)
+- [ ] FR-060-23: `mcpClient.ts` reads `ato-copilot.apiUrl` per-request (not cached across configuration changes).
+- [ ] FR-060-24: Extension registers `vscode.workspace.onDidChangeConfiguration` to reset MCP base URL on `ato-copilot.*` changes.
+- [ ] FR-060-25: `mcpClient.test.ts` test verifies a URL change takes effect on the next request without reload.
+- [ ] FR-060-26: README documents all six settings with purpose, type, default, and example values.
+
+## Non-Functional Requirements
+
+- [ ] NFR-060-01: No new TypeScript compiler errors introduced.
+- [ ] NFR-060-02: No new ESLint warnings in CI.
+- [ ] NFR-060-03: All 17 test suites complete within 120 seconds in CI.
+- [ ] NFR-060-04: VSIX package size is < 5 MB (use `--no-dependencies` to exclude `node_modules`).
+- [ ] NFR-060-05: Icon PNG is committed at exactly 128×128 (not upscaled from smaller source).

--- a/specs/060-vscode-extension-v1/contracts/extension-manifest.md
+++ b/specs/060-vscode-extension-v1/contracts/extension-manifest.md
@@ -1,0 +1,120 @@
+# Extension Manifest Contract — 060 VS Code Extension v1.0
+
+This document is the authoritative contract for `extensions/vscode/package.json`
+at the v1.0 release. All fields marked **v1.0 required** must be set before
+`vsce package` is run.
+
+---
+
+## Identity
+
+| Field | Type | v1.0 value | Notes |
+|-------|------|-----------|-------|
+| `name` | string | `ato-copilot-vscode` | npm package name; must be unique on Open VSX / Marketplace |
+| `displayName` | string | `ATO Copilot` | Shown in Extensions sidebar |
+| `version` | string | `0.1.0` | SemVer; bump before publish |
+| `publisher` | string | `ato-copilot` | **Must be a claimed Marketplace account** |
+| `description` | string | (existing) | < 100 chars, no markdown |
+| `icon` | string | `media/icon.png` | **v1.0 required** — 128×128 PNG |
+| `license` | string | `MIT` | **v1.0 required** |
+| `repository` | object | `{ "type": "git", "url": "https://github.com/..." }` | **v1.0 required** |
+| `engines.vscode` | string | `^1.90.0` | Minimum VS Code version |
+| `main` | string | `./dist/src/extension.js` | Compiled entry point |
+
+---
+
+## Activation Events
+
+```json
+"activationEvents": [
+  "onChatParticipant:ato"
+]
+```
+
+The extension activates when the `@ato` chat participant is first invoked.
+All nine palette commands are registered in the `activate()` function regardless
+of activation event.
+
+---
+
+## Chat Participants
+
+```json
+"chatParticipants": [
+  {
+    "id": "ato",
+    "fullName": "ATO Copilot",
+    "name": "ato",
+    "description": "Ask about ATO compliance, NIST 800-53 controls, and infrastructure-as-code",
+    "isSticky": true,
+    "iconPath": "media/icon.svg",
+    "commands": [
+      { "name": "compliance", "description": "Run compliance assessments, query controls, remediation" },
+      { "name": "knowledge",  "description": "Query ATO knowledge base, best practices, documentation" },
+      { "name": "config",     "description": "Manage ATO Copilot configuration settings" }
+    ]
+  }
+]
+```
+
+---
+
+## Commands
+
+All nine commands must be registered via `vscode.commands.registerCommand` in
+`extension.ts` `activate()`. Each must have a test (see
+`checklists/requirements.md` FR-060-13 through FR-060-22).
+
+| `command` | `title` | Handler module | Menu |
+|-----------|---------|---------------|------|
+| `ato.checkHealth` | ATO Copilot: Check API Health | `commands/health.ts` | — |
+| `ato.configure` | ATO Copilot: Configure Connection | `commands/configure.ts` | — |
+| `ato.signIn` | ATO Copilot: Sign In | `commands/signIn.ts` | — |
+| `ato.signOut` | ATO Copilot: Sign Out | `commands/signOut.ts` | — |
+| `ato.switchTenant` | ATO Copilot: Switch Tenant | `commands/switchTenant.ts` | — |
+| `ato.analyzeCurrentFile` | ATO Copilot: Analyze Current File for Compliance | `commands/analyzeFile.ts` | — |
+| `ato.analyzeWorkspace` | ATO Copilot: Analyze Workspace for Compliance | `commands/analyzeWorkspace.ts` | — |
+| `ato.followUpSuggestion` | ATO Copilot: Follow-Up Suggestion | `commands/followUpSuggestion.ts` | — |
+| `ato.requestFalsePositive` | ATO Copilot: Request False Positive | `commands/requestFalsePositive.ts` | `editor/context` when `editorTextFocus` |
+
+---
+
+## Configuration Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ato-copilot.apiUrl` | `string` | `http://localhost:3001` | MCP Server base URL. Examples: `https://ato-copilot-staging.example.com`, `https://ato.example.com` |
+| `ato-copilot.apiKey` | `string` | `""` | API key for authentication (if required). Stored in SecretStorage when non-empty. |
+| `ato-copilot.timeout` | `number` | `30000` | Request timeout in milliseconds. Range: 1000–300000. |
+| `ato-copilot.enableLogging` | `boolean` | `false` | Enable debug logging to the "ATO Copilot" Output channel. |
+| `ato-copilot.tenantId` | `string` | `""` | Home tenant id (GUID). Forwarded as `X-Tenant-Id` on MCP requests. |
+| `ato-copilot.impersonatedTenantId` | `string` | `""` | CSP-Admin impersonated tenant id (GUID). Forwarded as `X-Impersonated-Tenant-Id`. |
+
+---
+
+## Context Menu
+
+```json
+"menus": {
+  "editor/context": [
+    {
+      "command": "ato.requestFalsePositive",
+      "when": "editorTextFocus",
+      "group": "ATO Copilot"
+    }
+  ]
+}
+```
+
+---
+
+## Scripts
+
+| Script | Command | Purpose |
+|--------|---------|---------|
+| `compile` | `tsc -p ./` | Full build to `dist/` |
+| `watch` | `tsc -watch -p ./` | Incremental build |
+| `lint` | `eslint src --ext ts` | Lint source (not tests) |
+| `pretest` | `npm run compile` | Compile before running tests |
+| `test` | `node ./dist/test/runTests.js` | Run mocha suite |
+| `vscode:prepublish` | `npm run compile` | Build before packaging |

--- a/specs/060-vscode-extension-v1/contracts/mcp-client.md
+++ b/specs/060-vscode-extension-v1/contracts/mcp-client.md
@@ -1,0 +1,192 @@
+# MCP Client Contract — 060 VS Code Extension v1.0
+
+This document describes how the VS Code extension calls the ATO Copilot MCP
+server. The implementation lives in `extensions/vscode/src/services/mcpClient.ts`.
+
+---
+
+## Base URL resolution
+
+The MCP server URL is **not hardcoded**. It is read from VS Code settings on
+every request:
+
+```typescript
+import * as vscode from 'vscode';
+
+function getBaseUrl(): string {
+  return vscode.workspace
+    .getConfiguration('ato-copilot')
+    .get<string>('apiUrl', 'http://localhost:3001');
+}
+```
+
+This means changing `ato-copilot.apiUrl` in VS Code settings takes effect on the
+next API call without an extension reload. The extension registers an
+`onDidChangeConfiguration` listener to invalidate any internal cache:
+
+```typescript
+vscode.workspace.onDidChangeConfiguration(e => {
+  if (e.affectsConfiguration('ato-copilot')) {
+    mcpClient.resetBaseUrl();
+  }
+});
+```
+
+---
+
+## HTTP headers forwarded on every request
+
+| Header | Source | Purpose |
+|--------|--------|---------|
+| `Authorization` | `Bearer <accessToken>` from SecretStorage | Azure MSAL token |
+| `X-Tenant-Id` | `ato-copilot.tenantId` setting | Home tenant scope |
+| `X-Impersonated-Tenant-Id` | `ato-copilot.impersonatedTenantId` setting | CSP-Admin impersonation (omitted if empty) |
+| `Content-Type` | `application/json` | All POST/PUT requests |
+
+---
+
+## Endpoints called by each command
+
+### `ato.checkHealth`
+
+```
+GET {apiUrl}/health
+```
+
+**Response**:
+```json
+{ "status": "healthy", "version": "1.0.0" }
+```
+
+On success: `vscode.window.showInformationMessage('ATO Copilot: API is healthy ✓')`
+On error: `vscode.window.showErrorMessage('ATO Copilot: API unreachable — {message}')`
+
+---
+
+### `ato.analyzeCurrentFile`
+
+```
+POST {apiUrl}/api/compliance/analyze-file
+Content-Type: application/json
+
+{
+  "content": "<full text of active editor document>",
+  "fileName": "<basename of editor file>",
+  "language": "<VS Code languageId>"
+}
+```
+
+**Response**: `ComplianceAnalysisResult` (see `mcpClient.ts` for type).
+
+---
+
+### `ato.analyzeWorkspace`
+
+```
+POST {apiUrl}/api/compliance/analyze-workspace
+Content-Type: application/json
+
+{
+  "files": [
+    { "path": "relative/path.tf", "content": "..." },
+    ...
+  ]
+}
+```
+
+**Supported file extensions**: `.bicep`, `.tf`, `.yaml`, `.yml`, `.json`.
+
+---
+
+### `ato.requestFalsePositive`
+
+```
+POST {apiUrl}/api/compliance/false-positive
+Content-Type: application/json
+
+{
+  "findingId": "<uuid from active diagnostic>",
+  "selectedText": "<editor selection text>",
+  "reason": "<user-provided reason string>"
+}
+```
+
+---
+
+### `@ato` chat participant (all slash commands)
+
+The chat participant uses the MCP HTTP SSE endpoint for streaming responses:
+
+```
+POST {apiUrl}/api/chat/stream
+Content-Type: application/json
+Accept: text/event-stream
+
+{
+  "command": "compliance" | "knowledge" | "config",
+  "message": "<user chat message>",
+  "context": { ... }  // VS Code chat context
+}
+```
+
+SSE events:
+```
+data: {"type":"token","content":"..."}
+data: {"type":"done"}
+data: {"type":"error","message":"..."}
+```
+
+Implemented in `src/services/sseClient.ts`.
+
+---
+
+## Timeout
+
+All requests use `ato-copilot.timeout` (default 30 000 ms) as the axios timeout.
+SSE connections use the same timeout for the initial connection; streaming
+continues until the `done` event regardless.
+
+---
+
+## Error handling
+
+| HTTP status | Extension behaviour |
+|-------------|-------------------|
+| `401` | Prompt user to run `ATO Copilot: Sign In` |
+| `403` | Show `showErrorMessage` with role information from response body |
+| `429` | Show `showWarningMessage` with retry-after hint |
+| `5xx` | Show `showErrorMessage` with status code and message |
+| Network error | Show `showErrorMessage('ATO Copilot: Cannot reach server at {apiUrl}')` |
+
+---
+
+## Testing the MCP client
+
+`src/mcpClient.test.ts` uses sinon to stub axios:
+
+```typescript
+import sinon from 'sinon';
+import axios from 'axios';
+
+let getStub: sinon.SinonStub;
+
+beforeEach(() => {
+  getStub = sinon.stub(axios, 'get');
+});
+
+afterEach(() => {
+  sinon.restore();
+});
+
+it('reads apiUrl from settings per request', async () => {
+  const cfgStub = sinon.stub(vscode.workspace, 'getConfiguration')
+    .returns({ get: (k: string) => k === 'apiUrl' ? 'http://test:9999' : undefined } as any);
+
+  getStub.resolves({ data: { status: 'healthy' } });
+
+  await mcpClient.getHealth();
+
+  sinon.assert.calledWith(getStub, sinon.match(/http:\/\/test:9999/));
+  cfgStub.restore();
+});
+```

--- a/specs/060-vscode-extension-v1/data-model.md
+++ b/specs/060-vscode-extension-v1/data-model.md
@@ -1,0 +1,136 @@
+# Data Model — 060 VS Code Extension v1.0
+
+## No Database Entities
+
+The VS Code extension is a pure client-side application. It has no database,
+no backend persistence, and no new API endpoints. This document describes the
+**extension manifest schema** and **VS Code settings schema** as the canonical
+data model for this epic.
+
+---
+
+## Extension Manifest (`package.json`)
+
+The manifest is the authoritative contract between the extension and the VS Code
+host. All fields below are currently set in `extensions/vscode/package.json`.
+
+### Top-level identity fields
+
+| Field | Type | Current value | v1.0 requirement |
+|-------|------|--------------|-----------------|
+| `name` | `string` | `ato-copilot-vscode` | unchanged |
+| `displayName` | `string` | `ATO Copilot` | unchanged |
+| `version` | `string` | `0.1.0` | unchanged for initial release |
+| `publisher` | `string` | `ato-copilot` | must be a **claimed** Marketplace account |
+| `description` | `string` | set | unchanged |
+| `icon` | `string` | _(missing)_ | **`"media/icon.png"`** (128×128 PNG) |
+| `engines.vscode` | `string` | `^1.90.0` | unchanged |
+| `main` | `string` | `./dist/src/extension.js` | unchanged |
+| `license` | `string` | _(missing)_ | **`"MIT"`** |
+| `repository` | `object` | _(missing)_ | **`{ type: "git", url: "..." }`** |
+
+### `contributes.chatParticipants[]`
+
+| Field | Value |
+|-------|-------|
+| `id` | `"ato"` |
+| `fullName` | `"ATO Copilot"` |
+| `name` | `"ato"` (used as `@ato` in chat) |
+| `isSticky` | `true` |
+| `iconPath` | `"media/icon.svg"` |
+| slash commands | `/compliance`, `/knowledge`, `/config` |
+
+### `contributes.commands[]`
+
+See `contracts/extension-manifest.md` for the full table.
+
+### `contributes.configuration` (settings schema)
+
+See VS Code Settings Schema section below.
+
+---
+
+## VS Code Settings Schema
+
+Settings are accessed via `vscode.workspace.getConfiguration('ato-copilot')`.
+
+```jsonc
+{
+  "ato-copilot.apiUrl": {
+    "type": "string",
+    "default": "http://localhost:3001",
+    "description": "MCP Server base URL"
+    // Examples: "https://ato-copilot-staging.example.com"
+    //           "https://ato-copilot.example.com"
+  },
+  "ato-copilot.apiKey": {
+    "type": "string",
+    "default": "",
+    "description": "API key for authentication (if required by the MCP server)"
+    // Stored in VS Code SecretStorage when non-empty.
+  },
+  "ato-copilot.timeout": {
+    "type": "number",
+    "default": 30000,
+    "description": "Request timeout in milliseconds",
+    "minimum": 1000,
+    "maximum": 300000
+  },
+  "ato-copilot.enableLogging": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable debug logging to the ATO Copilot output channel"
+  },
+  "ato-copilot.tenantId": {
+    "type": "string",
+    "default": "",
+    "description": "Caller home tenant id (Guid). Forwarded on outbound MCP requests."
+  },
+  "ato-copilot.impersonatedTenantId": {
+    "type": "string",
+    "default": "",
+    "description": "Optional CSP-Admin impersonated tenant id (Guid)."
+  }
+}
+```
+
+### TypeScript type for settings
+
+```typescript
+// src/services/config.ts
+export interface AtoExtensionConfig {
+  apiUrl: string;
+  apiKey: string;
+  timeout: number;
+  enableLogging: boolean;
+  tenantId: string;
+  impersonatedTenantId: string;
+}
+
+export function getConfig(): AtoExtensionConfig {
+  const cfg = vscode.workspace.getConfiguration('ato-copilot');
+  return {
+    apiUrl:                cfg.get<string>('apiUrl', 'http://localhost:3001'),
+    apiKey:                cfg.get<string>('apiKey', ''),
+    timeout:               cfg.get<number>('timeout', 30_000),
+    enableLogging:         cfg.get<boolean>('enableLogging', false),
+    tenantId:              cfg.get<string>('tenantId', ''),
+    impersonatedTenantId:  cfg.get<string>('impersonatedTenantId', ''),
+  };
+}
+```
+
+---
+
+## SecretStorage schema
+
+Auth tokens cached by `src/auth/secretStorage.ts`:
+
+| Key | Value |
+|-----|-------|
+| `ato-copilot.accessToken` | Azure MSAL access token JWT |
+| `ato-copilot.refreshToken` | MSAL refresh token |
+
+These are written by `ato.signIn` and cleared by `ato.signOut`. They are
+**not** part of `contributes.configuration` — they live exclusively in
+`vscode.ExtensionContext.secrets`.

--- a/specs/060-vscode-extension-v1/plan.md
+++ b/specs/060-vscode-extension-v1/plan.md
@@ -1,0 +1,59 @@
+# Plan — 060 VS Code Extension v1.0
+
+## Delivery order
+
+```
+Week 1 — Tests green (P1)
+├── T01  Audit 17 test files for errors
+├── T02  Fix compilation errors
+├── T03  Verify/fix runner wiring (spec 053 dependency)
+└── T04  Fix runtime test failures
+
+Week 1 — Marketplace packaging (P1, parallelisable with tests)
+├── T05  Generate media/icon.png
+├── T06  Create CHANGELOG.md
+├── T07  Claim publisher + fix package.json fields
+└── T08  Add vsce package step to CI
+
+Week 2 — Command coverage (P2)
+├── T09  Gap audit
+├── T10  followUpSuggestion test
+├── T11  requestFalsePositive test
+└── T12  checkHealth + configure tests
+
+Week 2 — Config change propagation (P2)
+├── T13  onDidChangeConfiguration listener
+├── T14  Config change test
+└── T15  README settings update
+```
+
+## Dependency on spec 053
+
+Spec 053 / Issue #137 adds `npm test` to the CI job. If 053 is not merged when
+work on 060 begins, T03 covers the minimal runner wiring needed to unblock test
+execution. The 060 branch should be rebased on 053 once that branch merges to
+avoid duplicate CI changes.
+
+## Branch strategy
+
+`feat/060-vscode-extension-v1` off `main`. Commit structure:
+
+1. `fix(vscode): resolve test compilation errors`
+2. `fix(vscode): fix runtime test failures — N/17 pass`
+3. `feat(vscode): add icon.png, CHANGELOG.md, publisher fields for Marketplace`
+4. `ci(vscode): add vsce package step and test run to CI`
+5. `test(vscode): add missing command handler tests`
+6. `feat(vscode): propagate config changes via onDidChangeConfiguration`
+
+## Definition of Done
+
+- [ ] `npm test` exits 0 in CI with all 17 suites reported.
+- [ ] `vsce package --no-dependencies` exits 0 with no warnings.
+- [ ] `ato-copilot.vsix` artifact uploaded in CI.
+- [ ] All nine command IDs have `registerCommand` + at least one test.
+- [ ] `mcpClient.ts` reads base URL per-request; test proves config change
+      takes effect without extension reload.
+- [ ] `CHANGELOG.md` exists with `## [0.1.0]` entry.
+- [ ] `media/icon.png` (128×128) committed.
+- [ ] No new TypeScript compiler errors.
+- [ ] No new ESLint warnings.

--- a/specs/060-vscode-extension-v1/quickstart.md
+++ b/specs/060-vscode-extension-v1/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart — 060 VS Code Extension v1.0
+
+## Prerequisites
+
+- Node ≥ 20, npm ≥ 10
+- VS Code ≥ 1.90.0
+- `vsce` CLI: `npm install -g @vscode/vsce`
+- For icon conversion: ImageMagick (`convert`) or `sharp` npm package
+
+## Install dependencies
+
+```bash
+cd extensions/vscode
+npm install
+```
+
+## Compile the extension
+
+```bash
+npm run compile
+# Output: dist/src/, dist/test/
+```
+
+## Run tests
+
+```bash
+# Headless (CI-safe, requires xvfb on Linux)
+xvfb-run -a npm test
+
+# Developer machine (launches Extension Development Host)
+npm test
+```
+
+All 17 suites should report green. If any fail, check:
+1. `dist/src/` exists (compile step ran).
+2. `dist/test/runTests.js` exists.
+3. VS Code binary is available (installed via `@vscode/test-electron`).
+
+## Generate the icon PNG
+
+```bash
+# Using ImageMagick
+convert -background none media/icon.svg -resize 128x128 media/icon.png
+
+# Using sharp (if ImageMagick unavailable)
+node -e "require('sharp')('media/icon.svg').resize(128,128).png().toFile('media/icon.png', (e,i) => console.log(e||i))"
+```
+
+## Package for Marketplace
+
+```bash
+# Produces ato-copilot-vscode-0.1.0.vsix
+vsce package --no-dependencies
+
+# Inspect contents (no warnings should appear)
+vsce ls
+```
+
+## Install locally from VSIX
+
+```bash
+code --install-extension ato-copilot-vscode-0.1.0.vsix
+```
+
+## Test the extension end-to-end
+
+1. Press `F5` in VS Code (or install the VSIX) to launch Extension Development Host.
+2. Open GitHub Copilot Chat (`Ctrl+Shift+I` / `Cmd+Shift+I`).
+3. Type `@ato /compliance list controls for AC-2`.
+4. Run `Ctrl+Shift+P` → `ATO Copilot: Check API Health` — verify success message.
+5. Run `Ctrl+Shift+P` → `ATO Copilot: Configure Connection` — verify settings UI opens.
+
+## Publish to Marketplace (release engineers only)
+
+```bash
+# Requires VSCE_TOKEN env var (PAT from marketplace.visualstudio.com)
+vsce login ato-copilot
+vsce publish
+```

--- a/specs/060-vscode-extension-v1/research.md
+++ b/specs/060-vscode-extension-v1/research.md
@@ -1,0 +1,88 @@
+# Research — 060 VS Code Extension v1.0
+
+## Test infrastructure gap
+
+The `vscode-extension-compile` CI job (`.github/workflows/ci.yml` lines 49-72)
+runs only:
+```yaml
+- name: Compile extension
+  run: npm run compile
+```
+
+There is no `npm test` step. The 17 `.test.ts` files in `src/` are compiled but
+never executed. This means any regression since the test files were written is
+undetected by CI.
+
+`package.json` defines:
+```json
+"test": "node ./dist/test/runTests.js"
+```
+
+The runner file `dist/test/runTests.js` is compiled from `test/runTests.ts`
+(if it exists). If that source file is missing, the test step will fail with
+"cannot find module". Spec 053 / Issue #137 addresses the runner wiring.
+
+## Publisher registration process
+
+`vsce` (the VS Code extension CLI) enforces that the `publisher` value in
+`package.json` matches an account registered at
+`https://marketplace.visualstudio.com/manage`. Steps:
+
+1. Log in to marketplace.visualstudio.com with the org Microsoft account.
+2. Create a Personal Access Token (PAT) with Marketplace → Publish scope.
+3. `vsce login ato-copilot` using the PAT.
+4. `vsce package` then `vsce publish`.
+
+The PAT must be stored as a GitHub Actions secret (`VSCE_TOKEN`) for automated
+publishing.
+
+## Icon requirements
+
+`vsce` validates:
+- Icon path exists.
+- Icon is PNG (not SVG — SVG is rejected by the Marketplace renderer).
+- Minimum 128×128 pixels.
+
+`media/icon.svg` exists. Conversion to PNG can be done with:
+```bash
+# Option A: sharp (Node)
+node -e "require('sharp')('media/icon.svg').resize(128,128).png().toFile('media/icon.png')"
+
+# Option B: ImageMagick
+convert -background none media/icon.svg -resize 128x128 media/icon.png
+```
+
+## MCP client architecture
+
+`src/services/mcpClient.ts` uses `axios`. The base URL is read from
+`vscode.workspace.getConfiguration('ato-copilot').get('apiUrl')` at call time.
+This means changing the setting takes effect on the next API call without
+requiring extension reload — a good pattern to verify via test.
+
+The `tenantId` and `impersonatedTenantId` settings are forwarded as HTTP headers
+(`X-Tenant-Id`, `X-Impersonated-Tenant-Id`) on every MCP request per the
+Feature 048 contract.
+
+## Mocha runner compatibility with headless CI
+
+`@vscode/test-electron` launches a real VS Code process with a hidden window
+for testing. This works in CI only if `xvfb` (X virtual framebuffer) is
+available. On GitHub Actions `ubuntu-latest` runners, `xvfb-run` is available.
+
+The CI test step should use:
+```yaml
+- name: Run extension tests
+  run: xvfb-run -a npm test
+  working-directory: extensions/vscode
+```
+
+Alternatively, tests that do not need the VS Code runtime can be run with
+plain `mocha` by mocking the `vscode` module (the `test/mocks/vscode.ts` pattern).
+Inspecting the existing test files will determine which approach is required.
+
+## `vsce` packaging warnings
+
+Running `vsce package` on the current state will warn:
+- `WARNING Extension 'ato-copilot-vscode' has no icon.` → fixed by T05.
+- `WARNING No CHANGELOG.md found.` → fixed by T06.
+- Potential warning on missing `repository` field in package.json → fixed by T07.

--- a/specs/060-vscode-extension-v1/spec.md
+++ b/specs/060-vscode-extension-v1/spec.md
@@ -1,0 +1,206 @@
+# Feature Specification: VS Code Extension v1.0 — Marketplace + Commands + Tests
+
+**Feature Branch**: `060-vscode-extension-v1`
+**Created**: 2026-06-03
+**Status**: Draft
+**GitHub Issue**: #128
+**Depends on**: Issue #137 / Spec 053 (CI wiring for VS Code tests — tests must
+be *runnable* in CI before this spec can make them *green*)
+
+## Background
+
+The ATO Copilot VS Code extension (`extensions/vscode/`) is functionally rich —
+it ships a GitHub Copilot Chat participant (`@ato`), nine palette commands, IaC
+diagnostics, code actions, an analysis panel, PIM flow, and Azure MSAL auth.
+However, three blockers prevent it from reaching the VS Code Marketplace:
+
+1. **Tests never run in CI.** The `vscode-extension-compile` CI job only
+   compiles (`npm run compile`). The 16 mocha test files in `src/` (co-located
+   with source, not in a `test/suite/` directory) are never executed. Spec 053 /
+   Issue #137 wires the runner; this spec makes the tests green.
+
+2. **Publisher field is a placeholder.** `package.json` sets
+   `"publisher": "ato-copilot"` — a value that must be claimed on the VS Code
+   Marketplace before `vsce publish` can succeed. The `CHANGELOG.md`, icon, and
+   packaging script also need verification.
+
+3. **Commands lack uniform test coverage.** The nine `contributes.commands`
+   entries each have implementations in `src/commands/`, but some tests are stubs
+   or test only the happy path without mocking the MCP client.
+
+### Verified state of the code
+
+**`package.json` summary**
+
+| Field | Value |
+|-------|-------|
+| `name` | `ato-copilot-vscode` |
+| `displayName` | `ATO Copilot` |
+| `version` | `0.1.0` |
+| `publisher` | `ato-copilot` (must be claimed on Marketplace) |
+| `engines.vscode` | `^1.90.0` |
+| `main` | `./dist/src/extension.js` |
+| `activationEvents` | `["onChatParticipant:ato"]` |
+
+**Registered commands** (from `contributes.commands`):
+
+| Command ID | Title |
+|-----------|-------|
+| `ato.checkHealth` | ATO Copilot: Check API Health |
+| `ato.configure` | ATO Copilot: Configure Connection |
+| `ato.signIn` | ATO Copilot: Sign In |
+| `ato.signOut` | ATO Copilot: Sign Out |
+| `ato.switchTenant` | ATO Copilot: Switch Tenant |
+| `ato.analyzeCurrentFile` | ATO Copilot: Analyze Current File for Compliance |
+| `ato.analyzeWorkspace` | ATO Copilot: Analyze Workspace for Compliance |
+| `ato.followUpSuggestion` | ATO Copilot: Follow-Up Suggestion |
+| `ato.requestFalsePositive` | ATO Copilot: Request False Positive |
+
+**Configuration settings** (from `contributes.configuration`):
+
+| Key | Type | Default |
+|-----|------|---------|
+| `ato-copilot.apiUrl` | `string` | `http://localhost:3001` |
+| `ato-copilot.apiKey` | `string` | `""` |
+| `ato-copilot.timeout` | `number` | `30000` |
+| `ato-copilot.enableLogging` | `boolean` | `false` |
+| `ato-copilot.tenantId` | `string` | `""` |
+| `ato-copilot.impersonatedTenantId` | `string` | `""` |
+
+**Source structure** (directories under `src/`):
+`auth/`, `codeActions/`, `commands/`, `diagnostics/`, `panels/`, `services/`,
+`webview/` + `extension.ts`, `participant.ts`
+
+**Test files** (co-located in `src/`, not in `test/suite/`):
+`analysisPanel.test.ts`, `analysisPanelActions.test.ts`,
+`analysisPanelGrouping.test.ts`, `analyzeCommands.test.ts`,
+`complianceFinding.test.ts`, `exportWorkspace.test.ts`, `iacCodeActions.test.ts`,
+`iacDiagnostics.test.ts`, `mcpClient.test.ts`, `participant.test.ts`,
+`participantAttribution.test.ts`, `participantComplianceSummary.test.ts`,
+`participantEnrichment.test.ts`, `participantStreaming.test.ts`,
+`pimFlow.test.ts`, `rmfPanel.test.ts`, `sseClient.test.ts`
+
+**CI gap**: `vscode-extension-compile` job runs `npm run compile` only. No
+`npm test` step exists. Spec 053 / Issue #137 adds the runner step; this spec's
+US1 ensures all 17 test files pass once wired.
+
+**MCP client**: `src/services/mcpClient.ts` — uses `axios` with base URL read
+from `vscode.workspace.getConfiguration('ato-copilot').get('apiUrl')` at call
+time (configurable, not hardcoded).
+
+## Clarifications
+
+- **Q: Should the publisher be `ato-copilot` or `nous-research`?**
+  **A:** Register `ato-copilot` publisher on marketplace.visualstudio.com. If
+  the org decides to publish under `nous-research`, the package.json value and
+  the VSIX display name must change together. This spec uses `ato-copilot` as
+  the target.
+
+- **Q: Is `CHANGELOG.md` missing or just incomplete?**
+  **A:** A placeholder `CHANGELOG.md` must be created with at least a `## 0.1.0`
+  entry listing the features shipped. `vsce` rejects packages with no changelog.
+
+- **Q: Does the extension need an icon PNG for Marketplace listing?**
+  **A:** `media/icon.svg` exists. `vsce` requires a PNG ≥ 128×128. Add
+  `media/icon.png` (128×128) and set `"icon": "media/icon.png"` in `package.json`.
+
+- **Q: Should `ato.followUpSuggestion` and `ato.requestFalsePositive` remain as
+  commands, or are they internal participant actions?**
+  **A:** Keep as registered commands; add tests that verify the command handlers
+  are registered and do not throw on invocation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — All mocha tests pass in CI (Priority: P1)
+
+**As a** maintainer
+**I want** all 17 VS Code mocha test files to pass in CI
+**So that** regressions in the extension are caught automatically before merge.
+
+**Why this priority**: Tests exist but never run. Any breaking change since the
+test files were written is currently invisible. Making tests green in CI is
+the foundational quality gate for everything else in this epic.
+
+**Independent Test**: `npm test` in `extensions/vscode/` exits 0 with all
+17 suites reporting. Delivers standalone value: CI now catches regressions.
+
+**Acceptance**
+- Every `.test.ts` file in `src/` compiles without error.
+- `npm test` exits 0 on developer machines and in the CI job added by spec 053.
+- Test runner output lists each suite by file name; no suite is skipped.
+- Failing tests are fixed, not deleted (if a test asserts wrong behavior, fix
+  the implementation or the assertion with a comment explaining the change).
+
+### User Story 2 — Marketplace-publishable package (Priority: P1)
+
+**As a** release engineer
+**I want** `vsce package` to produce a valid `.vsix` without warnings
+**So that** the extension can be submitted to the VS Code Marketplace.
+
+**Why this priority**: Extension value is locked to internal developer machines
+until it ships on the Marketplace. The packaging blockers (icon, changelog,
+publisher) are each one-line fixes that unlock distribution to the broader ATO
+practitioner community.
+
+**Independent Test**: Run `vsce package --no-dependencies` in `extensions/vscode/`;
+assert exit code 0 and the output `.vsix` exists; inspect the manifest with
+`vsce ls` and assert no warnings about missing icon, changelog, or publisher.
+
+**Acceptance**
+- `"icon": "media/icon.png"` set in `package.json`.
+- `media/icon.png` exists (128×128 PNG, generated from existing SVG).
+- `CHANGELOG.md` exists with at minimum a `## [0.1.0]` section.
+- `publisher` field in `package.json` is `"ato-copilot"` (matching a claimed
+  Marketplace publisher account).
+- `vsce package` exits 0 with no warnings.
+- `.vsix` artifact is uploaded as a CI artifact in the `vscode-extension-compile`
+  job (or a new `vscode-extension-package` job).
+
+### User Story 3 — All commands tested (Priority: P2)
+
+**As a** developer
+**I want** every command in `contributes.commands` to have an implementation
+and a test
+**So that** users never invoke a command and see "command not found" or a JS
+exception.
+
+**Why this priority**: P2 — the commands are implemented but test coverage is
+uneven. Some test files focus on participant behavior; commands like
+`ato.followUpSuggestion` and `ato.requestFalsePositive` lack dedicated tests.
+
+**Independent Test**: For each command ID, assert: (a) a `registerCommand` call
+exists in `extension.ts` or a commands/ module, and (b) a test file exercises
+the handler. `npm test` passes.
+
+**Acceptance**
+- All nine command IDs are registered via `vscode.commands.registerCommand`.
+- Each command has at least one test that: invokes the handler, asserts no
+  exception thrown, and asserts the expected VS Code API calls were made
+  (using sinon stubs for `vscode.window.*`, `vscode.commands.*`).
+- `ato.requestFalsePositive` test verifies it reads editor selection text.
+- `ato.followUpSuggestion` test verifies it opens a chat panel.
+
+### User Story 4 — Configurable MCP server URL (Priority: P2)
+
+**As a** developer using a non-default MCP server deployment
+**I want** the extension to read its MCP server URL from VS Code settings
+**So that** I can point it at staging, prod, or a self-hosted instance without
+editing source code.
+
+**Why this priority**: P2 — `mcpClient.ts` already reads from
+`ato-copilot.apiUrl` at call time. This story validates the contract, adds a
+settings-change listener, and ensures tests cover the config path.
+
+**Independent Test**: In `mcpClient.test.ts`, stub
+`vscode.workspace.getConfiguration` to return `http://custom:9999`; assert the
+axios request targets `http://custom:9999/...`. Change stub mid-test; assert next
+call uses updated URL.
+
+**Acceptance**
+- `mcpClient.ts` reads `ato-copilot.apiUrl` per-request (already implemented;
+  verify by test).
+- Extension registers a `vscode.workspace.onDidChangeConfiguration` listener
+  that invalidates any cached base URL when `ato-copilot.*` settings change.
+- `ato-copilot.apiUrl` default `http://localhost:3001` matches the default MCP
+  server dev port.
+- Settings documented in README with example values for staging and prod.

--- a/specs/060-vscode-extension-v1/tasks.md
+++ b/specs/060-vscode-extension-v1/tasks.md
@@ -1,0 +1,192 @@
+# Tasks — 060 VS Code Extension v1.0
+
+## Milestone 1 — Make tests green (US1, P1)
+
+### T01 — Audit all 17 test files for compilation errors
+**Work**:
+- `npm run compile` with full output; collect every TS error from `.test.ts` files.
+- Categorise errors: wrong import path, missing mock type, changed API signature.
+- Output: a triage table (file → error → fix action).
+
+**Estimate**: 2 pts
+
+---
+
+### T02 — Fix test compilation errors
+**Work**: Apply fixes identified in T01. No test should be deleted; every
+failing assertion should be fixed at the implementation level or the assertion
+updated with an explanatory comment.
+
+Common expected fixes:
+- Update sinon stub types for `vscode.window.showInformationMessage`.
+- Align `mcpClient.test.ts` mock shape with current `McpClient` interface.
+- Fix import paths broken by any directory restructure.
+
+**Estimate**: 3 pts
+
+---
+
+### T03 — Verify test runner wiring (from spec 053)
+**Work**:
+- Confirm `dist/test/runTests.js` exists after compile.
+- Confirm `test/runTests.ts` (or equivalent) uses `@vscode/test-electron` or a
+  headless runner compatible with CI (no display server required).
+- If spec 053 is not yet merged, apply the minimal runner setup here:
+  - Add `"test:headless": "node ./dist/src/runTests.js"` script.
+  - Use `@vscode/test-electron` with `extensionDevelopmentPath` set.
+- Add `npm test` step to CI `vscode-extension-compile` job.
+
+**Estimate**: 2 pts (0 if spec 053 already merged)
+
+---
+
+### T04 — Run full test suite; fix remaining failures
+**Work**: `npm test` in CI; triage any runtime failures (e.g., missing VS Code
+API stubs at runtime). Fix each failure; do not skip.
+
+**Estimate**: 3 pts
+
+---
+
+## Milestone 2 — Marketplace packaging (US2, P1)
+
+### T05 — Generate `media/icon.png`
+**Work**:
+- Convert existing `media/icon.svg` to `media/icon.png` at 128×128 using
+  `sharp`, `inkscape --export-png`, or a one-time script.
+- Commit the PNG; add `"icon": "media/icon.png"` to `package.json`.
+
+**Estimate**: 1 pt
+
+---
+
+### T06 — Create `CHANGELOG.md`
+**Work**:
+- Create `CHANGELOG.md` following
+  [Keep a Changelog](https://keepachangelog.com/) format.
+- Minimum content:
+  ```md
+  ## [0.1.0] — 2026-06-03
+  ### Added
+  - @ato chat participant with /compliance, /knowledge, /config slash commands
+  - Analyze current file and workspace commands
+  - Azure MSAL sign-in (device code flow)
+  - IaC diagnostics and code actions for Bicep, Terraform, YAML
+  - RMF panel and analysis panel
+  - Export results as Markdown, JSON, or HTML
+  ```
+
+**Estimate**: 1 pt
+
+---
+
+### T07 — Claim publisher and verify `package.json`
+**Work**:
+- Register `ato-copilot` publisher account at marketplace.visualstudio.com
+  (one-time human action; document in `CONTRIBUTING.md`).
+- Verify `package.json` fields: `name`, `displayName`, `publisher`, `icon`,
+  `repository`, `license` (add MIT `LICENSE` file if absent).
+
+**Estimate**: 1 pt
+
+---
+
+### T08 — Add `vsce package` to CI
+**Work**:
+- Add `npx vsce package --no-dependencies -o ato-copilot.vsix` step to
+  `vscode-extension-compile` CI job (after compile).
+- Upload `ato-copilot.vsix` as a CI artifact.
+- Assert step exits 0 (packaging failure = CI failure).
+
+**Estimate**: 1 pt
+
+---
+
+## Milestone 3 — Command test coverage (US3, P2)
+
+### T09 — Audit command registration and test gaps
+**Work**: For each of the nine command IDs, verify:
+1. `registerCommand('ato.X', handler)` call exists.
+2. A test file exercises the handler.
+
+Output a gap table; create stub test files for commands with no coverage.
+
+**Estimate**: 1 pt
+
+---
+
+### T10 — Add tests for `ato.followUpSuggestion`
+**Work**: Create `src/followUpSuggestion.test.ts` (or add to
+`analyzeCommands.test.ts`). Stub `vscode.commands.executeCommand` for
+`workbench.action.chat.open`; assert it is called with the expected query.
+
+**Estimate**: 2 pts
+
+---
+
+### T11 — Add tests for `ato.requestFalsePositive`
+**Work**: Add tests verifying the handler reads `editor.selection` text and
+posts to the MCP false-positive endpoint (stub `mcpClient`).
+
+**Estimate**: 2 pts
+
+---
+
+### T12 — Add tests for `ato.checkHealth` and `ato.configure`
+**Work**: `ato.checkHealth` test asserts `mcpClient.getHealth()` called and
+result shown via `showInformationMessage`. `ato.configure` test asserts
+`vscode.commands.executeCommand('workbench.action.openSettings', ...)` called.
+
+**Estimate**: 2 pts
+
+---
+
+## Milestone 4 — Configurable MCP URL (US4, P2)
+
+### T13 — Add `onDidChangeConfiguration` listener
+**File**: `src/extension.ts`
+**Work**:
+- Register `vscode.workspace.onDidChangeConfiguration(e => { if (e.affectsConfiguration('ato-copilot')) { mcpClient.resetBaseUrl(); } })`.
+- Add `resetBaseUrl()` method to `McpClient` class.
+
+**Estimate**: 1 pt
+
+---
+
+### T14 — Test config change propagation in `mcpClient.test.ts`
+**Work**:
+- Add test: stub config to return URL A, make request, assert URL A used.
+- Change stub to URL B, call `resetBaseUrl()`, make request, assert URL B used.
+
+**Estimate**: 2 pts
+
+---
+
+### T15 — Update README settings table
+**Work**: Add staging and prod example values to README `## Configuration` section.
+Document each setting key with its purpose and example.
+
+**Estimate**: 1 pt
+
+---
+
+## Summary
+
+| Task | US | Points | Priority |
+|------|----|--------|----------|
+| T01 Audit test compilation | US1 | 2 | P1 |
+| T02 Fix test errors | US1 | 3 | P1 |
+| T03 Runner wiring | US1 | 2 | P1 |
+| T04 Runtime failures | US1 | 3 | P1 |
+| T05 icon.png | US2 | 1 | P1 |
+| T06 CHANGELOG | US2 | 1 | P1 |
+| T07 Publisher + package.json | US2 | 1 | P1 |
+| T08 vsce in CI | US2 | 1 | P1 |
+| T09 Command gap audit | US3 | 1 | P2 |
+| T10 followUpSuggestion test | US3 | 2 | P2 |
+| T11 requestFalsePositive test | US3 | 2 | P2 |
+| T12 checkHealth + configure test | US3 | 2 | P2 |
+| T13 onDidChangeConfiguration | US4 | 1 | P2 |
+| T14 Config change test | US4 | 2 | P2 |
+| T15 README settings | US4 | 1 | P2 |
+| **Total** | | **25** | |


### PR DESCRIPTION
Wave 1 specs 059 and 060. AuditQueryEndpoints, AdminMigrationEndpoints, NotificationEndpoints, DeploymentEndpoints confirmed mounted in Program.cs but have zero dashboard consumers. VS Code CI job only compiles — 17 mocha tests never execute.