### PR TITLE
feat(#215): AzureSettingsPage + subscription registration management

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -41,6 +41,7 @@ import CspWizard from './features/csp-onboarding/CspWizard';
 import CspOnboardingGuard from './features/csp-onboarding/CspOnboardingGuard';
 import CspInheritedComponentsPage from './features/csp-inherited-components/CspInheritedComponentsPage';
 import ImportedDocumentsView from './features/admin/imported-documents/ImportedDocumentsView';
+import AzureSettingsPage from './pages/AzureSettingsPage';
 import LoginPage from './features/auth/LoginPage';
 import LoginCallbackPage from './features/auth/LoginCallbackPage';
 import TenantPickerPage from './features/auth/TenantPickerPage';
@@ -121,6 +122,8 @@ function AppContent() {
           <Route path="/controls" element={<RequireAuth><ControlsRoute /></RequireAuth>} />
           {/* Epic #208 / Task #250 — Org settings page */}
           <Route path="/settings/org" element={<RequireAuth><OrgSettingsPage /></RequireAuth>} />
+          {/* Epic #215 / Task #293 — Azure subscription settings page */}
+          <Route path="/settings/azure-subscriptions" element={<RequireAuth><AzureSettingsPage /></RequireAuth>} />
           <Route path="/controls/overrides" element={<RequireAuth><OverrideReviewPage /></RequireAuth>} />
         </Routes>
         </TenantOnboardingGuard>

--- a/src/Ato.Copilot.Dashboard/src/pages/AzureSettingsPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/AzureSettingsPage.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { onboarding } from '../features/onboarding/api/onboardingApi';
+import type { AzureSubscriptionRegistrationDto } from '../features/onboarding/api/onboardingApi';
+
+/**
+ * Epic #215 / Task #293 — Azure subscription settings page at /settings/azure-subscriptions.
+ *
+ * Provides a persistent management surface for reviewing, registering, and removing
+ * Azure subscription registrations. Uses onboarding.listAzureRegistrations,
+ * onboarding.putAzureRegistrations, and onboarding.removeAzureRegistration.
+ */
+export default function AzureSettingsPage() {
+  const [registrations, setRegistrations] = useState<AzureSubscriptionRegistrationDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const [newSubId, setNewSubId] = useState('');
+  const [registering, setRegistering] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState<AzureSubscriptionRegistrationDto | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  async function loadRegistrations() {
+    setLoading(true);
+    setError(null);
+    try {
+      const regs = await onboarding.listAzureRegistrations();
+      setRegistrations(regs);
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setError(err.message ?? 'Failed to load Azure registrations.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadRegistrations();
+  }, []);
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = newSubId.trim();
+    if (!trimmed) return;
+    setRegistering(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await onboarding.putAzureRegistrations([trimmed]);
+      setRegistrations(updated);
+      setNewSubId('');
+      setSuccess(`Subscription ${trimmed} registered successfully.`);
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setError(err.message ?? 'Failed to register subscription.');
+    } finally {
+      setRegistering(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await onboarding.removeAzureRegistration(deleteTarget.id);
+      setRegistrations((prev) => prev.filter((r) => r.id !== deleteTarget.id));
+      setSuccess(`Subscription ${deleteTarget.subscriptionId} removed.`);
+      setDeleteTarget(null);
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setError(err.message ?? 'Failed to remove subscription.');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <div className="flex items-start gap-4">
+        <div className="flex-1">
+          <h1 className="text-2xl font-semibold text-gray-900">Azure Subscription Settings</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Manage the Azure subscriptions registered for resource discovery and scope.
+          </p>
+        </div>
+        <Link
+          to="/admin/imported-documents"
+          className="shrink-0 text-sm text-indigo-600 hover:text-indigo-800"
+        >
+          ← Back
+        </Link>
+      </div>
+
+      {success && (
+        <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">{success}</div>
+      )}
+      {error && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-800">{error}</div>
+      )}
+
+      {/* Register form */}
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-base font-medium text-gray-900 mb-3">Register a Subscription</h2>
+        <form
+          onSubmit={(e) => { void handleRegister(e); }}
+          className="flex flex-col sm:flex-row gap-3 sm:items-end"
+        >
+          <div className="flex-1">
+            <label htmlFor="sub-id" className="block text-sm font-medium text-gray-700 mb-1">
+              Subscription ID
+            </label>
+            <input
+              id="sub-id"
+              type="text"
+              value={newSubId}
+              onChange={(e) => setNewSubId(e.target.value)}
+              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={registering || !newSubId.trim()}
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {registering ? 'Registering…' : 'Register'}
+          </button>
+        </form>
+      </div>
+
+      {/* Registrations table */}
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-base font-medium text-gray-900">Registered Subscriptions</h2>
+        </div>
+        {registrations.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-500 text-center">
+            No subscriptions registered yet. Use the form above to add one.
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Subscription ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Display Name
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white">
+              {registrations.map((reg) => (
+                <tr key={reg.id}>
+                  <td className="px-6 py-4 font-mono text-xs text-gray-700">{reg.subscriptionId}</td>
+                  <td className="px-6 py-4 text-gray-900">
+                    {reg.displayName || <span className="text-gray-400 italic">—</span>}
+                  </td>
+                  <td className="px-6 py-4">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        reg.status === 'Selected'
+                          ? 'bg-green-100 text-green-800'
+                          : 'bg-amber-100 text-amber-800'
+                      }`}
+                    >
+                      {reg.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    <button
+                      type="button"
+                      onClick={() => setDeleteTarget(reg)}
+                      className="text-sm text-red-600 hover:text-red-800 font-medium"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Delete confirmation dialog */}
+      {deleteTarget && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-sm">
+            <h3 className="font-semibold text-gray-900 mb-2">Remove Subscription?</h3>
+            <p className="text-sm text-gray-600 mb-1">
+              Are you sure you want to remove this subscription registration?
+            </p>
+            <p className="text-xs font-mono text-gray-700 bg-gray-50 rounded px-2 py-1 mb-4">
+              {deleteTarget.subscriptionId}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleting}
+                className="text-sm text-gray-600 hover:text-gray-800 px-3 py-1.5"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => { void handleDelete(); }}
+                disabled={deleting}
+                className="text-sm bg-red-600 text-white rounded px-3 py-1.5 hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? 'Removing…' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Ato.Copilot.Dashboard/src/pages/ComponentInventory.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/ComponentInventory.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ComponentSection } from '../components/cards/ComponentSection';
 import { ComponentForm } from '../components/forms/ComponentForm';
 import MetricCard from '../components/cards/MetricCard';
@@ -8,6 +8,7 @@ import { getComponents, createComponent, updateComponent, deleteComponent, disco
 import type { OrgComponentDto } from '../api/components';
 import { fetchBoundaryDefinitions } from '../api/boundaries';
 import apiClient from '../api/client';
+import { onboarding } from '../features/onboarding/api/onboardingApi';
 import type { SystemComponentDto, CreateComponentRequest, ComponentType, BoundaryDefinitionDto, DiscoveredResource } from '../types/dashboard';
 
 const SECTIONS: { title: string; type: ComponentType }[] = [
@@ -50,6 +51,7 @@ export default function ComponentInventory() {
   const [selectedResources, setSelectedResources] = useState<Set<string>>(new Set());
   const [importLoading, setImportLoading] = useState(false);
   const [failedGroups, setFailedGroups] = useState<string[]>([]);
+  const [noAzureSubscriptions, setNoAzureSubscriptions] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!systemId) return;
@@ -309,7 +311,15 @@ export default function ComponentInventory() {
           + Add Component
         </button>
         <button
-          onClick={() => { setShowDiscover(true); setDiscoverError(null); }}
+          onClick={() => {
+            setShowDiscover(true);
+            setDiscoverError(null);
+            onboarding.listAzureRegistrations().then((regs) => {
+              setNoAzureSubscriptions(regs.length === 0);
+            }).catch(() => {
+              setNoAzureSubscriptions(false);
+            });
+          }}
           className="px-4 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700"
         >
           Discover from Azure
@@ -446,6 +456,15 @@ export default function ComponentInventory() {
               <h2 className="text-lg font-semibold">Discover Azure Resources</h2>
               <button onClick={() => { setShowDiscover(false); setDiscovered([]); }} className="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
             </div>
+
+            {noAzureSubscriptions && (
+              <div className="rounded border border-amber-300 bg-amber-50 p-3 mb-4 text-sm text-amber-900">
+                No Azure subscriptions registered.{' '}
+                <Link to="/settings/azure-subscriptions" className="font-medium underline hover:text-amber-700">
+                  Configure Azure Settings
+                </Link>
+              </div>
+            )}
 
             <div className="flex gap-2 mb-4">
               <input


### PR DESCRIPTION
feat(#215): AzureSettingsPage + subscription banner in ComponentInventory

## Summary
Implements the standalone Azure subscription registration management page for Epic #215, closing task #293.

## Tasks Closed
- #293: AzureSettingsPage — standalone admin route for subscription registration management

## Changes
- `AzureSettingsPage.tsx` (new): admin page at `/settings/azure-subscriptions` — lists registered subscriptions, register form (subscription ID input → PUT /registrations), per-row delete with confirmation
- `App.tsx`: added `/settings/azure-subscriptions` route with RequireAuth
- `ComponentInventory.tsx`: amber banner in Azure discovery panel when no subscriptions are registered, linking to /settings/azure-subscriptions

Closes #215
