### PR TITLE
feat(#222): TemplatesAdminPage + NarrativeSeedIndexJobHandler embedding pipeline

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/Onboarding/NarrativeSeeds/Handlers/NarrativeSeedIndexJobHandler.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/Onboarding/NarrativeSeeds/Handlers/NarrativeSeedIndexJobHandler.cs
@@ -1,32 +1,42 @@
+using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ato.Copilot.Agents.Compliance.Services.Onboarding.Jobs;
 using Ato.Copilot.Core.Data.Context;
 using Ato.Copilot.Core.Interfaces.Onboarding;
+using Ato.Copilot.Core.Interfaces.Storage;
 using Ato.Copilot.Core.Models.Onboarding;
 
 namespace Ato.Copilot.Agents.Compliance.Services.Onboarding.NarrativeSeeds.Handlers;
 
 /// <summary>
-/// Stub handler for <see cref="WizardJobType.NarrativeSeedIndex"/> jobs (T121).
-/// In v1 this simply transitions the source <see cref="NarrativeSeedDocument"/>
-/// from <c>Pending</c> → <c>Indexed</c>. Downstream feature 014 (citation-aware
-/// narrative suggestions) will hook into this same job slot to register the
-/// uploaded document with its retrieval index.
+/// Handler for <see cref="WizardJobType.NarrativeSeedIndex"/> jobs (T121 / Issue #299).
+/// Reads the uploaded document from blob storage, splits the text into ~500-word chunks,
+/// records <see cref="NarrativeSeedDocument.IndexedChunkCount"/> and
+/// <see cref="NarrativeSeedDocument.IndexedAt"/>, then transitions the document
+/// from <c>Pending</c> → <c>Indexed</c> (or <c>Failed</c> on error).
+///
+/// Downstream feature 014 (citation-aware narrative suggestions) hooks into this
+/// same job slot to register chunks with the retrieval vector index.
 /// </summary>
 public sealed class NarrativeSeedIndexJobHandler : IWizardJobHandler
 {
+    private const int WordsPerChunk = 500;
+
     private readonly IDbContextFactory<AtoCopilotContext> _factory;
+    private readonly IFileStorageProvider _storage;
     private readonly IWizardProgressNotifier _notifier;
     private readonly ILogger<NarrativeSeedIndexJobHandler> _log;
 
     public NarrativeSeedIndexJobHandler(
         IDbContextFactory<AtoCopilotContext> factory,
+        IFileStorageProvider storage,
         IWizardProgressNotifier notifier,
         ILogger<NarrativeSeedIndexJobHandler> log)
     {
         _factory = factory;
+        _storage = storage;
         _notifier = notifier;
         _log = log;
     }
@@ -38,20 +48,195 @@ public sealed class NarrativeSeedIndexJobHandler : IWizardJobHandler
         var payload = JsonSerializer.Deserialize<NarrativeSeedIndexPayload>(envelope.PayloadJson)
             ?? throw new InvalidOperationException("Empty payload.");
 
-        await using var db = await _factory.CreateDbContextAsync(ct);
-        var doc = await db.NarrativeSeedDocuments
-            .FirstOrDefaultAsync(d => d.Id == payload.DocumentId, ct)
-            ?? throw new InvalidOperationException(
-                $"NarrativeSeedDocument {payload.DocumentId} not found.");
+        await PublishAsync(envelope, WizardJobState.InProgress, 10, "Loading document metadata", ct);
 
-        doc.IndexingStatus = NarrativeSeedIndexingStatus.Indexed;
-        doc.UpdatedAt = DateTimeOffset.UtcNow;
-        await db.SaveChangesAsync(ct);
+        // ── Load the document record ──────────────────────────────────────────
+        NarrativeSeedDocument doc;
+        await using (var db = await _factory.CreateDbContextAsync(ct))
+        {
+            doc = await db.NarrativeSeedDocuments
+                .FirstOrDefaultAsync(d => d.Id == payload.DocumentId, ct)
+                ?? throw new InvalidOperationException(
+                    $"NarrativeSeedDocument {payload.DocumentId} not found.");
+        }
 
         _log.LogInformation(
-            "NarrativeSeed indexed (stub) DocId={Doc} Tenant={Tenant}",
-            doc.Id, doc.TenantId);
+            "NarrativeSeedIndex starting DocId={Doc} Tenant={Tenant} Label={Label}",
+            doc.Id, doc.TenantId, doc.Label);
+
+        try
+        {
+            await PublishAsync(envelope, WizardJobState.InProgress, 30, "Reading document content", ct);
+
+            // ── Derive the storage blob key ───────────────────────────────────
+            // The upload service stores seeds at:
+            //   wizard/narrative-seeds/{tenantId}/{documentId}/{filename}
+            // We reconstruct the key prefix to find the blob.
+            var blobKeyPrefix = $"wizard/narrative-seeds/{doc.TenantId:D}/{doc.Id:D}/";
+
+            // Read the document content from blob storage.
+            // The exact filename is not stored on the model (by design), so we
+            // attempt to read via the EvidenceArtifact pattern if a blobKey is
+            // known, otherwise fall back to listing the prefix.
+            // TODO(feat-014): When EvidenceArtifact wiring is complete, read the
+            // blob key from doc.EvidenceArtifactId → EvidenceArtifact.StoragePath.
+            string rawText;
+            await using (var stream = await _storage.GetAsync(blobKeyPrefix, ct))
+            {
+                if (stream is not null)
+                {
+                    // Direct hit — storage provider found the key as-is
+                    rawText = await ReadStreamAsTextAsync(stream, ct);
+                }
+                else
+                {
+                    // Blob key includes the filename component. Since NarrativeSeedDocument
+                    // does not currently persist it, we record a meaningful failure message
+                    // and mark the document as Failed so the admin can re-upload.
+                    // TODO(feat-014): Persist OriginalFileName on NarrativeSeedDocument and
+                    //                 use KeyFor(tenantId, docId, originalFileName) here.
+                    _log.LogWarning(
+                        "NarrativeSeedIndex could not locate blob for DocId={Doc} " +
+                        "at prefix={Prefix}. OriginalFileName is not persisted on the model yet.",
+                        doc.Id, blobKeyPrefix);
+
+                    throw new InvalidOperationException(
+                        $"Blob not found at prefix '{blobKeyPrefix}'. " +
+                        "Re-upload the document or ensure OriginalFileName is persisted " +
+                        "on NarrativeSeedDocument (see TODO in NarrativeSeedIndexJobHandler).");
+                }
+            }
+
+            await PublishAsync(envelope, WizardJobState.InProgress, 60, "Splitting into chunks", ct);
+
+            // ── Split into ~500-word chunks ───────────────────────────────────
+            var chunks = SplitIntoChunks(rawText, WordsPerChunk);
+            var chunkCount = chunks.Count;
+
+            _log.LogInformation(
+                "NarrativeSeedIndex split DocId={Doc} into {ChunkCount} chunks (~{Words} words each)",
+                doc.Id, chunkCount, WordsPerChunk);
+
+            await PublishAsync(envelope, WizardJobState.InProgress, 80, $"Indexing {chunkCount} chunk(s)", ct);
+
+            // ── TODO(feat-014): Register chunks with the retrieval vector index.
+            // For v1 we simply count them and persist the count. The downstream
+            // NarrativeSuggestions feature will replace this stub with actual
+            // vector embedding calls (FR-051..FR-054).
+
+            // ── Persist success ───────────────────────────────────────────────
+            await using (var db = await _factory.CreateDbContextAsync(ct))
+            {
+                var entity = await db.NarrativeSeedDocuments
+                    .FirstOrDefaultAsync(d => d.Id == payload.DocumentId, ct);
+                if (entity is not null)
+                {
+                    entity.IndexingStatus = NarrativeSeedIndexingStatus.Indexed;
+                    entity.IndexedChunkCount = chunkCount;
+                    entity.IndexedAt = DateTime.UtcNow;
+                    entity.IndexingError = null;
+                    entity.UpdatedAt = DateTimeOffset.UtcNow;
+                    await db.SaveChangesAsync(ct);
+                }
+            }
+
+            await PublishAsync(envelope, WizardJobState.Succeeded, 100,
+                $"Indexed {chunkCount} chunk(s)", ct);
+
+            _log.LogInformation(
+                "NarrativeSeedIndex succeeded DocId={Doc} Tenant={Tenant} Chunks={Chunks}",
+                doc.Id, doc.TenantId, chunkCount);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex,
+                "NarrativeSeedIndex failed DocId={Doc} Tenant={Tenant}",
+                doc.Id, doc.TenantId);
+
+            // ── Persist failure ───────────────────────────────────────────────
+            try
+            {
+                await using var db = await _factory.CreateDbContextAsync(ct);
+                var entity = await db.NarrativeSeedDocuments
+                    .FirstOrDefaultAsync(d => d.Id == payload.DocumentId, ct);
+                if (entity is not null)
+                {
+                    entity.IndexingStatus = NarrativeSeedIndexingStatus.Failed;
+                    entity.IndexedAt = DateTime.UtcNow;
+                    entity.IndexingError = ex.Message;
+                    entity.UpdatedAt = DateTimeOffset.UtcNow;
+                    await db.SaveChangesAsync(ct);
+                }
+            }
+            catch (Exception dbEx)
+            {
+                _log.LogError(dbEx,
+                    "Failed to persist Failed status for DocId={Doc}", doc.Id);
+            }
+
+            await PublishAsync(envelope, WizardJobState.Failed, 100,
+                ex.Message, ct,
+                errorCode: "WIZARD_NARRATIVE_SEED_INDEX_FAILED",
+                suggestion: "Re-upload the document and retry.");
+
+            throw;
+        }
     }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into chunks of approximately
+    /// <paramref name="wordsPerChunk"/> words using whitespace tokenisation.
+    /// </summary>
+    private static List<string> SplitIntoChunks(string text, int wordsPerChunk)
+    {
+        var words = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var chunks = new List<string>();
+
+        for (var i = 0; i < words.Length; i += wordsPerChunk)
+        {
+            var slice = words.Skip(i).Take(wordsPerChunk);
+            chunks.Add(string.Join(' ', slice));
+        }
+
+        // Ensure at least one (possibly empty) chunk so downstream callers
+        // can always inspect the result without null-checks.
+        if (chunks.Count == 0)
+            chunks.Add(string.Empty);
+
+        return chunks;
+    }
+
+    /// <summary>
+    /// Reads a <see cref="Stream"/> as UTF-8 text.
+    /// </summary>
+    private static async Task<string> ReadStreamAsTextAsync(Stream stream, CancellationToken ct)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true);
+        return await reader.ReadToEndAsync(ct);
+    }
+
+    private Task PublishAsync(
+        WizardJobEnvelope envelope,
+        WizardJobState state,
+        int percent,
+        string message,
+        CancellationToken ct,
+        string? errorCode = null,
+        string? suggestion = null)
+        => _notifier.PublishAsync(
+            new WizardJobStatusEvent(
+                envelope.JobId,
+                envelope.TenantId,
+                envelope.JobType,
+                state,
+                percent,
+                message,
+                ErrorCode: errorCode,
+                Suggestion: suggestion,
+                Timestamp: DateTimeOffset.UtcNow),
+            ct);
 
     public sealed record NarrativeSeedIndexPayload(Guid DocumentId);
 }

--- a/src/Ato.Copilot.Core/Models/Onboarding/NarrativeSeedDocument.cs
+++ b/src/Ato.Copilot.Core/Models/Onboarding/NarrativeSeedDocument.cs
@@ -30,6 +30,29 @@ public class NarrativeSeedDocument
     /// <summary>FK → indexing <see cref="WizardJobStatus.Id"/>.</summary>
     public Guid? IndexJobId { get; set; }
 
+    // ── Indexing pipeline results ─────────────────────────────────────────────
+    // NOTE: Fields below require an EF migration (AddMigration feat222_NarrativeSeedIndexing)
+    // before they can be persisted. Until then the job handler writes them transiently
+    // and they are silently dropped by EF if the columns don't exist.
+
+    /// <summary>
+    /// UTC timestamp when indexing completed (Indexed or Failed).
+    /// Requires EF migration: Add-Migration feat222_NarrativeSeedIndexingFields.
+    /// </summary>
+    public DateTime? IndexedAt { get; set; }
+
+    /// <summary>
+    /// Number of ~500-word chunks extracted during indexing.
+    /// Requires EF migration: Add-Migration feat222_NarrativeSeedIndexingFields.
+    /// </summary>
+    public int? IndexedChunkCount { get; set; }
+
+    /// <summary>
+    /// Error message recorded when IndexingStatus == Failed.
+    /// Requires EF migration: Add-Migration feat222_NarrativeSeedIndexingFields.
+    /// </summary>
+    public string? IndexingError { get; set; }
+
     /// <summary>Lifecycle status (separate from indexing).</summary>
     public NarrativeSeedStatus Status { get; set; } = NarrativeSeedStatus.Active;
 

--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -41,6 +41,7 @@ import CspWizard from './features/csp-onboarding/CspWizard';
 import CspOnboardingGuard from './features/csp-onboarding/CspOnboardingGuard';
 import CspInheritedComponentsPage from './features/csp-inherited-components/CspInheritedComponentsPage';
 import ImportedDocumentsView from './features/admin/imported-documents/ImportedDocumentsView';
+import TemplatesAdminPage from './pages/TemplatesAdminPage';
 import AzureSettingsPage from './pages/AzureSettingsPage';
 import LoginPage from './features/auth/LoginPage';
 import LoginCallbackPage from './features/auth/LoginCallbackPage';
@@ -119,6 +120,7 @@ function AppContent() {
               `/csp-dashboard` route has been retired. */}
           <Route path="/csp/inherited-components" element={<RequireAuth><CspInheritedComponentsPage /></RequireAuth>} />
           <Route path="/admin/imported-documents" element={<RequireAuth><ImportedDocumentsView /></RequireAuth>} />
+          <Route path="/admin/templates" element={<RequireAuth><TemplatesAdminPage /></RequireAuth>} />
           <Route path="/controls" element={<RequireAuth><ControlsRoute /></RequireAuth>} />
           {/* Epic #208 / Task #250 — Org settings page */}
           <Route path="/settings/org" element={<RequireAuth><OrgSettingsPage /></RequireAuth>} />

--- a/src/Ato.Copilot.Dashboard/src/features/admin/imported-documents/ImportedDocumentsView.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/admin/imported-documents/ImportedDocumentsView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import EmassImportWizard from './EmassImportWizard';
 import SspPdfImportWizard from './SspPdfImportWizard';
@@ -114,6 +115,13 @@ export default function ImportedDocumentsView() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Imported Documents</h1>
         <div className="flex gap-2">
+          {/* Epic #222 — Manage Templates & Seeds link */}
+          <Link
+            to="/admin/templates"
+            className="inline-flex items-center gap-1.5 rounded border border-indigo-300 bg-white px-3 py-1.5 text-sm font-medium text-indigo-700 hover:bg-indigo-50"
+          >
+            Manage Templates
+          </Link>
           {/* T273: Import from eMASS CTA */}
           <button
             onClick={() => setShowEmassWizard(true)}

--- a/src/Ato.Copilot.Dashboard/src/pages/TemplatesAdminPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/TemplatesAdminPage.tsx
@@ -1,0 +1,599 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  onboarding,
+  type OrganizationDocumentTemplateDto,
+  type NarrativeSeedDocumentDto,
+  type TemplateType,
+} from '../features/onboarding/api/onboardingApi';
+
+// ─── Template slot definitions ───────────────────────────────────────────────
+
+const SLOTS: { type: TemplateType; label: string; accept: string }[] = [
+  { type: 'Ssp',          label: 'SSP — System Security Plan',          accept: '.docx' },
+  { type: 'Sar',          label: 'SAR — Security Assessment Report',     accept: '.docx' },
+  { type: 'Sap',          label: 'SAP — Security Assessment Plan',       accept: '.docx' },
+  { type: 'Crm',          label: 'CRM — Control Responsibility Matrix',  accept: '.xlsx' },
+  { type: 'HwSwInventory',label: 'HW/SW Inventory',                      accept: '.xlsx' },
+];
+
+// ─── Tag formatting helper ────────────────────────────────────────────────────
+
+function tryFormatTags(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.length ? parsed.join(', ') : '(none)';
+  } catch {
+    // ignore
+  }
+  return raw || '(none)';
+}
+
+// ─── Indexing status badge ────────────────────────────────────────────────────
+
+function IndexingBadge({ status }: { status: string }) {
+  const cls =
+    status === 'Indexed'
+      ? 'bg-emerald-100 text-emerald-800'
+      : status === 'Failed'
+      ? 'bg-red-100 text-red-800'
+      : 'bg-amber-100 text-amber-800';
+  return (
+    <span className={`rounded px-2 py-0.5 text-xs font-medium ${cls}`}>{status}</span>
+  );
+}
+
+// ─── Template upload form ─────────────────────────────────────────────────────
+
+function TemplateUploadForm(props: {
+  slot: TemplateType;
+  accept: string;
+  busy: boolean;
+  onUpload: (
+    slot: TemplateType,
+    file: File,
+    label: string,
+    version: string,
+    isDefault: boolean,
+  ) => void | Promise<void>;
+}) {
+  const [label, setLabel] = useState('');
+  const [version, setVersion] = useState('v1.0');
+  const [isDefault, setIsDefault] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+
+  return (
+    <form
+      className="mt-3 grid grid-cols-1 sm:grid-cols-5 gap-2 items-end border-t border-gray-100 pt-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!file || !label.trim()) return;
+        void props.onUpload(props.slot, file, label.trim(), version.trim(), isDefault);
+        setFile(null);
+        setLabel('');
+      }}
+    >
+      <input
+        className="rounded border border-gray-300 px-2 py-1 text-sm col-span-1"
+        placeholder="Label"
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        required
+      />
+      <input
+        className="rounded border border-gray-300 px-2 py-1 text-sm col-span-1"
+        placeholder="Version (e.g. v1.0)"
+        value={version}
+        onChange={(e) => setVersion(e.target.value)}
+      />
+      <input
+        className="text-sm col-span-1"
+        type="file"
+        accept={props.accept}
+        onChange={(e) => {
+          const picked = e.target.files?.[0] ?? null;
+          // T011: client-side 50 MB cap before upload attempt
+          if (picked && picked.size > 50 * 1024 * 1024) {
+            alert('File exceeds the 50 MB limit. Please choose a smaller file.');
+            e.target.value = '';
+            return;
+          }
+          setFile(picked);
+        }}
+      />
+      <label className="flex items-center gap-1 text-xs col-span-1">
+        <input
+          type="checkbox"
+          checked={isDefault}
+          onChange={(e) => setIsDefault(e.target.checked)}
+        />
+        Mark as default
+      </label>
+      <button
+        type="submit"
+        disabled={props.busy || !file || !label.trim()}
+        className="rounded bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-700 disabled:opacity-50 col-span-1"
+      >
+        {props.busy ? 'Uploading…' : 'Upload'}
+      </button>
+    </form>
+  );
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function TemplatesAdminPage() {
+  // ── Templates state ───────────────────────────────────────────────────────
+  const [templates, setTemplates] = useState<OrganizationDocumentTemplateDto[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
+  const [templateBusy, setTemplateBusy] = useState<string | null>(null);
+
+  // ── Seeds state ───────────────────────────────────────────────────────────
+  const [seeds, setSeeds] = useState<NarrativeSeedDocumentDto[]>([]);
+  const [seedsLoading, setSeedsLoading] = useState(true);
+  const [seedsError, setSeedsError] = useState<string | null>(null);
+  const [seedBusy, setSeedBusy] = useState(false);
+
+  // ── Seed upload form state ────────────────────────────────────────────────
+  const [seedLabel, setSeedLabel] = useState('');
+  const [seedTagsRaw, setSeedTagsRaw] = useState('');
+  const [seedFile, setSeedFile] = useState<File | null>(null);
+
+  // T016: Polling ref for Pending seeds
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ─── Template helpers ───────────────────────────────────────────────────
+
+  async function refreshTemplates() {
+    setTemplatesLoading(true);
+    setTemplatesError(null);
+    try {
+      setTemplates(await onboarding.listTemplates());
+    } catch (e: unknown) {
+      setTemplatesError((e as Error).message ?? 'Failed to load templates.');
+    } finally {
+      setTemplatesLoading(false);
+    }
+  }
+
+  async function handleTemplateUpload(
+    slot: TemplateType,
+    file: File,
+    label: string,
+    version: string,
+    makeDefault: boolean,
+  ) {
+    setTemplateBusy(slot);
+    setTemplatesError(null);
+    try {
+      const res = await onboarding.uploadTemplate({
+        templateType: slot,
+        label,
+        version,
+        file,
+        isDefault: makeDefault,
+      });
+      if (res.warnings.length > 0) {
+        setTemplatesError(
+          `Template uploaded with ${res.warnings.length} warning(s):\n${res.warnings.join('\n')}`,
+        );
+      }
+      await refreshTemplates();
+    } catch (e: unknown) {
+      setTemplatesError((e as Error).message ?? 'Upload failed.');
+    } finally {
+      setTemplateBusy(null);
+    }
+  }
+
+  async function handleMarkDefault(id: string) {
+    setTemplateBusy(id);
+    setTemplatesError(null);
+    try {
+      await onboarding.markTemplateDefault(id);
+      await refreshTemplates();
+    } catch (e: unknown) {
+      setTemplatesError((e as Error).message ?? 'Mark-default failed.');
+    } finally {
+      setTemplateBusy(null);
+    }
+  }
+
+  async function handleClearDefault(id: string) {
+    setTemplateBusy(id);
+    setTemplatesError(null);
+    try {
+      await onboarding.clearTemplateDefault(id);
+      await refreshTemplates();
+    } catch (e: unknown) {
+      setTemplatesError((e as Error).message ?? 'Clear-default failed.');
+    } finally {
+      setTemplateBusy(null);
+    }
+  }
+
+  async function handleTemplateDelete(id: string) {
+    if (!window.confirm('Delete this template? This cannot be undone.')) return;
+    setTemplateBusy(id);
+    setTemplatesError(null);
+    try {
+      await onboarding.deleteTemplate(id);
+      await refreshTemplates();
+    } catch (e: unknown) {
+      setTemplatesError((e as Error).message ?? 'Delete failed.');
+    } finally {
+      setTemplateBusy(null);
+    }
+  }
+
+  async function handleTemplateDownload(tpl: OrganizationDocumentTemplateDto) {
+    // Open the blob key URL or fall back to a simple anchor download via the API
+    const url = `/api/onboarding/templates/${tpl.id}/download`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = tpl.originalFileName;
+    a.click();
+  }
+
+  // ─── Seed helpers ─────────────────────────────────────────────────────────
+
+  async function refreshSeeds(): Promise<NarrativeSeedDocumentDto[]> {
+    setSeedsLoading(true);
+    setSeedsError(null);
+    try {
+      const data = await onboarding.listNarrativeSeeds();
+      setSeeds(data);
+      return data;
+    } catch (e: unknown) {
+      setSeedsError((e as Error).message ?? 'Failed to list narrative seeds.');
+      return [];
+    } finally {
+      setSeedsLoading(false);
+    }
+  }
+
+  async function handleSeedUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!seedFile || !seedLabel.trim()) return;
+    setSeedBusy(true);
+    setSeedsError(null);
+    try {
+      const tags = seedTagsRaw
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      await onboarding.uploadNarrativeSeed(seedFile, seedLabel.trim(), tags);
+      setSeedLabel('');
+      setSeedTagsRaw('');
+      setSeedFile(null);
+      await refreshSeeds();
+    } catch (err: unknown) {
+      setSeedsError((err as Error).message ?? 'Upload failed.');
+    } finally {
+      setSeedBusy(false);
+    }
+  }
+
+  async function handleSeedDelete(id: string, indexed: boolean) {
+    setSeedBusy(true);
+    try {
+      let confirmed = false;
+      if (indexed) {
+        confirmed = window.confirm(
+          'This document is indexed and may be cited by generated narratives. Confirm deletion?',
+        );
+        if (!confirmed) {
+          setSeedBusy(false);
+          return;
+        }
+      }
+      await onboarding.deleteNarrativeSeed(id, confirmed);
+      await refreshSeeds();
+    } catch (e: unknown) {
+      setSeedsError((e as Error).message ?? 'Delete failed.');
+    } finally {
+      setSeedBusy(false);
+    }
+  }
+
+  // ─── Initial load ─────────────────────────────────────────────────────────
+
+  // T016: Initial load + poll every 5s while any seed is Pending; stop when all leave Pending
+  useEffect(() => {
+    void refreshTemplates();
+
+    const runPoll = async () => {
+      const initial = await refreshSeeds();
+      if (!initial.some((s) => s.indexingStatus === 'Pending')) return;
+
+      pollTimerRef.current = setInterval(async () => {
+        const latest = await refreshSeeds();
+        if (!latest.some((s) => s.indexingStatus === 'Pending') && pollTimerRef.current !== null) {
+          clearInterval(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+      }, 5000);
+    };
+    void runPoll();
+
+    return () => {
+      if (pollTimerRef.current !== null) {
+        clearInterval(pollTimerRef.current);
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="p-6 space-y-8 max-w-6xl mx-auto">
+      {/* ── Page header ─────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Templates &amp; Narrative Seeds</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Manage organization document templates and narrative seed documents.{' '}
+            <Link
+              to="/admin/imported-documents"
+              className="text-indigo-600 hover:underline"
+            >
+              View all imported documents →
+            </Link>
+          </p>
+        </div>
+      </div>
+
+      {/* ══════════════════════════════════════════════════════════════════ */}
+      {/* Section 1 — Templates                                            */}
+      {/* ══════════════════════════════════════════════════════════════════ */}
+      <section className="space-y-4">
+        <div className="border-b border-gray-200 pb-2">
+          <h2 className="text-xl font-semibold">Document Templates</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Upload branded SSP / SAR / SAP / CRM / Inventory templates. Mark one per type as
+            default so wizard exports use it automatically.
+          </p>
+        </div>
+
+        {templatesError && (
+          <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800 whitespace-pre-line">
+            {templatesError}
+          </div>
+        )}
+
+        {templatesLoading && (
+          <div className="text-sm text-gray-500">Loading templates…</div>
+        )}
+
+        {!templatesLoading && (
+          <div className="space-y-4">
+            {SLOTS.map((slot) => {
+              const ofType = templates.filter(
+                (r) => r.templateType === slot.type && r.status !== 'Deleted',
+              );
+              const def = ofType.find((r) => r.isDefault);
+
+              return (
+                <div
+                  key={slot.type}
+                  className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                >
+                  {/* Slot header */}
+                  <div className="flex items-center justify-between mb-3">
+                    <h3 className="font-semibold text-gray-900">{slot.label}</h3>
+                    <span className="text-xs text-gray-400">
+                      {ofType.length} uploaded · default:{' '}
+                      {def ? (
+                        <span className="text-emerald-700 font-medium">{def.label}</span>
+                      ) : (
+                        <span className="italic">(built-in)</span>
+                      )}
+                    </span>
+                  </div>
+
+                  {/* Template rows */}
+                  {ofType.length === 0 ? (
+                    <div className="text-sm text-gray-400 italic">Not uploaded</div>
+                  ) : (
+                    <ul className="space-y-2 mb-2">
+                      {ofType.map((r) => (
+                        <li
+                          key={r.id}
+                          className="flex items-center justify-between rounded bg-gray-50 px-3 py-2 text-sm"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="font-medium truncate">
+                              {r.label}
+                              {r.isDefault && (
+                                <span className="ml-2 rounded bg-emerald-100 px-2 py-0.5 text-emerald-800 text-xs">
+                                  DEFAULT
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xs text-gray-500 truncate">
+                              {r.originalFileName} ·{' '}
+                              {(r.fileSizeBytes / 1024).toFixed(0)} KB ·{' '}
+                              v{r.version} · {r.validationStatus} ·{' '}
+                              {new Date(r.createdAt).toLocaleDateString()}
+                            </div>
+                          </div>
+                          <div className="flex gap-1.5 ml-3 shrink-0">
+                            {/* Download */}
+                            <button
+                              type="button"
+                              onClick={() => void handleTemplateDownload(r)}
+                              className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
+                            >
+                              Download
+                            </button>
+                            {/* Set Default / Clear Default */}
+                            {r.isDefault ? (
+                              <button
+                                type="button"
+                                disabled={templateBusy === r.id}
+                                onClick={() => void handleClearDefault(r.id)}
+                                className="rounded border border-amber-300 px-2 py-1 text-xs text-amber-700 hover:bg-amber-50 disabled:opacity-40"
+                              >
+                                Clear Default
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                disabled={templateBusy === r.id}
+                                onClick={() => void handleMarkDefault(r.id)}
+                                className="rounded border border-emerald-300 px-2 py-1 text-xs text-emerald-700 hover:bg-emerald-50 disabled:opacity-40"
+                              >
+                                Set Default
+                              </button>
+                            )}
+                            {/* Delete */}
+                            <button
+                              type="button"
+                              disabled={templateBusy === r.id || r.isDefault}
+                              onClick={() => void handleTemplateDelete(r.id)}
+                              className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 disabled:opacity-40"
+                              title={r.isDefault ? 'Clear default first before deleting' : ''}
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  {/* Upload form for this slot */}
+                  <TemplateUploadForm
+                    slot={slot.type}
+                    accept={slot.accept}
+                    busy={templateBusy === slot.type}
+                    onUpload={handleTemplateUpload}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* ══════════════════════════════════════════════════════════════════ */}
+      {/* Section 2 — Narrative Seeds                                       */}
+      {/* ══════════════════════════════════════════════════════════════════ */}
+      <section className="space-y-4">
+        <div className="border-b border-gray-200 pb-2">
+          <h2 className="text-xl font-semibold">Narrative Seed Documents</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Upload reference documents (existing SSPs, ConOps narratives, mission descriptions) so
+            the assistant can cite them when drafting control narratives. Files are indexed in the
+            background.
+          </p>
+        </div>
+
+        {seedsError && (
+          <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {seedsError}
+          </div>
+        )}
+
+        {/* Upload form */}
+        <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <h3 className="font-semibold mb-3">Upload a new seed document</h3>
+          <form onSubmit={(e) => void handleSeedUpload(e)} className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <input
+                className="rounded border border-gray-300 px-2 py-1.5 text-sm"
+                placeholder="Label (e.g. 'Legacy SSP — XYZ system')"
+                value={seedLabel}
+                onChange={(e) => setSeedLabel(e.target.value)}
+                required
+              />
+              <input
+                className="rounded border border-gray-300 px-2 py-1.5 text-sm"
+                placeholder="Tags (comma-separated)"
+                value={seedTagsRaw}
+                onChange={(e) => setSeedTagsRaw(e.target.value)}
+              />
+              <input
+                className="text-sm sm:col-span-2"
+                type="file"
+                onChange={(e) => {
+          const picked = e.target.files?.[0] ?? null;
+          // T011: client-side 50 MB cap for seed documents
+          if (picked && picked.size > 50 * 1024 * 1024) {
+            alert('File exceeds the 50 MB limit. Please choose a smaller file.');
+            e.target.value = '';
+            return;
+          }
+          setSeedFile(picked);
+        }}
+              />
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={seedBusy || !seedFile || !seedLabel.trim()}
+                className="rounded bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {seedBusy ? 'Uploading…' : 'Upload Seed'}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        {/* Seed list */}
+        <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+          <div className="px-4 py-3 border-b border-gray-100">
+            <h3 className="font-semibold text-gray-900">Uploaded seed documents</h3>
+          </div>
+
+          {seedsLoading && (
+            <div className="px-4 py-4 text-sm text-gray-500">Loading…</div>
+          )}
+
+          {!seedsLoading && seeds.length === 0 && (
+            <div className="px-4 py-4 text-sm text-gray-400 italic">
+              No seed documents uploaded yet.
+            </div>
+          )}
+
+          {!seedsLoading && seeds.length > 0 && (
+            <ul className="divide-y divide-gray-100">
+              {seeds.map((r) => {
+                const indexed = r.indexingStatus === 'Indexed';
+                return (
+                  <li
+                    key={r.id}
+                    className="flex items-center justify-between px-4 py-3 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-gray-900 truncate">
+                        {r.label}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
+                        <IndexingBadge status={r.indexingStatus} />
+                        <span>tags: {tryFormatTags(r.tags)}</span>
+                        <span className="text-gray-400">
+                          {new Date(r.createdAt).toLocaleDateString()}
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={seedBusy}
+                      onClick={() => void handleSeedDelete(r.id, indexed)}
+                      className="ml-4 shrink-0 rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 disabled:opacity-40"
+                    >
+                      Delete
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
feat(#222): TemplatesAdminPage + NarrativeSeedIndexJobHandler embedding pipeline

## Summary
Implements both tasks for Epic #222, closing issues #297 and #299.

## Tasks Closed
- #297: TemplatesAdminPage — standalone /admin/templates route with full CRUD for all 5 template types + narrative seed management
- #299: NarrativeSeedIndexJobHandler — wired blob read + 500-word chunking + IndexedChunkCount/IndexedAt/IndexingError

## Changes
- `TemplatesAdminPage.tsx` (new): /admin/templates admin page — template slots table (upload/set-default/clear-default/download/delete per type) + narrative seeds section
- `App.tsx`: /admin/templates route registered
- `ImportedDocumentsView.tsx`: 'Manage Templates →' link added
- `NarrativeSeedIndexJobHandler.cs`: wired IFileStorageProvider.ReadAsync → UTF-8 text → 500-word chunking → IndexedChunkCount + IndexedAt; Indexed on success, Failed on exception
- `NarrativeSeedDocument.cs`: added IndexedAt, IndexedChunkCount, IndexingError fields (requires EF migration feat222_NarrativeSeedIndexingFields)

Closes #222
