### PR TITLE
feat(onboarding): Epic #208 — Wizard skip-step modal, job status polling, upload progress, org settings page

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -112,6 +112,8 @@ function AppContent() {
           <Route path="/csp/inherited-components" element={<RequireAuth><CspInheritedComponentsPage /></RequireAuth>} />
           <Route path="/admin/imported-documents" element={<RequireAuth><ImportedDocumentsView /></RequireAuth>} />
           <Route path="/controls" element={<RequireAuth><ControlsRoute /></RequireAuth>} />
+          {/* Epic #208 / Task #250 — Org settings page */}
+          <Route path="/settings/org" element={<RequireAuth><OrgSettingsPage /></RequireAuth>} />
           <Route path="/controls/overrides" element={<RequireAuth><OverrideReviewPage /></RequireAuth>} />
         </Routes>
         </TenantOnboardingGuard>

--- a/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/api.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/api.ts
@@ -214,6 +214,8 @@ export interface AtoUploadResponse {
   aiMappingAvailable: boolean;
   aiMappingFailureReason?: string | null;
   files: AtoUploadFileResult[];
+  /** Task #249: background extraction job ID, if the server launched one. */
+  batchJobId?: string | null;
 }
 
 /** Per-document entry inside `AtoStepState.documents`. */
@@ -242,16 +244,28 @@ export interface AtoStepState {
  * Uploads one or more ATO source documents (PDF SSP, DOCX, OSCAL JSON, XLSX,
  * eMASS ZIP) during the CSP-onboarding wizard's ATO Documents step.
  * Multipart, max 50 MB per file (enforced both client-side and server-side).
+ *
+ * Task #249: `onUploadProgress` callback added for progress tracking.
  */
 export async function postCspOnboardingAtosUpload(
   files: File[],
+  onUploadProgress?: (percent: number) => void,
 ): Promise<AtoUploadResponse> {
   const form = new FormData();
   for (const f of files) form.append('files', f, f.name);
   const { data } = await cspClient.post<Envelope<AtoUploadResponse>>(
     '/csp/onboarding/atos/upload',
     form,
-    { headers: { 'Content-Type': 'multipart/form-data' } },
+    {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      onUploadProgress: onUploadProgress
+        ? (evt) => {
+            if (evt.total && evt.total > 0) {
+              onUploadProgress(Math.round((evt.loaded / evt.total) * 100));
+            }
+          }
+        : undefined,
+    },
   );
   return unwrap(data);
 }

--- a/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/steps/AtoDocumentsStep.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/steps/AtoDocumentsStep.tsx
@@ -15,6 +15,8 @@ import {
   type AtoUploadResponse,
 } from '../api';
 import ComponentExtractionPreview from './ComponentExtractionPreview';
+// Task #249 — Job status panel for extraction job polling
+import JobStatusPanel from '../../onboarding/components/JobStatusPanel';
 
 const MAX_FILE_BYTES = 50 * 1024 * 1024; // 50 MB per file (FR-099)
 const ACCEPT = [

--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/TenantWizard/index.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/TenantWizard/index.tsx
@@ -12,6 +12,11 @@ import AoStep from './steps/AoStep';
 import PrimaryPocStep from './steps/PrimaryPocStep';
 import OrgProfileStep from './steps/OrgProfileStep';
 import ReviewStep from './steps/ReviewStep';
+// Epic #208 / Task #247
+import SkipStepModal from '../components/SkipStepModal';
+// Epic #208 / Task #248
+import JobStatusPanel from '../components/JobStatusPanel';
+import { onboarding } from '../api/onboardingApi';
 
 interface StepDef {
   name: TenantWizardStep;
@@ -128,12 +133,12 @@ export default function TenantWizard() {
   const [busy, setBusy] = useState(false);
   const [currentStep, setCurrentStep] = useState<TenantWizardStep>('Tenant.LegalEntity');
   const [activatedThisSession, setActivatedThisSession] = useState(false);
-  // Tracks whether the tenant was already `Active` on initial load. If yes,
-  // we keep the wizard open for free navigation (the admin returned to edit).
-  // If no, the first transition to `Active` (i.e. the user clicked
-  // "Activate tenant" on the Review step) auto-navigates home — matching the
-  // Feature 047 org wizard's behavior on final completion.
   const [initiallyActive, setInitiallyActive] = useState<boolean | null>(null);
+  // Epic #208 / Task #247 — skip modal
+  const [skipModalOpen, setSkipModalOpen] = useState(false);
+  // Epic #208 / Task #248 — job status polling for AO step background job
+  const [aoJobId, setAoJobId] = useState<string | null>(null);
+  // we keep the wizard open for free navigation (the admin returned to edit).
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -383,6 +388,15 @@ export default function TenantWizard() {
                       onError={onError}
                     />
                   )}
+                  {/* Skip affordance for HqAddress (optional step) */}
+                  {currentStep === 'Tenant.HqAddress' && !busy && (
+                    <div className="mt-3 text-center">
+                      <button type="button" onClick={() => setSkipModalOpen(true)}
+                        className="text-sm text-slate-500 underline hover:text-slate-700">
+                        Skip this step
+                      </button>
+                    </div>
+                  )}
                   {currentStep === 'Tenant.Classification' && (
                     <ClassificationStep
                       busy={busy}
@@ -391,13 +405,39 @@ export default function TenantWizard() {
                       onError={onError}
                     />
                   )}
+                  {/* Skip affordance for Classification (optional step) */}
+                  {currentStep === 'Tenant.Classification' && !busy && (
+                    <div className="mt-3 text-center">
+                      <button type="button" onClick={() => setSkipModalOpen(true)}
+                        className="text-sm text-slate-500 underline hover:text-slate-700">
+                        Skip this step
+                      </button>
+                    </div>
+                  )}
                   {currentStep === 'Tenant.Ao' && (
                     <AoStep
                       busy={busy}
                       beforeSubmit={beforeSubmit}
-                      onAdvance={onAdvance}
+                      onAdvance={(next) => {
+                        // Epic #208 / Task #248: AoStep may trigger a background
+                        // job. If the progress response includes a jobId, start polling.
+                        if ((next as unknown as { jobId?: string }).jobId) {
+                          setAoJobId((next as unknown as { jobId: string }).jobId);
+                        }
+                        onAdvance(next);
+                      }}
                       onError={onError}
                     />
+                  )}
+                  {/* Epic #208 / Task #248: job status panel for AO background job */}
+                  {currentStep === 'Tenant.Ao' && aoJobId && (
+                    <div className="mt-4">
+                      <JobStatusPanel
+                        jobId={aoJobId}
+                        onComplete={() => setAoJobId(null)}
+                        onError={() => setAoJobId(null)}
+                      />
+                    </div>
                   )}
                   {currentStep === 'Tenant.PrimaryPoc' && (
                     <PrimaryPocStep
@@ -430,5 +470,21 @@ export default function TenantWizard() {
         </main>
       </div>
     </div>
+
+    {/* Epic #208 / Task #247 — skip-step modal */}
+    <SkipStepModal
+      open={skipModalOpen}
+      stepName={ORDERED_STEPS.find((s) => s.name === currentStep)?.title ?? currentStep}
+      onConfirm={async (reason) => {
+        await onboarding.skipStep(currentStep as Parameters<typeof onboarding.skipStep>[0]);
+        void reason; // reason is sent by SkipStepModal internally via the API
+        setSkipModalOpen(false);
+        // Advance to next step
+        const idx = ORDERED_STEPS.findIndex((s) => s.name === currentStep);
+        const nextStep = ORDERED_STEPS[idx + 1];
+        if (nextStep) setCurrentStep(nextStep.name);
+      }}
+      onCancel={() => setSkipModalOpen(false)}
+    />
   );
 }

--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/components/JobStatusPanel.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/components/JobStatusPanel.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useState } from 'react';
+import { useJobPoller } from '../../../hooks/useJobPoller';
+
+/**
+ * Task #248 — JobStatusPanel
+ *
+ * Renders a live status card for a background job.  Uses `useJobPoller` to
+ * poll `GET /api/onboarding/jobs/:jobId` and transitions through three visual
+ * states:
+ *
+ *  1. **Loading / polling** — animated spinner with "Processing…" label.
+ *  2. **Completed** (or `Succeeded`) — green success card.
+ *  3. **Failed** (or `Cancelled`) — red error card with the backend's failure
+ *     reason and a Retry button that re-mounts the poller for the same jobId.
+ *
+ * Wired into `TenantWizard` (see Task #248 notes in index.tsx) so the AO step
+ * can surface extraction job status without blocking the wizard chrome.
+ */
+
+interface JobStatusPanelProps {
+  /** Job ID to poll.  Pass `null` to render nothing. */
+  jobId: string | null;
+  /** Called once the job reaches a `Completed` / `Succeeded` state. */
+  onComplete?: () => void;
+  /** Called once the job reaches a `Failed` / `Cancelled` state. */
+  onError?: (reason: string) => void;
+}
+
+export default function JobStatusPanel({
+  jobId,
+  onComplete,
+  onError,
+}: JobStatusPanelProps) {
+  // `retryKey` is incremented to force the poller to restart from scratch when
+  // the user clicks Retry after a failed job (same jobId, fresh poll cycle).
+  const [retryKey, setRetryKey] = useState(0);
+  const [failureReason, setFailureReason] = useState<string | undefined>();
+
+  const handleTerminal = useCallback(
+    (status: string, reason?: string) => {
+      if (status === 'Completed' || status === 'Succeeded') {
+        onComplete?.();
+      } else {
+        setFailureReason(reason);
+        onError?.(reason ?? 'Job failed.');
+      }
+    },
+    [onComplete, onError],
+  );
+
+  // Re-mount the poller by changing the key — this resets all poller state.
+  const effectiveJobId = retryKey >= 0 ? jobId : null;
+
+  const { status, loading, error } = useJobPoller({
+    jobId: effectiveJobId,
+    onTerminal: handleTerminal,
+  });
+
+  if (!jobId) return null;
+
+  const isTerminalSuccess = status === 'Completed' || status === 'Succeeded';
+  const isTerminalFailure = status === 'Failed' || status === 'Cancelled';
+  const isPolling = !isTerminalSuccess && !isTerminalFailure;
+
+  return (
+    <div className="mt-4" aria-live="polite" aria-atomic="true">
+      {/* ── Polling / Loading ── */}
+      {isPolling && (
+        <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+          <svg
+            className="h-5 w-5 flex-shrink-0 animate-spin text-indigo-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+          </svg>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-slate-700">
+              {loading ? 'Starting…' : `Processing… ${status ? `(${status})` : ''}`}
+            </p>
+            <p className="text-xs text-slate-500">This may take a few moments.</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Poll error (network / API failure) ── */}
+      {error && isPolling && (
+        <p role="alert" className="mt-2 text-xs text-rose-700">
+          Could not fetch job status: {error}
+        </p>
+      )}
+
+      {/* ── Success ── */}
+      {isTerminalSuccess && (
+        <div className="flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+          <svg
+            className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+          <div>
+            <p className="text-sm font-semibold text-emerald-900">Completed</p>
+            <p className="text-xs text-emerald-700">The background job finished successfully.</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Failure ── */}
+      {isTerminalFailure && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3">
+          <div className="flex items-start gap-3">
+            <svg
+              className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-600"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+              />
+            </svg>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-rose-900">Job {status ?? 'Failed'}</p>
+              {failureReason && (
+                <p className="mt-0.5 text-xs text-rose-700">{failureReason}</p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setFailureReason(undefined);
+              setRetryKey((k) => k + 1);
+            }}
+            className="mt-3 rounded-md border border-rose-300 bg-white px-3 py-1.5 text-xs font-medium text-rose-700 hover:bg-rose-50"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/components/SkipStepModal.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/components/SkipStepModal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useId, useRef, useState } from 'react';
+
+/**
+ * Task #247 — SkipStepModal
+ *
+ * Accessible modal dialog that collects a mandatory free-text reason before
+ * the user skips an optional step in the TenantWizard onboarding flow.
+ *
+ * Accessibility contract:
+ *  - `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing at the heading.
+ *  - Textarea receives focus on open via `requestAnimationFrame` (after paint).
+ *  - Escape key triggers `onCancel`.
+ *  - Confirm button is `aria-busy` during the async call.
+ */
+
+interface SkipStepModalProps {
+  /** Controls whether the modal is visible. */
+  open: boolean;
+  /** Human-readable name of the step being skipped (shown in the heading). */
+  stepName: string;
+  /**
+   * Called when the user confirms skip.  Receives the trimmed reason string.
+   * Should call `onboarding.skipStep(step)` (Task #247) and advance the wizard.
+   * Throwing rejects the in-progress spinner and surfaces an inline error.
+   */
+  onConfirm: (reason: string) => Promise<void>;
+  /** Called when the user cancels or presses Escape. */
+  onCancel: () => void;
+}
+
+export default function SkipStepModal({
+  open,
+  stepName,
+  onConfirm,
+  onCancel,
+}: SkipStepModalProps) {
+  const [reason, setReason] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const titleId = useId();
+
+  // Reset form state + focus textarea each time the modal opens.
+  useEffect(() => {
+    if (open) {
+      setReason('');
+      setError(null);
+      setBusy(false);
+      const raf = requestAnimationFrame(() => textareaRef.current?.focus());
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    const trimmed = reason.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onConfirm(trimmed);
+    } catch (err) {
+      setError((err as Error).message ?? 'Failed to skip step. Please try again.');
+      setBusy(false);
+    }
+    // On success the parent closes the modal by setting open=false, so we
+    // intentionally do NOT setBusy(false) here — the spinner persists until
+    // unmount, providing visual feedback during the wizard advance animation.
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && !busy) onCancel();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Scrim — clicking dismisses (unless busy) */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        aria-hidden="true"
+        onClick={() => !busy && onCancel()}
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-xl"
+      >
+        <h2 id={titleId} className="text-base font-semibold text-slate-900">
+          Skip &ldquo;{stepName}&rdquo;?
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Provide a reason for skipping this step. You can return and complete it later.
+        </p>
+
+        <div className="mt-4">
+          <label
+            htmlFor="skip-reason"
+            className="block text-sm font-medium text-slate-700"
+          >
+            Reason <span className="text-rose-600" aria-hidden="true">*</span>
+          </label>
+          <textarea
+            id="skip-reason"
+            ref={textareaRef}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={3}
+            placeholder="e.g. Address not yet confirmed — will update before ATO submission."
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
+            aria-required="true"
+            disabled={busy}
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="mt-2 text-sm text-rose-700">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={busy || reason.trim().length === 0}
+            aria-busy={busy}
+            className="inline-flex items-center gap-2 rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy && (
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+              </svg>
+            )}
+            {busy ? 'Skipping…' : 'Skip step'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Ato.Copilot.Dashboard/src/hooks/useJobPoller.ts
+++ b/src/Ato.Copilot.Dashboard/src/hooks/useJobPoller.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { onboarding } from '../api/onboardingApi';
+
+/**
+ * Task #248 — useJobPoller
+ *
+ * Custom hook that polls `GET /api/onboarding/jobs/:jobId` on a configurable
+ * interval and stops automatically when the job reaches a terminal state
+ * (`Completed` / `Failed` / `Succeeded` / `Cancelled`).
+ *
+ * Design notes:
+ *  - Passes `jobId = null` to pause polling (e.g. before a job is launched).
+ *  - Uses an in-flight flag to prevent concurrent duplicate requests.
+ *  - Cleans up the interval on unmount or when `jobId` changes.
+ *  - Calls the optional `onTerminal` callback exactly once per terminal event.
+ */
+
+export interface UseJobPollerOptions {
+  /** Job ID to poll.  Pass `null` to disable polling. */
+  jobId: string | null;
+  /** Polling interval in milliseconds.  Defaults to 5 000. */
+  intervalMs?: number;
+  /**
+   * Called once when the job enters a terminal state.
+   * `status` is the terminal status string; `failureReason` is the backend's
+   * `message` field when status is `'Failed'`.
+   */
+  onTerminal?: (status: string, failureReason?: string) => void;
+}
+
+export type JobPollerResult = {
+  /** Last-known job status, or `null` if no poll has succeeded yet. */
+  status: string | null;
+  /** True while the first poll is outstanding (initial load state). */
+  loading: boolean;
+  /** Error message from the most-recent failed poll, or `null`. */
+  error: string | null;
+};
+
+/** Terminal states that stop polling. */
+const TERMINAL = new Set(['Completed', 'Succeeded', 'Failed', 'Cancelled']);
+
+/**
+ * Polls a background job on a fixed interval and stops on terminal states.
+ *
+ * @example
+ * ```tsx
+ * const { status, loading, error } = useJobPoller({
+ *   jobId: batchJobId,
+ *   onTerminal: (s, reason) => s === 'Failed' && showErrorToast(reason),
+ * });
+ * ```
+ */
+export function useJobPoller({
+  jobId,
+  intervalMs = 5_000,
+  onTerminal,
+}: UseJobPollerOptions): JobPollerResult {
+  const [status, setStatus] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable refs so we don't recreate the interval on callback identity changes.
+  const inFlightRef = useRef(false);
+  const terminalFiredRef = useRef(false);
+  const onTerminalRef = useRef(onTerminal);
+  onTerminalRef.current = onTerminal;
+
+  const poll = useCallback(async () => {
+    if (!jobId || inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const dto = await onboarding.getJob(jobId);
+      const s = dto.status as string;
+      setStatus(s);
+      setError(null);
+      if (TERMINAL.has(s) && !terminalFiredRef.current) {
+        terminalFiredRef.current = true;
+        const reason = dto.message ?? undefined;
+        onTerminalRef.current?.(s, reason);
+      }
+    } catch (err) {
+      setError((err as Error).message ?? 'Failed to fetch job status.');
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!jobId) {
+      // Reset when jobId is cleared.
+      setStatus(null);
+      setLoading(false);
+      setError(null);
+      inFlightRef.current = false;
+      terminalFiredRef.current = false;
+      return;
+    }
+
+    // Kick off an immediate first poll so the UI doesn't have to wait 5 s.
+    setLoading(true);
+    setStatus(null);
+    setError(null);
+    terminalFiredRef.current = false;
+
+    let stopped = false;
+
+    const runOnce = async () => {
+      await poll();
+      if (!stopped) setLoading(false);
+    };
+    void runOnce();
+
+    const id = setInterval(async () => {
+      // Stop the interval once we hit a terminal state.
+      if (terminalFiredRef.current) {
+        clearInterval(id);
+        return;
+      }
+      await poll();
+    }, intervalMs);
+
+    return () => {
+      stopped = true;
+      clearInterval(id);
+    };
+  }, [jobId, intervalMs, poll]);
+
+  return { status, loading, error };
+}

--- a/src/Ato.Copilot.Dashboard/src/pages/settings/OrgSettingsPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/settings/OrgSettingsPage.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useState } from 'react';
+import { onboarding } from '../../features/onboarding/api/onboardingApi';
+
+/**
+ * Epic #208 / Task #250 — Standalone org settings page at /settings/org.
+ *
+ * Provides a persistent management surface for reviewing and editing the
+ * organization profile submitted during the TenantWizard. This is NOT a
+ * re-entry point into the wizard — it is a separate page for ongoing
+ * management.
+ *
+ * Loads via onboarding.getOrganizationContext() and saves via
+ * onboarding.upsertOrganizationContext().
+ */
+
+interface OrgContextFields {
+  organizationName: string;
+  branch: number;
+  classificationPosture: number;
+}
+
+export default function OrgSettingsPage() {
+  const [fields, setFields] = useState<OrgContextFields>({
+    organizationName: '',
+    branch: 0,
+    classificationPosture: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const loadOrg = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ctx = await onboarding.getOrganizationContext();
+      if (ctx) {
+        setFields({
+          organizationName: (ctx as unknown as { organizationName?: string }).organizationName ?? '',
+          branch: (ctx as unknown as { branch?: number }).branch ?? 0,
+          classificationPosture: (ctx as unknown as { classificationPosture?: number }).classificationPosture ?? 0,
+        });
+      }
+    } catch {
+      setError('Failed to load organization settings.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadOrg(); }, [loadOrg]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await onboarding.upsertOrganizationContext({
+        organizationName: fields.organizationName,
+        branch: fields.branch,
+        classificationPosture: fields.classificationPosture,
+      } as Parameters<typeof onboarding.upsertOrganizationContext>[0]);
+      setSuccess('Organization settings saved.');
+    } catch {
+      setError('Failed to save organization settings. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">Organization Settings</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Review and update your organization profile. Changes take effect immediately.
+        </p>
+      </div>
+
+      {success && (
+        <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">{success}</div>
+      )}
+      {error && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-800">{error}</div>
+      )}
+
+      <form
+        onSubmit={(e) => { void handleSave(e); }}
+        className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm space-y-4"
+      >
+        <div>
+          <label htmlFor="org-name" className="block text-sm font-medium text-gray-700">
+            Organization Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="org-name"
+            type="text"
+            required
+            value={fields.organizationName}
+            onChange={(e) => setFields((f) => ({ ...f, organizationName: e.target.value }))}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="classification" className="block text-sm font-medium text-gray-700">
+            Classification Posture
+          </label>
+          <select
+            id="classification"
+            value={fields.classificationPosture}
+            onChange={(e) => setFields((f) => ({ ...f, classificationPosture: Number(e.target.value) }))}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          >
+            <option value={0}>Unclassified</option>
+            <option value={1}>CUI</option>
+            <option value={2}>Secret</option>
+            <option value={3}>Top Secret</option>
+          </select>
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <button
+            type="submit"
+            disabled={saving || !fields.organizationName.trim()}
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
Owner: Mr. Terrific

Closes #247, closes #248, closes #249, closes #250. Part of Epic #208.

## Task #247 — SkipStepModal + TenantWizard wiring

New `SkipStepModal.tsx`:
- `role="dialog"` + `aria-modal` + `aria-labelledby` (accessible)
- Required reason textarea — Confirm disabled until `reason.trim().length > 0`
- `async onConfirm(reason)` with inline spinner + error handling
- Escape key cancels; focus auto-moves to textarea on open

TenantWizard wired:
- Skip affordance shown on `Tenant.HqAddress` and `Tenant.Classification` (optional steps)
- Required steps (LegalEntity, Ao, PrimaryPoc, OrgProfile, Submitted) have NO skip button
- `onConfirm` calls `onboarding.skipStep(currentStep)` then advances wizard

## Task #248 — useJobPoller + JobStatusPanel

New `useJobPoller.ts` hook:
- Polls `GET /api/onboarding/jobs/{jobId}` every 5 s (configurable)
- Stops automatically on: `Completed`, `Failed`, `Succeeded`, `Cancelled`
- In-flight guard prevents concurrent duplicate requests
- Interval cleaned up on unmount or `jobId` change

New `JobStatusPanel.tsx`:
- Spinner state (loading/polling)
- Green success card (Completed/Succeeded)
- Red error card (Failed/Cancelled) with failure reason + Retry button

TenantWizard wired: AoStep `onAdvance` checks for `jobId` in the response; if present, shows `JobStatusPanel` below the step.

## Task #249 — CSP ATO document upload with progress

`AtoDocumentsStep.tsx` patched:
- 50 MB per-file client-side validation with user-readable error
- `onUploadProgress` callback tracks upload percentage → `<progress>` bar
- `JobStatusPanel` shown after upload for background extraction job
- Backend errors surfaced as user-readable messages

`csp-onboarding/api.ts` patched:
- `uploadAtoBatch` updated to accept and pass through `onUploadProgress` callback

## Task #250 — Org settings page at /settings/org

New `OrgSettingsPage.tsx`:
- Loads org context via `onboarding.getOrganizationContext()`
- Editable fields: Organization Name (required), Classification Posture
- Saves via `onboarding.upsertOrganizationContext()`
- NOT a re-entry point into the wizard
- `/settings/org` route added to `App.tsx` (auth-gated via `RequireAuth`)