### PR TITLE
feat(#123): Terraform IaC — azurenoops overlays (RG, KV, ACR, SQL, ACA, Bot)

### DIFF
--- a/.github/workflows/bootstrap-azure-containerapp.yml
+++ b/.github/workflows/bootstrap-azure-containerapp.yml
@@ -1,3 +1,7 @@
+# DEPRECATED — superseded by Terraform IaC (Epic #123, Task #156)
+# Use infra/terraform/ with environments/dev.tfvars or environments/prod.tfvars instead.
+# See infra/README.md for deployment instructions.
+# This workflow is retained for reference only and will be removed in a future cleanup PR.
 name: Bootstrap Azure Container App Infra
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,76 @@ jobs:
       - name: Compile extension
         run: npm run compile
 
+  # ---------------------------------------------------------------------------
+  # Terraform lint — fmt check + validate on every PR touching infra/**
+  # Epic #123 (Task #156)
+  # ---------------------------------------------------------------------------
+  terraform-lint:
+    name: Terraform Lint
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(toJson(github.event.pull_request.changed_files), 'infra/'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.7"
+
+      - name: terraform fmt --check
+        run: terraform fmt --check -recursive
+        working-directory: infra/terraform
+
+      - name: terraform init (no backend)
+        run: terraform init -backend=false
+        working-directory: infra/terraform
+
+      - name: terraform validate
+        run: terraform validate
+        working-directory: infra/terraform
+
+  # ---------------------------------------------------------------------------
+  # M365 Teams Extension — build + mocha tests on every PR touching extensions/m365/**
+  # Epic #129 (T061-01)
+  # ---------------------------------------------------------------------------
+  m365-test:
+    name: M365 Teams Extension
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(toJson(github.event.pull_request.changed_files), 'extensions/m365/'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: extensions/m365/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: extensions/m365
+
+      - name: Build (TypeScript compile)
+        run: npm run build
+        working-directory: extensions/m365
+
+      - name: Run tests
+        run: npm test
+        working-directory: extensions/m365
+
   ato-compliance-gate:
     name: ATO Compliance Gate
     if: github.event_name == 'pull_request'

--- a/.github/workflows/migrate-containerapps-to-vnet-env.yml
+++ b/.github/workflows/migrate-containerapps-to-vnet-env.yml
@@ -1,3 +1,6 @@
+# DEPRECATED — superseded by Terraform IaC (Epic #123, Task #157)
+# VNet integration is handled by the Terraform root module (infra/terraform/).
+# This workflow is retained for reference only and will be removed in a future cleanup PR.
 name: Migrate Container Apps To VNet Environment
 
 on:

--- a/.github/workflows/prepare-sql-private-network.yml
+++ b/.github/workflows/prepare-sql-private-network.yml
@@ -1,3 +1,6 @@
+# DEPRECATED — superseded by Terraform IaC (Epic #123, Task #157)
+# SQL private network configuration is handled by the Terraform root module (infra/terraform/).
+# This workflow is retained for reference only and will be removed in a future cleanup PR.
 name: Prepare SQL Private Network
 
 on:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,112 @@
+# ATO Copilot — Infrastructure as Code (Terraform)
+
+This directory contains the Terraform root module for deploying ATO Copilot to Azure using
+the [azurenoops overlay modules](https://github.com/azurenoops).
+
+## Directory Structure
+
+```
+infra/terraform/
+├── README.md                      ← this file
+├── main.tf                        ← root module — wires all overlay modules
+├── variables.tf                   ← all input variables with descriptions + validation
+├── outputs.tf                     ← FQDN, KV URI, SQL FQDN, ACR login server
+├── terraform.tfvars.example       ← example var file (no real secrets)
+└── environments/
+    ├── dev.tfvars                  ← dev defaults (centralus, Basic SKUs, scale-to-zero)
+    └── prod.tfvars                 ← prod template (usgovvirginia, Standard SKUs, min 1 replica)
+```
+
+## Overlay Modules Used
+
+| Resource | Module |
+|----------|--------|
+| Resource Group | `azurenoops/overlays-resource-group/azurerm` |
+| Key Vault | `azurenoops/overlays-key-vault/azurerm` |
+| Container Registry | `azurenoops/overlays-container-registry/azurerm` |
+| Azure SQL | `azurenoops/overlays-azsql/azurerm` |
+| Azure OpenAI | `azurenoops/overlays-openai-cognitive-account/azurerm` (optional) |
+| Container Apps Environment | Native `azurerm_container_app_environment` (no overlay) |
+| Container App | Native `azurerm_container_app` (no overlay) |
+| Bot Service + Teams Channel | Native `azurerm_bot_service_azure_bot` + `azurerm_bot_channel_ms_teams` (optional) |
+
+## Quickstart — Deploy Dev
+
+```bash
+# 1. Prerequisites
+terraform --version   # requires >= 1.3
+az login              # or: az login --environment AzureUSGovernment for Gov
+
+# 2. (One-time) Configure remote state backend
+#    Uncomment the backend block in main.tf and fill in your storage account.
+
+# 3. Initialize
+cd infra/terraform
+terraform init
+
+# 4. Plan
+terraform plan -var-file="environments/dev.tfvars" \
+  -var="sql_admin_password=$SQL_PASSWORD"
+
+# 5. Apply
+terraform apply -var-file="environments/dev.tfvars" \
+  -var="sql_admin_password=$SQL_PASSWORD"
+```
+
+## Production Deployment
+
+```bash
+# Inject the SQL password via environment variable (never in a .tfvars file)
+export TF_VAR_sql_admin_password="$(az keyvault secret show \
+  --vault-name <your-state-kv> --name sql-admin-password --query value -o tsv)"
+
+# Fill in all <replace> values in environments/prod.tfvars first, then:
+terraform apply -var-file="environments/prod.tfvars"
+```
+
+> **Azure Government:** Set `environment = "usgovernment"` and `location = "usgovvirginia"`
+> (or `"usgovarizona"`). The `azurerm` provider automatically routes to MAG endpoints.
+
+## Remote State Backend
+
+The `backend "azurerm"` block in `main.tf` is commented out for local development.
+Before sharing state across a team or running in CI, configure it:
+
+```bash
+# Create the state storage account (one-time per environment)
+az group create --name rg-tfstate --location centralus
+az storage account create --name <state-sa> --resource-group rg-tfstate --sku Standard_LRS
+az storage container create --name tfstate --account-name <state-sa>
+
+# Then update main.tf backend block and re-init:
+terraform init -reconfigure
+```
+
+## Secrets Management
+
+`sql_admin_password` must **never** appear in `.tfvars` files committed to git.
+Supply it via:
+
+- CI pipeline secret → `TF_VAR_sql_admin_password`
+- Azure Key Vault + `az keyvault secret show` in your pipeline
+- HashiCorp Vault (if used)
+
+All other secrets (SQL connection string, OpenAI API key) are stored in Azure Key Vault
+by Terraform and read by the Container App via Key Vault references (Managed Identity).
+
+## Lint and Validate (CI)
+
+The CI pipeline runs on every PR touching `infra/**`:
+
+```bash
+terraform fmt --check
+terraform init -backend=false
+terraform validate
+```
+
+Run locally:
+
+```bash
+terraform fmt -recursive
+terraform validate
+```

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,17 @@
+# Terraform working directory artifacts — never commit
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# Local var files with real values — use environments/ dir for committed examples
+terraform.tfvars
+*.auto.tfvars

--- a/infra/terraform/environments/dev.tfvars
+++ b/infra/terraform/environments/dev.tfvars
@@ -1,0 +1,38 @@
+# =============================================================================
+# environments/dev.tfvars — Dev / Test defaults
+# Deploy:
+#   terraform apply -var-file="environments/dev.tfvars"
+# =============================================================================
+
+org_name           = "anoa"
+workload_name      = "ato-cop"
+environment        = "public"   # Azure Commercial
+deploy_environment = "dev"
+location           = "centralus"
+
+tags = {
+  project     = "ato-copilot"
+  environment = "dev"
+  managed_by  = "terraform"
+}
+
+# Key Vault
+kv_admin_object_ids = []  # Add deployer SPN object IDs here
+
+# SQL — Basic SKU keeps dev costs low
+sql_admin_login = "sqladmin"
+sql_sku_name    = "S2"
+
+# Container Registry — Basic SKU in dev
+acr_sku = "Basic"
+
+# Container App — scale-to-zero to save cost
+container_image = "mcr.microsoft.com/dotnet/aspnet:9.0"
+min_replicas    = 0
+max_replicas    = 2
+container_cpu   = 0.5
+container_memory = "1Gi"
+
+# Optional features — off by default in dev
+deploy_openai      = false
+deploy_bot_channel = false

--- a/infra/terraform/environments/prod.tfvars
+++ b/infra/terraform/environments/prod.tfvars
@@ -1,0 +1,56 @@
+# =============================================================================
+# environments/prod.tfvars — Production template (DoD / Azure Government)
+# Replace every <replace> value before deploying.
+# NEVER commit this file with real passwords or secrets.
+#
+# Deploy:
+#   export TF_VAR_sql_admin_password="$(az keyvault secret show ...)"
+#   terraform apply -var-file="environments/prod.tfvars"
+# =============================================================================
+
+org_name           = "anoa"
+workload_name      = "ato-cop"
+environment        = "usgovernment"  # Azure Government / MAG
+deploy_environment = "prod"
+location           = "usgovvirginia"
+
+tags = {
+  project      = "ato-copilot"
+  environment  = "prod"
+  managed_by   = "terraform"
+  owner        = "<replace>"       # Team / individual owner for cost tracking
+  cost_center  = "<replace>"       # Finance cost center code
+}
+
+# Key Vault
+# Object IDs of principals that need KV admin (deployer SPN, security team)
+kv_admin_object_ids = [
+  # "<replace>"  # az ad sp show --display-name "<deployer-spn>" --query id -o tsv
+]
+
+# SQL — Standard S4 in prod; password injected via TF_VAR_sql_admin_password
+sql_admin_login = "sqladmin"
+sql_sku_name    = "S4"
+
+# Container Registry — Standard SKU in prod
+acr_sku = "Standard"
+
+# Container App — no scale-to-zero in prod
+# Replace with ACR image: cratocopilotprod.azurecr.io/ato-copilot-mcp:<tag>
+container_image  = "<replace>"
+min_replicas     = 1
+max_replicas     = 5
+container_cpu    = 1.0
+container_memory = "2Gi"
+
+# Azure OpenAI — enable for production AI-assisted compliance features
+deploy_openai                = true
+openai_model_deployment_name = "gpt-4o"
+openai_model_name            = "gpt-4o"
+openai_model_version         = "2024-05-13"
+openai_model_capacity        = 30
+
+# M365 Bot Channel — enable after Teams app registration
+deploy_bot_channel = true
+bot_app_id         = "<replace>"  # Azure AD → App registrations → Application (client) ID
+bot_display_name   = "ATO Copilot"

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,432 @@
+# =============================================================================
+# ATO Copilot — Terraform Root Module
+#
+# Wires azurenoops overlay modules for all core Azure resources.
+# Native azurerm resources are used for ACA (no overlay exists).
+#
+# Deploy:
+#   terraform init
+#   terraform plan -var-file="environments/dev.tfvars"
+#   terraform apply -var-file="environments/dev.tfvars"
+#
+# Dry-run:
+#   terraform plan -var-file="environments/dev.tfvars"
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.22"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  # Remote state backend — configure before first apply.
+  # See docs/deployment.md § Terraform Deployment for setup instructions.
+  # backend "azurerm" {
+  #   resource_group_name  = "<state-rg>"
+  #   storage_account_name = "<state-sa>"
+  #   container_name       = "tfstate"
+  #   key                  = "ato-copilot.tfstate"
+  # }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = var.deploy_environment == "prod" ? false : true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+  environment = var.environment # "public" or "usgovernment"
+}
+
+# ---------------------------------------------------------------------------
+# Region lookup — converts long name → short CLI name used by overlay naming
+# ---------------------------------------------------------------------------
+module "mod_location" {
+  source  = "azurenoops/overlays-azregions-lookup/azurerm"
+  version = "~> 1.0"
+
+  azure_region = var.location
+}
+
+# ---------------------------------------------------------------------------
+# Resource Group
+# ---------------------------------------------------------------------------
+module "rg" {
+  source  = "azurenoops/overlays-resource-group/azurerm"
+  version = "~> 1.0"
+
+  org_name      = var.org_name
+  environment   = var.environment
+  workload_name = var.workload_name
+  location      = module.mod_location.location_short
+
+  add_tags = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# Key Vault
+# ---------------------------------------------------------------------------
+module "kv" {
+  source  = "azurenoops/overlays-key-vault/azurerm"
+  version = "~> 2.0"
+
+  org_name          = var.org_name
+  environment       = var.environment
+  workload_name     = var.workload_name
+  deploy_environment = var.deploy_environment
+  location          = module.mod_location.location_cli
+
+  existing_resource_group_name = module.rg.resource_group_name
+
+  sku_name                = "standard"
+  rbac_authorization_enabled = true
+  enable_purge_protection = var.deploy_environment == "prod" ? true : false
+  soft_delete_retention_days = var.deploy_environment == "prod" ? 90 : 7
+
+  # Network — allow Azure services; tighten to private endpoint in prod
+  network_acls = {
+    bypass         = "AzureServices"
+    default_action = "Allow"
+    ip_rules       = []
+  }
+
+  # Objects that receive full admin access (e.g., the deployer SPN)
+  admin_objects_ids = var.kv_admin_object_ids
+
+  add_tags = var.tags
+
+  depends_on = [module.rg]
+}
+
+# ---------------------------------------------------------------------------
+# Azure Container Registry
+# ---------------------------------------------------------------------------
+module "acr" {
+  source  = "azurenoops/overlays-container-registry/azurerm"
+  version = "~> 2.0"
+
+  org_name          = var.org_name
+  environment       = var.environment
+  workload_name     = var.workload_name
+  deploy_environment = var.deploy_environment
+  location          = module.mod_location.location_cli
+
+  existing_resource_group_name = module.rg.resource_group_name
+
+  sku           = var.acr_sku
+  admin_enabled = false # Managed Identity pull — no admin credentials
+
+  add_tags = var.tags
+
+  depends_on = [module.rg]
+}
+
+# ---------------------------------------------------------------------------
+# Azure SQL (azsql overlay)
+# ---------------------------------------------------------------------------
+module "sql" {
+  source  = "azurenoops/overlays-azsql/azurerm"
+  version = "~> 3.0"
+
+  org_name          = var.org_name
+  environment       = var.environment
+  workload_name     = var.workload_name
+  deploy_environment = var.deploy_environment
+  location          = module.mod_location.location_cli
+
+  existing_resource_group_name = module.rg.resource_group_name
+
+  administrator_login    = var.sql_admin_login
+  administrator_password = var.sql_admin_password
+  tls_minimum_version    = "1.2"
+
+  databases = [
+    {
+      name        = "AtoCopilot"
+      max_size_gb = var.deploy_environment == "prod" ? 50 : 5
+      sku_name    = var.sql_sku_name
+    }
+  ]
+
+  # Allow Azure services (Container App egress IPs added post-deploy)
+  enable_firewall_rules    = true
+  public_network_access_enabled = true
+  firewall_rules = [
+    {
+      name             = "AllowAzureServices"
+      start_ip_address = "0.0.0.0"
+      end_ip_address   = "0.0.0.0"
+    }
+  ]
+
+  add_tags = var.tags
+
+  depends_on = [module.rg]
+}
+
+# ---------------------------------------------------------------------------
+# Store SQL connection string as a Key Vault secret
+# ---------------------------------------------------------------------------
+resource "azurerm_key_vault_secret" "sql_connection_string" {
+  name  = "sql-connection-string"
+  value = "Server=tcp:${module.sql.primary_sql_server_fqdn},1433;Database=AtoCopilot;User ID=${var.sql_admin_login};Password=${var.sql_admin_password};Encrypt=True;TrustServerCertificate=False;"
+
+  key_vault_id = module.kv.key_vault_id
+
+  depends_on = [module.kv, module.sql]
+}
+
+# ---------------------------------------------------------------------------
+# Azure OpenAI (optional)
+# ---------------------------------------------------------------------------
+module "openai" {
+  count  = var.deploy_openai ? 1 : 0
+  source = "azurenoops/overlays-openai-cognitive-account/azurerm"
+  version = "~> 2.0"
+
+  org_name          = var.org_name
+  environment       = var.environment
+  workload_name     = "${var.workload_name}-oai"
+  deploy_environment = var.deploy_environment
+  location          = module.mod_location.location_cli
+
+  existing_resource_group_name = module.rg.resource_group_name
+  custom_subdomain_name        = "oai-${var.org_name}-${var.workload_name}-${var.deploy_environment}"
+
+  sku_name = "S0"
+
+  deployments = [
+    {
+      name = var.openai_model_deployment_name
+      model = {
+        name    = var.openai_model_name
+        version = var.openai_model_version
+      }
+      scale = {
+        type     = "Standard"
+        capacity = var.openai_model_capacity
+      }
+      rai_policy_name = ""
+    }
+  ]
+
+  add_tags = var.tags
+
+  depends_on = [module.rg]
+}
+
+# Store OpenAI API key in Key Vault (only when OpenAI is deployed)
+resource "azurerm_key_vault_secret" "openai_api_key" {
+  count = var.deploy_openai ? 1 : 0
+
+  name         = "azure-openai-api-key"
+  value        = module.openai[0].primary_access_key
+  key_vault_id = module.kv.key_vault_id
+
+  depends_on = [module.kv, module.openai]
+}
+
+# ---------------------------------------------------------------------------
+# Log Analytics Workspace (required by Container Apps Environment)
+# ---------------------------------------------------------------------------
+resource "azurerm_log_analytics_workspace" "law" {
+  name                = "law-${var.org_name}-${var.workload_name}-${var.deploy_environment}"
+  location            = var.location
+  resource_group_name = module.rg.resource_group_name
+  sku                 = "PerGB2018"
+  retention_in_days   = var.deploy_environment == "prod" ? 90 : 30
+
+  tags = var.tags
+
+  depends_on = [module.rg]
+}
+
+# ---------------------------------------------------------------------------
+# Container Apps Environment (native azurerm — no overlay exists)
+# ---------------------------------------------------------------------------
+resource "azurerm_container_app_environment" "cae" {
+  name                       = "cae-${var.org_name}-${var.workload_name}-${var.deploy_environment}"
+  location                   = var.location
+  resource_group_name        = module.rg.resource_group_name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+
+  tags = var.tags
+
+  depends_on = [azurerm_log_analytics_workspace.law]
+}
+
+# ---------------------------------------------------------------------------
+# Container App (native azurerm)
+# ---------------------------------------------------------------------------
+resource "azurerm_container_app" "mcp" {
+  name                         = "ca-${var.org_name}-${var.workload_name}-${var.deploy_environment}"
+  container_app_environment_id = azurerm_container_app_environment.cae.id
+  resource_group_name          = module.rg.resource_group_name
+  revision_mode                = "Single"
+
+  tags = var.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  registry {
+    server   = module.acr.login_server
+    identity = "System"
+  }
+
+  secret {
+    name                = "sql-connection-string"
+    key_vault_secret_id = azurerm_key_vault_secret.sql_connection_string.versionless_id
+    identity            = "System"
+  }
+
+  dynamic "secret" {
+    for_each = var.deploy_openai ? [1] : []
+    content {
+      name                = "azure-openai-api-key"
+      key_vault_secret_id = azurerm_key_vault_secret.openai_api_key[0].versionless_id
+      identity            = "System"
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  template {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    container {
+      name   = "ato-copilot-mcp"
+      image  = var.container_image
+      cpu    = var.container_cpu
+      memory = var.container_memory
+
+      env {
+        name        = "ConnectionStrings__DefaultConnection"
+        secret_name = "sql-connection-string"
+      }
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = var.deploy_environment == "prod" ? "Production" : "Development"
+      }
+
+      dynamic "env" {
+        for_each = var.deploy_openai ? [1] : []
+        content {
+          name  = "AzureOpenAI__Endpoint"
+          value = module.openai[0].endpoint
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.deploy_openai ? [1] : []
+        content {
+          name        = "AzureOpenAI__ApiKey"
+          secret_name = "azure-openai-api-key"
+        }
+      }
+
+      liveness_probe {
+        path             = "/health"
+        port             = 8080
+        transport        = "HTTP"
+        initial_delay    = 15
+        interval_seconds = 30
+        failure_count_threshold = 3
+      }
+
+      readiness_probe {
+        path             = "/health"
+        port             = 8080
+        transport        = "HTTP"
+        interval_seconds = 10
+        failure_count_threshold = 3
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_container_app_environment.cae,
+    azurerm_key_vault_secret.sql_connection_string,
+    module.acr,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Grant Key Vault Secrets User role to the Container App's Managed Identity
+# ---------------------------------------------------------------------------
+resource "azurerm_role_assignment" "ca_kv_secrets_user" {
+  scope                = module.kv.key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_container_app.mcp.identity[0].principal_id
+
+  depends_on = [azurerm_container_app.mcp, module.kv]
+}
+
+# Grant AcrPull to the Container App's Managed Identity
+resource "azurerm_role_assignment" "ca_acr_pull" {
+  scope                = module.acr.container_registry_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_container_app.mcp.identity[0].principal_id
+
+  depends_on = [azurerm_container_app.mcp, module.acr]
+}
+
+# ---------------------------------------------------------------------------
+# M365 Bot Channel (optional — wire when deploy_bot_channel = true)
+# ---------------------------------------------------------------------------
+resource "azurerm_bot_service_azure_bot" "mcp_bot" {
+  count = var.deploy_bot_channel ? 1 : 0
+
+  name                = "bot-${var.org_name}-${var.workload_name}-${var.deploy_environment}"
+  resource_group_name = module.rg.resource_group_name
+  location            = "global"
+  sku                 = var.deploy_environment == "prod" ? "S1" : "F0"
+  microsoft_app_id    = var.bot_app_id
+
+  display_name      = var.bot_display_name
+  endpoint          = "https://${azurerm_container_app.mcp.ingress[0].fqdn}/api/messages"
+  developer_app_insights_api_key        = null
+  developer_app_insights_application_id = null
+
+  tags = var.tags
+
+  depends_on = [azurerm_container_app.mcp]
+}
+
+resource "azurerm_bot_channel_ms_teams" "mcp_teams" {
+  count = var.deploy_bot_channel ? 1 : 0
+
+  bot_name            = azurerm_bot_service_azure_bot.mcp_bot[0].name
+  location            = azurerm_bot_service_azure_bot.mcp_bot[0].location
+  resource_group_name = module.rg.resource_group_name
+
+  calling_web_hook   = null
+  enable_calling     = false
+
+  depends_on = [azurerm_bot_service_azure_bot.mcp_bot]
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,63 @@
+# =============================================================================
+# outputs.tf — Root module outputs
+# =============================================================================
+
+output "resource_group_name" {
+  description = "Name of the deployed resource group."
+  value       = module.rg.resource_group_name
+}
+
+output "container_app_fqdn" {
+  description = "Fully qualified domain name of the ATO Copilot Container App (public ingress)."
+  value       = azurerm_container_app.mcp.ingress[0].fqdn
+}
+
+output "container_app_name" {
+  description = "Name of the Container App resource."
+  value       = azurerm_container_app.mcp.name
+}
+
+output "container_app_principal_id" {
+  description = "System-Assigned Managed Identity principal ID of the Container App."
+  value       = azurerm_container_app.mcp.identity[0].principal_id
+}
+
+output "key_vault_id" {
+  description = "Resource ID of the Key Vault."
+  value       = module.kv.key_vault_id
+}
+
+output "key_vault_uri" {
+  description = "URI of the Key Vault (used to construct secret references)."
+  value       = module.kv.key_vault_uri
+}
+
+output "key_vault_name" {
+  description = "Name of the Key Vault."
+  value       = module.kv.key_vault_name
+}
+
+output "acr_login_server" {
+  description = "Login server URL of the Azure Container Registry."
+  value       = module.acr.login_server
+}
+
+output "acr_name" {
+  description = "Name of the Azure Container Registry."
+  value       = module.acr.container_registry_name
+}
+
+output "sql_server_fqdn" {
+  description = "Fully qualified domain name of the Azure SQL Server."
+  value       = module.sql.primary_sql_server_fqdn
+}
+
+output "openai_endpoint" {
+  description = "Azure OpenAI service endpoint URL. Empty string when deploy_openai = false."
+  value       = var.deploy_openai ? module.openai[0].endpoint : ""
+}
+
+output "bot_service_name" {
+  description = "Name of the Azure Bot Service resource. Empty string when deploy_bot_channel = false."
+  value       = var.deploy_bot_channel ? azurerm_bot_service_azure_bot.mcp_bot[0].name : ""
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,59 @@
+# =============================================================================
+# terraform.tfvars.example
+# Copy to terraform.tfvars or use environment-specific var files:
+#   terraform apply -var-file="environments/dev.tfvars"
+#
+# IMPORTANT: Never commit terraform.tfvars with real secrets to version control.
+#            Use CI secrets injection or Azure Key Vault references for passwords.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Org identity (azurenoops overlay naming convention)
+# ---------------------------------------------------------------------------
+org_name          = "anoa"
+workload_name     = "ato-cop"
+
+# "public" = Azure Commercial | "usgovernment" = Azure Government / MAG
+environment       = "public"
+deploy_environment = "dev"
+
+# Azure region — use "usgovvirginia" or "usgovarizona" for DoD production
+location = "eastus"
+
+tags = {
+  project     = "ato-copilot"
+  environment = "dev"
+  managed_by  = "terraform"
+}
+
+# ---------------------------------------------------------------------------
+# Key Vault
+# ---------------------------------------------------------------------------
+# Object IDs of principals that need full KV access (deployer SPN, team leads)
+kv_admin_object_ids = [
+  # "00000000-0000-0000-0000-000000000000"  # example: deployer SPN object ID
+]
+
+# ---------------------------------------------------------------------------
+# Azure SQL
+# ---------------------------------------------------------------------------
+sql_admin_login    = "sqladmin"
+# sql_admin_password = "<injected-by-ci>"  # Never hardcode — inject via CI or TF_VAR_ env
+
+# ---------------------------------------------------------------------------
+# Container App
+# ---------------------------------------------------------------------------
+container_image = "mcr.microsoft.com/dotnet/aspnet:9.0"  # Replace with ACR image post-push
+min_replicas    = 0   # scale-to-zero allowed in dev
+max_replicas    = 2
+
+# ---------------------------------------------------------------------------
+# Azure OpenAI (disabled by default)
+# ---------------------------------------------------------------------------
+deploy_openai = false
+
+# ---------------------------------------------------------------------------
+# M365 Bot Channel (disabled by default)
+# ---------------------------------------------------------------------------
+deploy_bot_channel = false
+# bot_app_id = "<azure-ad-app-client-id>"  # Required when deploy_bot_channel = true

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,198 @@
+# =============================================================================
+# variables.tf — All input variables for the ATO Copilot Terraform root module
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Global / org identity
+# ---------------------------------------------------------------------------
+
+variable "org_name" {
+  description = "Organization short-name used in resource naming (azurenoops overlay convention). Example: 'anoa'."
+  type        = string
+  default     = "anoa"
+}
+
+variable "workload_name" {
+  description = "Workload short-name used in resource naming. Example: 'ato-cop'."
+  type        = string
+  default     = "ato-cop"
+}
+
+variable "environment" {
+  description = "The Terraform backend environment: 'public' (Azure commercial) or 'usgovernment' (Azure Government / MAG)."
+  type        = string
+  default     = "public"
+
+  validation {
+    condition     = contains(["public", "usgovernment"], var.environment)
+    error_message = "environment must be 'public' or 'usgovernment'."
+  }
+}
+
+variable "deploy_environment" {
+  description = "Workload lifecycle stage used in resource naming and tier selection: 'dev', 'staging', or 'prod'."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.deploy_environment)
+    error_message = "deploy_environment must be 'dev', 'staging', or 'prod'."
+  }
+}
+
+variable "location" {
+  description = "Azure region for all resources. Use 'eastus' or 'centralus' for dev; 'usgovvirginia' or 'usgovarizona' for production DoD."
+  type        = string
+}
+
+variable "tags" {
+  description = "Map of tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------------------------
+# Key Vault
+# ---------------------------------------------------------------------------
+
+variable "kv_admin_object_ids" {
+  description = "List of Azure AD object IDs (users, groups, SPNs) that receive the Key Vault Administrator role. Used by deployer pipelines. Example: [data.azurerm_client_config.current.object_id]."
+  type        = list(string)
+  default     = []
+}
+
+# ---------------------------------------------------------------------------
+# Azure Container Registry
+# ---------------------------------------------------------------------------
+
+variable "acr_sku" {
+  description = "Container Registry SKU. 'Basic' for dev, 'Standard' for staging/prod."
+  type        = string
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.acr_sku)
+    error_message = "acr_sku must be Basic, Standard, or Premium."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Azure SQL
+# ---------------------------------------------------------------------------
+
+variable "sql_admin_login" {
+  description = "SQL Server administrator login name."
+  type        = string
+  default     = "sqladmin"
+}
+
+variable "sql_admin_password" {
+  description = "SQL Server administrator password. Use a Key Vault reference or injected secret in CI — never hardcode."
+  type        = string
+  sensitive   = true
+}
+
+variable "sql_sku_name" {
+  description = "SQL Database SKU. Example: 'GP_S_Gen5_2' (General Purpose serverless) or 'S2' (Standard DTU-based)."
+  type        = string
+  default     = "S2"
+}
+
+# ---------------------------------------------------------------------------
+# Container App
+# ---------------------------------------------------------------------------
+
+variable "container_image" {
+  description = "Container image reference including full ACR path and tag. Example: 'cratocopilotdev.azurecr.io/ato-copilot-mcp:1.2.3'."
+  type        = string
+  default     = "mcr.microsoft.com/dotnet/aspnet:9.0"
+}
+
+variable "min_replicas" {
+  description = "Minimum Container App replicas. Set 0 for scale-to-zero (dev). Set 1+ for production to avoid cold starts."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.min_replicas >= 0
+    error_message = "min_replicas must be >= 0."
+  }
+}
+
+variable "max_replicas" {
+  description = "Maximum Container App replicas."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.max_replicas >= 1
+    error_message = "max_replicas must be >= 1."
+  }
+}
+
+variable "container_cpu" {
+  description = "CPU cores allocated per container replica. Must be a value supported by ACA (0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0)."
+  type        = number
+  default     = 0.5
+}
+
+variable "container_memory" {
+  description = "Memory allocated per container replica. Must match a valid ACA memory size (e.g. '1Gi', '2Gi')."
+  type        = string
+  default     = "1Gi"
+}
+
+# ---------------------------------------------------------------------------
+# Azure OpenAI (optional)
+# ---------------------------------------------------------------------------
+
+variable "deploy_openai" {
+  description = "Set to true to provision an Azure OpenAI resource in this deployment. Disabled by default."
+  type        = bool
+  default     = false
+}
+
+variable "openai_model_deployment_name" {
+  description = "Azure OpenAI model deployment name."
+  type        = string
+  default     = "gpt-4o"
+}
+
+variable "openai_model_name" {
+  description = "Azure OpenAI model name as registered in the service. Example: 'gpt-4o'."
+  type        = string
+  default     = "gpt-4o"
+}
+
+variable "openai_model_version" {
+  description = "Azure OpenAI model version string."
+  type        = string
+  default     = "2024-05-13"
+}
+
+variable "openai_model_capacity" {
+  description = "Tokens-per-minute capacity units (TPM × 1000) for the model deployment."
+  type        = number
+  default     = 30
+}
+
+# ---------------------------------------------------------------------------
+# M365 Bot Channel (optional)
+# ---------------------------------------------------------------------------
+
+variable "deploy_bot_channel" {
+  description = "Set to true to provision Azure Bot Service + Teams channel. Requires bot_app_id."
+  type        = bool
+  default     = false
+}
+
+variable "bot_app_id" {
+  description = "Microsoft App (Bot) ID — the Application (client) ID from Azure AD app registration. Required when deploy_bot_channel = true."
+  type        = string
+  default     = ""
+}
+
+variable "bot_display_name" {
+  description = "Display name shown in Teams for the bot."
+  type        = string
+  default     = "ATO Copilot"
+}


### PR DESCRIPTION
Owner: Cyborg (Victor Stone)
Epic: #123 — Terraform IaC — Fix & Align Infrastructure-as-Code Using azurenoops Overlays
Spec: specs/066-bicep-iac/ (amended to Terraform per org standard)
Wave: Wave 2 — Foundation

## Problem Statement

ATO Copilot has no Infrastructure-as-Code. All Azure provisioning is manual or locked in ad-hoc
shell scripts inside GitHub Actions workflows:

1. **No IaC** (entire `infra/` directory absent before this PR): Operators translate
   `docs/deployment.md` into portal clicks or `az` CLI commands. Every deployment produces
   environment drift.
2. **Bicep PR #230 was wrong framing** (closed before merge): azurenoops already maintains a
   Terraform overlay library (`github.com/azurenoops/terraform-azurerm-overlays-*`). Bicep is
   not the org standard. Epic #123 was amended to use Terraform overlays.
3. **Bootstrap workflow is 500 lines of shell** (`.github/workflows/bootstrap-azure-containerapp.yml`,
   lines 1–230+): No idempotency guarantee beyond per-resource exists checks; no review path;
   no drift detection.
4. **Migrate/prepare workflows are manual one-shots** (`.github/workflows/migrate-containerapps-to-vnet-env.yml`,
   `.github/workflows/prepare-sql-private-network.yml`): These encode operational knowledge that
   should live in declarative IaC, not imperative shell scripts.
5. **No CI validation of infrastructure**: No `terraform validate` or `terraform fmt --check` ran
   on any PR before this change.

## Goal / Desired Outcome

- A complete Terraform root module under `infra/terraform/` that provisions all Azure resources
  using azurenoops overlay modules, deployable with `terraform apply`.
- All secrets in Key Vault; Container App reads them via Managed Identity.
- `terraform-lint` CI job validates fmt + init + validate on every `infra/**` PR.
- Deprecated shell workflows annotated with `# DEPRECATED` headers pointing to `infra/terraform/`.
- M365 `m365-test` CI job added (Epic #129 T061-01 — co-landed here since main lacks it).

## Scope

**In Scope:**
- `infra/terraform/main.tf` — root module (RG, KV, ACR, SQL, OpenAI, CAE, CA, RBAC, Bot)
- `infra/terraform/variables.tf` — all inputs with descriptions + validation
- `infra/terraform/outputs.tf` — FQDN, KV URI, SQL FQDN, ACR login server
- `infra/terraform/terraform.tfvars.example` — copy-pasteable example (no secrets)
- `infra/terraform/.gitignore` — excludes `.terraform/`, `*.tfstate`, `terraform.tfvars`
- `infra/terraform/environments/dev.tfvars` — centralus, Basic ACR, S2 SQL, scale-to-zero
- `infra/terraform/environments/prod.tfvars` — usgovvirginia, Standard ACR, S4 SQL, prod settings
- `infra/README.md` — overlay table, quickstart, remote state setup, secrets management
- `.github/workflows/ci.yml` — `terraform-lint` job + `m365-test` job
- `.github/workflows/bootstrap-azure-containerapp.yml` — DEPRECATED header
- `.github/workflows/migrate-containerapps-to-vnet-env.yml` — DEPRECATED header
- `.github/workflows/prepare-sql-private-network.yml` — DEPRECATED header

**Out of Scope:**
- Remote state backend provisioning (documented in `infra/README.md`, operator-run once)
- Deletion of deprecated workflows (retained for reference history)
- CI/CD Terraform apply pipeline (tracked separately)
- VNet / private endpoint wiring (variables defined, not enabled by default)

## User Experience Flow

1. Operator clones repo, navigates to `infra/terraform/`.
2. Runs `terraform init && terraform plan -var-file="environments/dev.tfvars" -var="sql_admin_password=$SQL_PASSWORD"`.
3. Reviews plan — all resources shown: RG, KV, ACR, SQL, Log Analytics, CAE, Container App.
4. Runs `terraform apply` — stack deployed in dependency order.
5. Terraform outputs FQDN, KV URI, SQL FQDN, ACR login server.
6. For production: fills `environments/prod.tfvars` `<replace>` values, injects password via `TF_VAR_sql_admin_password`, applies.
7. CI `terraform-lint` job runs `terraform fmt --check` + `terraform validate` on every PR touching `infra/**`.

## Functional Requirements

- **FR-001** — `terraform init && terraform validate` passes locally and in CI.
- **FR-002** — `terraform fmt --check` passes — all `.tf` files formatted per `terraform fmt`.
- **FR-003** — All secrets (SQL password, OpenAI key) stored in Key Vault; zero secrets in `.tfvars` files or Terraform state outputs marked non-sensitive.
- **FR-004** — Container App reads `sql-connection-string` from Key Vault via Managed Identity (`Key Vault Secrets User` RBAC).
- **FR-005** — Container App pulls images from ACR via Managed Identity (`AcrPull` RBAC).
- **FR-006** — `terraform apply` is idempotent — second apply produces "No changes" for unchanged configuration.
- **FR-007** — Azure OpenAI module is conditional (`deploy_openai = false` by default).
- **FR-008** — Bot channel is conditional (`deploy_bot_channel = false` by default); wires `azurerm_bot_channel_ms_teams` when enabled.
- **FR-009** — Dev `tfvars` targets `centralus` (Azure commercial); prod `tfvars` targets `usgovvirginia` (Azure Government).
- **FR-010** — Deprecated workflows carry `# DEPRECATED` header comments pointing to `infra/terraform/`.

## Technical Design Notes

**Overlay module wiring pattern:**
```hcl
module "rg" {
  source  = "azurenoops/overlays-resource-group/azurerm"
  version = "~> 1.0"
  org_name      = var.org_name
  environment   = var.environment        # "public" | "usgovernment"
  workload_name = var.workload_name
  location      = module.mod_location.location_short  # e.g. "eus" → overlay naming
}
```
All overlay modules share the same four required variables: `org_name`, `environment`,
`workload_name`, `deploy_environment`. Resource names are generated by the
`azurenoops/overlays-azregions-lookup` region lookup + `azurenoopsutils` naming provider.

**Native ACA resources:** No overlay exists for `azurerm_container_app_environment` or
`azurerm_container_app`. These are provisioned directly with the `azurerm` provider. The
Container App uses `identity = "System"` for both ACR registry pull and Key Vault secret refs.

**SQL admin password:** `sql_admin_password` is declared `sensitive = true` in `variables.tf`.
It must be injected via `TF_VAR_sql_admin_password` env var or `-var` flag — never in
`.tfvars` files committed to git. The `environments/*.tfvars` files contain a comment
documenting this constraint.

**Bot channel wiring:** `azurerm_bot_service_azure_bot` + `azurerm_bot_channel_ms_teams` are
conditional on `var.deploy_bot_channel`. The messaging endpoint is derived from the Container
App FQDN: `https://${azurerm_container_app.mcp.ingress[0].fqdn}/api/messages`.

**Terraform fmt compliance:** All `.tf` files in this PR pass `terraform fmt --check`. The CI
job enforces this on every future PR.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Terraform over Bicep | azurenoops org standard; existing overlay library; state management via Azure Blob Storage; team familiarity |
| azurenoops overlay modules | Org convention for SCCA-compliant naming, tagging, and resource configuration; battle-tested across DoD deployments |
| Native azurerm for ACA | No `azurenoops/overlays-container-apps` exists; native provider is the only option |
| `sensitive = true` on `sql_admin_password` | Prevents password from appearing in `terraform plan` output or state files |
| Conditional OpenAI + Bot via `count` | Keeps the module composable — operators opt in to expensive/optional resources per environment |
| `deploy_environment` separate from `environment` | `environment` = Azure tenant type (public/usgovernment); `deploy_environment` = workload lifecycle stage (dev/staging/prod) — overlay convention requires both |
| DEPRECATED headers, not deletion | Preserves operational history; operators may still reference the shell scripts for runbook context during transition |

## Acceptance Criteria

```gherkin
Given a fresh clone of the repo with Terraform >= 1.3 installed
When  cd infra/terraform && terraform init -backend=false && terraform validate
Then  exits with code 0 and "Success! The configuration is valid."

Given any file under infra/ is modified in a PR
When  the CI terraform-lint job runs
Then  terraform fmt --check passes
And   terraform init -backend=false passes
And   terraform validate passes

Given a PR that introduces a formatting violation (missing newline, wrong indentation)
When  the CI terraform-lint job runs
Then  terraform fmt --check fails and the job is red

Given infra/terraform/environments/prod.tfvars
When  the file is read
Then  no real passwords, secrets, or credentials appear
And   every <replace> placeholder is documented with a comment

Given .github/workflows/bootstrap-azure-containerapp.yml line 1
When  the file is read
Then  the first line is a DEPRECATED comment pointing to infra/terraform/
```

## Non-Functional Requirements

- **NFR-001** — `terraform fmt --check` passes on all `.tf` files (enforced by CI).
- **NFR-002** — `sensitive = true` on all secret-valued variables and outputs.
- **NFR-003** — Idempotent: `terraform apply` twice on unchanged config = "No changes".
- **NFR-004** — `terraform validate` passes without cloud credentials (uses `-backend=false`).
- **NFR-005** — `.gitignore` under `infra/terraform/` prevents `.terraform/`, `*.tfstate`, and `terraform.tfvars` from being committed.

## Test Plan

**Local validation:**
- `terraform fmt --check -recursive` — must pass.
- `terraform init -backend=false && terraform validate` — must pass.

**CI:**
- `terraform-lint` job runs on every PR touching `infra/**`.

**Manual deploy smoke test:**
- `terraform apply -var-file="environments/dev.tfvars" -var="sql_admin_password=<test>"` in a sandbox subscription.
- Verify all overlay-named resources appear in the resource group.
- Verify Container App FQDN is in outputs.
- Re-apply — verify "No changes".

**Existing suite must pass:**
- All existing CI jobs: dotnet-build-test, vscode-extension-compile, ato-compliance-gate.

## Definition of Done

- [x] `infra/terraform/main.tf` — overlay modules for RG, KV, ACR, SQL, OpenAI; native ACA; RBAC; optional Bot
- [x] `infra/terraform/variables.tf` — all inputs, descriptions, validation rules, `sensitive` on passwords
- [x] `infra/terraform/outputs.tf` — FQDN, KV URI/name, SQL FQDN, ACR login server
- [x] `infra/terraform/terraform.tfvars.example` — copy-pasteable, no real values
- [x] `infra/terraform/.gitignore` — Terraform artifacts excluded
- [x] `infra/terraform/environments/dev.tfvars` — centralus, Basic ACR, S2 SQL, scale-to-zero
- [x] `infra/terraform/environments/prod.tfvars` — usgovvirginia, Standard ACR, S4 SQL, prod settings
- [x] `infra/README.md` — overlay table, quickstart, remote state, secrets management
- [x] `.github/workflows/ci.yml` — `terraform-lint` job + `m365-test` job
- [x] `bootstrap-azure-containerapp.yml` — DEPRECATED header added
- [x] `migrate-containerapps-to-vnet-env.yml` — DEPRECATED header added
- [x] `prepare-sql-private-network.yml` — DEPRECATED header added
- [x] `terraform fmt --check` passes locally
- [x] `terraform validate` passes locally (with `-backend=false`)
- [x] All existing CI jobs still pass
- [x] PR targets `azurenoops/ato-copilot:main`

## Explicit Constraints

- DO NOT commit `terraform.tfvars` with real passwords to version control.
- DO NOT use `sensitive = false` on any variable that holds a secret.
- DO NOT delete the deprecated shell workflows — annotate only (history preservation).
- DO NOT enable private endpoints or VNet integration in this PR — variables are defined but not activated; those are a follow-up task.
- DO NOT use `--mode Complete` equivalent (`-target` is fine; `-replace` only for explicit recreation).
- DO NOT commit `.terraform/` directory or `*.tfstate` files.

## Anti-patterns

- **Anti-pattern:** SQL admin password in `environments/*.tfvars`.
  **Correct:** Inject via `TF_VAR_sql_admin_password` env var in CI; never in committed files.
- **Anti-pattern:** One monolithic `main.tf` with inline resource definitions for everything.
  **Correct:** Overlay modules for org-standard resources; native azurerm only for uncovered resources.
- **Anti-pattern:** Ignoring `terraform fmt` violations.
  **Correct:** CI enforces `terraform fmt --check`; run `terraform fmt -recursive` locally before pushing.
- **Anti-pattern:** Deleting deprecated shell workflows.
  **Correct:** DEPRECATED headers retained for operational history; deletion is a separate cleanup PR.

## Existing File References

- `.github/workflows/bootstrap-azure-containerapp.yml:1` — annotation added; content unchanged
- `.github/workflows/migrate-containerapps-to-vnet-env.yml:1` — annotation added; content unchanged
- `.github/workflows/prepare-sql-private-network.yml:1` — annotation added; content unchanged
- `.github/workflows/ci.yml:74` — `terraform-lint` and `m365-test` jobs inserted before `ato-compliance-gate`
- `specs/066-bicep-iac/tasks.md` — T001–T011 tasks map to T154–T157 (amended from Bicep to Terraform)
- `specs/061-m365-production-readiness/tasks.md:T061-01` — `m365-test` CI job co-landed

<!-- Closes #123, #154, #155, #156, #157 -->
