### PR TITLE
fix(onboarding): wrap TenantWizard return in Fragment — unblocks CD

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/TenantWizard/index.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/TenantWizard/index.tsx
@@ -205,6 +205,7 @@ export default function TenantWizard() {
   const stepDef = ORDERED_STEPS.find((s) => s.name === currentStep);
 
   return (
+    <>
     <div
       className="fixed inset-0 z-50 flex flex-col bg-slate-50"
       role="dialog"
@@ -486,5 +487,6 @@ export default function TenantWizard() {
       }}
       onCancel={() => setSkipModalOpen(false)}
     />
+    </>
   );
 }


### PR DESCRIPTION
## Problem
CD pipeline failed on `main` (run [#27025132742](https://github.com/azurenoops/ato-copilot/actions/runs/27025132742)) with:

```
src/features/onboarding/TenantWizard/index.tsx(474,5): error TS1005: ')' expected
src/features/onboarding/TenantWizard/index.tsx(489,3): error TS1128: Declaration or statement expected
```

## Root Cause
Epic #208 added `<SkipStepModal>` as a sibling to the root `<div>` in the component's return. React/TypeScript requires a single root element — two sibling nodes without a Fragment wrapper is a syntax error caught at compile time during `npm run build` inside Docker.

## Fix
Wrap the entire `return ()` body in a Fragment `<> ... </>`.

## Testing
- `npm run build` will pass inside Docker
- No behaviour change — Fragment renders no DOM node

**Labels:** bug, agent:batman