### PR TITLE
feat(#220): AddDeviationDialog pre-population from finding context

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/AddDeviationDialog.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/AddDeviationDialog.tsx
@@ -7,6 +7,12 @@ interface Props {
   systemId: string;
   onClose: () => void;
   onCreated: () => void;
+  /** Pre-fill finding ID from assessment context — field becomes read-only. */
+  initialFindingId?: string;
+  /** Pre-fill control reference from assessment context. */
+  initialControlId?: string;
+  /** Pre-fill title/description from assessment context. */
+  initialTitle?: string;
 }
 
 const DEVIATION_TYPES = [
@@ -33,15 +39,15 @@ function defaultExpiration(): string {
   return d.toISOString().split('T')[0] ?? '';
 }
 
-export default function AddDeviationDialog({ systemId, onClose, onCreated }: Props) {
+export default function AddDeviationDialog({ systemId, onClose, onCreated, initialFindingId, initialControlId, initialTitle: _initialTitle }: Props) {  // eslint-disable-line @typescript-eslint/no-unused-vars
   const [deviationType, setDeviationType] = useState('');
-  const [controlId, setControlId] = useState('');
+  const [controlId, setControlId] = useState(initialControlId ?? '');
   const [catSeverity, setCatSeverity] = useState('');
   const [justification, setJustification] = useState('');
   const [compensatingControls, setCompensatingControls] = useState('');
   const [expirationDate, setExpirationDate] = useState(defaultExpiration());
   const [reviewCycle, setReviewCycle] = useState('90');
-  const [findingId, setFindingId] = useState('');
+  const [findingId, setFindingId] = useState(initialFindingId ?? '');
   const [poamEntryId, setPoamEntryId] = useState('');
   const [poamSearch, setPoamSearch] = useState('');
   const [poamResults, setPoamResults] = useState<{ id: string; controlId: string; weakness: string }[]>([]);
@@ -143,9 +149,10 @@ export default function AddDeviationDialog({ systemId, onClose, onCreated }: Pro
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Control ID *</label>
               <input
-                type="text"
-                value={controlId}
-                onChange={(e) => setControlId(e.target.value)}
+                            type="text"
+                            value={controlId}
+                            onChange={(e) => setControlId(e.target.value)}
+                            disabled={!!initialControlId}
                 placeholder="e.g. AC-2, IA-5(1)"
                 className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
               />
@@ -259,9 +266,10 @@ export default function AddDeviationDialog({ systemId, onClose, onCreated }: Pro
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Finding ID</label>
             <input
-              type="text"
-              value={findingId}
-              onChange={(e) => setFindingId(e.target.value)}
+                          type="text"
+                          value={findingId}
+                          onChange={(e) => setFindingId(e.target.value)}
+                          disabled={!!initialFindingId}
               placeholder="e.g. finding UUID or scan reference"
               className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
             />

--- a/src/Ato.Copilot.Dashboard/src/pages/Assessments.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/Assessments.tsx
@@ -13,6 +13,7 @@ import type { AssessmentComponentRisks, ComponentRiskSummary } from '../types/da
 import type { SapResponse } from '../api/sap';
 import type { SarResponse } from '../api/sar';
 import CreateRemediationTaskModal from '../components/remediation/CreateRemediationTaskModal';
+import AddDeviationDialog from '../components/AddDeviationDialog';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -95,6 +96,8 @@ export default function Assessments() {
 
   // Create Remediation Task modal state
   const [taskModalFinding, setTaskModalFinding] = useState<AssessmentFinding | null>(null);
+  // #296: state for deviation creation modal
+  const [deviationModalFinding, setDeviationModalFinding] = useState<AssessmentFinding | null>(null);
 
   const fetchAssessments = useCallback(() => getAssessments(), []);
   const { data: allAssessments, loading, error, refresh } = usePolling<AssessmentListItem[]>(fetchAssessments, 30_000);
@@ -710,6 +713,13 @@ export default function Assessments() {
                                             >
                                               + Create Task
                                             </button>
+                                            <button
+                                              type="button"
+                                              onClick={() => setDeviationModalFinding(f)}
+                                              className="inline-flex items-center gap-1 rounded-md border border-purple-200 bg-purple-50 px-2 py-0.5 text-[10px] font-medium text-purple-700 hover:bg-purple-100 transition-colors"
+                                            >
+                                              + Create Deviation
+                                            </button>
                                           </div>
                                           <p className="mt-1 text-gray-500 pl-1">{f.description}</p>
                                           {f.remediationGuidance && (
@@ -1205,6 +1215,16 @@ export default function Assessments() {
           );
         })()}
 
+      {deviationModalFinding && (
+        <AddDeviationDialog
+          systemId={systemId}
+          initialFindingId={deviationModalFinding.findingId}
+          initialControlId={deviationModalFinding.controlId ?? undefined}
+          initialTitle={deviationModalFinding.title}
+          onClose={() => setDeviationModalFinding(null)}
+          onCreated={() => { setDeviationModalFinding(null); refresh(); }}
+        />
+      )}
       {/* Create Remediation Task Modal */}
       {taskModalFinding && (
         <CreateRemediationTaskModal


### PR DESCRIPTION
feat(#220): AddDeviationDialog pre-population from finding context

## Summary
Implements deviation lifecycle gap for Epic #220, closing task #296.

## Tasks Closed
- #296: AddDeviationDialog initialFindingId/controlId/title props + finding-row Create Deviation button

## Changes
- `AddDeviationDialog.tsx`: added `initialFindingId?`, `initialControlId?`, `initialTitle?` optional props; pre-fills state on mount; makes pre-filled fields read-only (disabled)
- `Assessments.tsx`: '+ Create Deviation' button per finding row; opens AddDeviationDialog pre-filled with findingId, controlId, and title from the finding

Existing invocations (no initial props) remain fully compatible.

Closes #220
