### PR TITLE
fix(055): wrap BeginTransaction in CreateExecutionStrategy for SQL Server retry compat

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/AlertManager.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/AlertManager.cs
@@ -358,33 +358,40 @@ public class AlertManager : IAlertManager
 
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        // Use a transaction for atomic increment
-        await using var transaction = await db.Database.BeginTransactionAsync(cancellationToken);
-        try
+        // Use a transaction for atomic increment. SqlServerRetryingExecutionStrategy
+        // requires user-initiated transactions to be wrapped in CreateExecutionStrategy().
+        string alertId = null!;
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
-            var counter = await db.AlertIdCounters.FindAsync(new object[] { today }, cancellationToken);
-
-            if (counter == null)
+            await using var transaction = await db.Database.BeginTransactionAsync(cancellationToken);
+            try
             {
-                counter = new AlertIdCounter { Date = today, LastSequence = 1 };
-                db.AlertIdCounters.Add(counter);
+                var counter = await db.AlertIdCounters.FindAsync(new object[] { today }, cancellationToken);
+
+                if (counter == null)
+                {
+                    counter = new AlertIdCounter { Date = today, LastSequence = 1 };
+                    db.AlertIdCounters.Add(counter);
+                }
+                else
+                {
+                    counter.LastSequence++;
+                }
+
+                await db.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+
+                // Format: ALT-YYYYMMDDNNNNN
+                alertId = $"ALT-{today:yyyyMMdd}{counter.LastSequence:D5}";
             }
-            else
+            catch
             {
-                counter.LastSequence++;
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
             }
-
-            await db.SaveChangesAsync(cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
-
-            // Format: ALT-YYYYMMDDNNNNN
-            return $"ALT-{today:yyyyMMdd}{counter.LastSequence:D5}";
-        }
-        catch
-        {
-            await transaction.RollbackAsync(cancellationToken);
-            throw;
-        }
+        });
+        return alertId;
     }
 
     /// <inheritdoc />

--- a/src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Templates/OrganizationTemplateService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Templates/OrganizationTemplateService.cs
@@ -300,35 +300,41 @@ public sealed class OrganizationTemplateService : IOrganizationTemplateService
     {
         await using var db = await _factory.CreateDbContextAsync(ct);
         var supportsTx = db.Database.IsRelational();
-        await using var tx = supportsTx
-            ? await db.Database.BeginTransactionAsync(ct)
-            : null;
-        var target = await db.OrganizationDocumentTemplates
-            .FirstOrDefaultAsync(t => t.TenantId == tenantId && t.Id == templateId, ct)
-            ?? throw new KeyNotFoundException("Template not found.");
 
-        var prevDefaults = await db.OrganizationDocumentTemplates
-            .Where(t => t.TenantId == tenantId
-                     && t.TemplateType == target.TemplateType
-                     && t.IsDefault
-                     && t.Id != target.Id)
-            .ToListAsync(ct);
-        foreach (var p in prevDefaults)
+        OrganizationDocumentTemplate? target = null;
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
-            p.IsDefault = false;
-            p.UpdatedAt = DateTimeOffset.UtcNow;
-            p.UpdatedBy = actorUserId;
-        }
-        target.IsDefault = true;
-        target.UpdatedAt = DateTimeOffset.UtcNow;
-        target.UpdatedBy = actorUserId;
-        await db.SaveChangesAsync(ct);
-        if (tx is not null) await tx.CommitAsync(ct);
+            await using var tx = supportsTx
+                ? await db.Database.BeginTransactionAsync(ct)
+                : null;
+            target = await db.OrganizationDocumentTemplates
+                .FirstOrDefaultAsync(t => t.TenantId == tenantId && t.Id == templateId, ct)
+                ?? throw new KeyNotFoundException("Template not found.");
+
+            var prevDefaults = await db.OrganizationDocumentTemplates
+                .Where(t => t.TenantId == tenantId
+                         && t.TemplateType == target.TemplateType
+                         && t.IsDefault
+                         && t.Id != target.Id)
+                .ToListAsync(ct);
+            foreach (var p in prevDefaults)
+            {
+                p.IsDefault = false;
+                p.UpdatedAt = DateTimeOffset.UtcNow;
+                p.UpdatedBy = actorUserId;
+            }
+            target.IsDefault = true;
+            target.UpdatedAt = DateTimeOffset.UtcNow;
+            target.UpdatedBy = actorUserId;
+            await db.SaveChangesAsync(ct);
+            if (tx is not null) await tx.CommitAsync(ct);
+        });
 
         await _audit.RecordAsync(
             tenantId, actorUserId, WizardAuditAction.TemplateMarkedDefault,
             $"Template/{templateId:D}", null, null,
-            JsonSerializer.Serialize(new { target.TemplateType, target.Label }),
+            JsonSerializer.Serialize(new { target!.TemplateType, target.Label }),
             null, Guid.NewGuid(), ct);
 
         return target;

--- a/src/Ato.Copilot.Core/Services/Tenancy/CspInheritedComponentService.cs
+++ b/src/Ato.Copilot.Core/Services/Tenancy/CspInheritedComponentService.cs
@@ -219,42 +219,50 @@ public sealed class CspInheritedComponentService : ICspInheritedComponentService
         // Begin a transaction so the capability INSERT and the 1–2 history
         // INSERTs commit atomically. SQLite InMemory provider ignores
         // transactions; SqlServer / file-backed SQLite honors them per FR-004.
-        var supportsTransactions = db.Database.ProviderName?.Contains("InMemory", StringComparison.OrdinalIgnoreCase) != true;
-        await using var tx = supportsTransactions
-            ? await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
-            : null;
-
-        await db.CspInheritedCapabilities.AddAsync(capability, ct).ConfigureAwait(false);
-
-        // History row #1: Created. Metadata only when the override was used.
-        await _history.AppendAsync(
-            db, capability.Id, tenantId,
-            CapabilityHistoryEventType.Created,
-            actorOid: actor,
-            summary: "Capability manually created.",
-            metadata: markMappedImmediately
-                ? new { markedMappedImmediately = true }
-                : null,
-            ct).ConfigureAwait(false);
-
-        // History row #2: Reviewed — only when the creator opted to skip
-        // review at creation time (FR-001 override path).
-        if (markMappedImmediately)
+        //
+        // SqlServerRetryingExecutionStrategy does not support user-initiated
+        // transactions unless they are wrapped in CreateExecutionStrategy().ExecuteAsync.
+        // See: https://learn.microsoft.com/ef/core/miscellaneous/connection-resiliency
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
+            var supportsTransactions = db.Database.ProviderName?.Contains("InMemory", StringComparison.OrdinalIgnoreCase) != true;
+            await using var tx = supportsTransactions
+                ? await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+                : null;
+
+            await db.CspInheritedCapabilities.AddAsync(capability, ct).ConfigureAwait(false);
+
+            // History row #1: Created. Metadata only when the override was used.
             await _history.AppendAsync(
                 db, capability.Id, tenantId,
-                CapabilityHistoryEventType.Reviewed,
+                CapabilityHistoryEventType.Created,
                 actorOid: actor,
-                summary: "Reviewed and approved at creation time.",
-                metadata: new { reviewerNote = "Mapped on create by creator." },
+                summary: "Capability manually created.",
+                metadata: markMappedImmediately
+                    ? new { markedMappedImmediately = true }
+                    : null,
                 ct).ConfigureAwait(false);
-        }
 
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
-        if (tx is not null)
-        {
-            await tx.CommitAsync(ct).ConfigureAwait(false);
-        }
+            // History row #2: Reviewed — only when the creator opted to skip
+            // review at creation time (FR-001 override path).
+            if (markMappedImmediately)
+            {
+                await _history.AppendAsync(
+                    db, capability.Id, tenantId,
+                    CapabilityHistoryEventType.Reviewed,
+                    actorOid: actor,
+                    summary: "Reviewed and approved at creation time.",
+                    metadata: new { reviewerNote = "Mapped on create by creator." },
+                    ct).ConfigureAwait(false);
+            }
+
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            if (tx is not null)
+            {
+                await tx.CommitAsync(ct).ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Manually added CspInheritedCapability {CapabilityId} ('{Name}') to component {ComponentId} by {Actor}; markMappedImmediately={Override}",
@@ -825,10 +833,10 @@ public sealed class CspInheritedComponentService : ICspInheritedComponentService
         // SQLite/SqlServer honor transactions; InMemory does not. Keep parity
         // with AddCapabilityAsync so unit tests stay green on InMemory while
         // SQL providers get true atomicity.
-        var supportsTransactions = db.Database.ProviderName?.Contains("InMemory", StringComparison.OrdinalIgnoreCase) != true;
-        await using var tx = supportsTransactions
-            ? await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
-            : null;
+        //
+        // SqlServerRetryingExecutionStrategy does not support user-initiated
+        // transactions unless they are wrapped in CreateExecutionStrategy().ExecuteAsync.
+        // See: https://learn.microsoft.com/ef/core/miscellaneous/connection-resiliency
 
         // 1. Target eligibility — tenant-scoped on read via EF query filters
         //    (CspInheritedComponent is [GlobalReference] today, so the actual
@@ -867,25 +875,34 @@ public sealed class CspInheritedComponentService : ICspInheritedComponentService
         capability.ReviewerNote = null;
         capability.MappingFailureReason = "Moved to a new component; re-review required.";
 
-        // 5. Audit row — same transaction; no SaveChanges inside AppendAsync.
-        await _history.AppendAsync(
-            db, capability.Id, tenantId,
-            CapabilityHistoryEventType.Moved,
-            actorOid: actor,
-            summary: $"Moved from '{fromComponentName}' to '{target.Name}'.",
-            metadata: new
-            {
-                fromComponentId = componentId,
-                toComponentId = targetComponentId,
-            },
-            ct).ConfigureAwait(false);
-
-        // 6. Commit — DbUpdateConcurrencyException bubbles to the endpoint as 412.
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
-        if (tx is not null)
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct).ConfigureAwait(false);
-        }
+            var supportsTransactions = db.Database.ProviderName?.Contains("InMemory", StringComparison.OrdinalIgnoreCase) != true;
+            await using var tx = supportsTransactions
+                ? await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+                : null;
+
+            // 5. Audit row — same transaction; no SaveChanges inside AppendAsync.
+            await _history.AppendAsync(
+                db, capability.Id, tenantId,
+                CapabilityHistoryEventType.Moved,
+                actorOid: actor,
+                summary: $"Moved from '{fromComponentName}' to '{target.Name}'.",
+                metadata: new
+                {
+                    fromComponentId = componentId,
+                    toComponentId = targetComponentId,
+                },
+                ct).ConfigureAwait(false);
+
+            // 6. Commit — DbUpdateConcurrencyException bubbles to the endpoint as 412.
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            if (tx is not null)
+            {
+                await tx.CommitAsync(ct).ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Reparented CspInheritedCapability {CapabilityId} from {FromComponentId} to {ToComponentId} by {Actor}",


### PR DESCRIPTION
## Summary

Fixes `POST /api/csp-inherited/capabilities` returning HTTP 500 on SQL Server. The `SqlServerRetryingExecutionStrategy` throws `InvalidOperationException` when a user-initiated `BeginTransaction` is opened outside a `CreateExecutionStrategy().ExecuteAsync(...)` wrapper.

Closes #205

---

## Root Cause

`CspInheritedComponentService.AddCapabilityAsync` opened `db.Database.BeginTransactionAsync()` directly. EF Core's SQL Server retry strategy refuses to enlist in transactions it doesn't own unless they are wrapped in its execution strategy.

---

## Changes

| File | Site | Change |
|------|------|--------|
| `CspInheritedComponentService.cs` | `AddCapabilityAsync` | Wrap in `CreateExecutionStrategy().ExecuteAsync` |
| `CspInheritedComponentService.cs` | `ReparentCapabilityAsync` | Same — same pattern, same risk |
| `AlertManager.cs` | `GenerateAlertIdAsync` | Same — pre-emptive fix |
| `OrganizationTemplateService.cs` | `MarkDefaultAsync` | Same — pre-emptive fix |

`BoundaryMigrationService` already had the correct pattern and was not touched.

---

## Pattern Applied

**Before:**
```csharp
await using var tx = await db.Database.BeginTransactionAsync(ct);
// ... mutations ...
await db.SaveChangesAsync(ct);
await tx.CommitAsync(ct);
```

**After:**
```csharp
var strategy = db.Database.CreateExecutionStrategy();
await strategy.ExecuteAsync(async () =>
{
    await using var tx = await db.Database.BeginTransactionAsync(ct);
    // ... mutations ...
    await db.SaveChangesAsync(ct);
    await tx.CommitAsync(ct);
});
```

InMemory/SQLite providers: `CreateExecutionStrategy()` returns a no-op — behavior unchanged for unit and integration tests.

---

## Spec Compliance

- Spec: #205
- No schema changes
- No new dependencies
- Existing `SaveChangesAsync` call sites outside transactions: unaffected

---

## Acceptance Criteria

- [ ] `POST /api/csp-inherited/capabilities` → 201 on SQL Server
- [ ] `seed-csp-inherited.sh` seeds all 3 capabilities without error
- [ ] CI green (unit + integration suites pass)
- [ ] No regression on `CspInheritedComponentManualCreateTests`, `ReparentCapabilityEndpointTests`
