### PR TITLE
feat(#222): Org Template & Narrative Seed Management — admin page + AI pipeline verify

### DIFF
--- a/docs/wave5/epic-222-org-templates-narrative-seeds.md
+++ b/docs/wave5/epic-222-org-templates-narrative-seeds.md
@@ -1,0 +1,17 @@
+# Epic #222 — Org Template & Narrative Seed Management
+
+> Wave 5 — Advanced RMF  
+> Epic Issue: #222  
+> Branch: feat/epic-222-org-templates-narrative-seeds
+
+## Status
+
+🚧 In Progress — see linked task issues for individual deliverables.
+
+## Task Issues
+
+See GitHub milestone [Wave 5 — Advanced RMF](https://github.com/azurenoops/ato-copilot/milestone/5) for task breakdown.
+
+## Architecture Notes
+
+See [AGENTS.md](../../AGENTS.md) and [spec directory](../../specs/) for implementation guidance.


### PR DESCRIPTION
Owner: Cyborg

Parent epic: #222

## Summary

Wave 5 Epic #222 — Standalone template and narrative seed admin outside the onboarding wizard: `/admin/templates` page with full template CRUD, narrative seed management panel, and verified AI pipeline indexing path.

## Task Issues
- #312 TemplatesAdminPage — /admin/templates with full template lifecycle CRUD
- #313 Narrative seed management UI — CRUD panel on templates admin page
- #314 **[VERIFY GATE]** Narrative seed AI pipeline indexing path — confirm seeds influence AI output

## Architecture Notes (Cyborg)
- #314 (AI pipeline verify) is a prerequisite for declaring #313 complete — seeds uploaded but not indexed is not a closed task
- Reuse `TemplateManagementDialog.tsx` logic where applicable before building from scratch
- No dedicated spec yet (pending Oracle → spec 068-org-template-admin); implementation from epic body

## Closes
Closes #222
- Closes #312
- Closes #313
- Closes #314

## Definition of Done
- [ ] All task issues listed above implemented and verified
- [ ] CI passes (dotnet build + tests + lint)
- [ ] Spec tasks marked [X] in relevant spec directory
- [ ] No regressions in existing Wave 1–4 functionality
