### PR TITLE
feat(#221,#223,#225): CSP admin UX — tenant status actions, impersonation exit confirm, onboarding banner, NeedsReview badge, /capability-library route

### DIFF
--- a/specs/050-csp-capability-lifecycle/tasks.md
+++ b/specs/050-csp-capability-lifecycle/tasks.md
@@ -204,6 +204,32 @@ All paths below match the verified structure on the `050-csp-capability-lifecycl
 
 ---
 
+## Phase 9: Trust-Chain Gap Closure (Epic #223)
+
+**Purpose**: Eight targeted fixes closing trust-chain gaps identified in Epic #223. T055 (DB migration) blocks T060. All other tasks are independent unless noted.
+
+**Epic:** #223
+
+---
+
+- [ ] **T055** `src/Ato.Copilot.Core/Models/Tenancy/CspInheritedCapability.cs` + EF migration — Add `SourceOrgCapabilityId Guid?` nullable FK. Add index on `(TenantId, SourceOrgCapabilityId)`. Generate: `dotnet ef migrations add Feature050_CapabilityProvenanceFK --project src/Ato.Copilot.Core --startup-project src/Ato.Copilot.Mcp`. **Blocks T060.**
+
+- [ ] **T056** `src/Ato.Copilot.Core/Interfaces/Tenancy/ICspInheritedComponentService.cs` — Add `UnarchiveCapabilityAsync(Guid componentId, Guid capabilityId, string actorOid, CancellationToken ct)` mirroring `ArchiveCapabilityAsync`.
+
+- [ ] **T057** `src/Ato.Copilot.Core/Services/Tenancy/CspInheritedComponentService.cs` — Implement `UnarchiveCapabilityAsync`: load (404 if not found or Status != Archived), set `Status = NeedsReview`, append `CapabilityHistoryEvent` with `EventType = Unarchived`, save. Depends on T056.
+
+- [ ] **T058** `src/Ato.Copilot.Mcp/Endpoints/Csp/CspInheritedComponentEndpoints.cs` — Add `POST .../capabilities/{capId}/unarchive` (CSP-Admin only, same policy as archive DELETE). Returns 200 + updated DTO; 404 if not found; 409 if not Archived. Depends on T056 + T057.
+
+- [ ] **T059** `src/Ato.Copilot.Dashboard/src/pages/ControlInheritance.tsx` + `src/Ato.Copilot.Dashboard/src/api/orgControlOverrides.ts` (create if absent) — Wire `GET /api/orgs/control-overrides` into ControlInheritance: fetch on mount, render "Org override" badge per row, add "Edit override" action via `PUT /api/orgs/control-overrides/{controlId}`. Backend endpoint exists at `OrgControlOverrideEndpoints.cs`; frontend wiring is the only missing piece.
+
+- [ ] **T060** `src/Ato.Copilot.Core/Services/NarrativeTemplateService.cs` + `IControlNarrativeService.cs` — Add optional `IReadOnlyList<string>? referenceChunks` to `GenerateNarrativeWithAiAsync`. When non-empty, append "Reference Documents" section to user prompt. Callers pass `null`; backward-compatible. **Gated on T055.**
+
+- [ ] **T061** `ComponentDetailDrawer.tsx` + remap endpoint + service — Close T045 deviation: extend `POST .../capabilities/{capId}/remap` body with optional `reviewerNote: string?`, persist to `CspInheritedCapability.ReviewerNote`, forward value from `RemapConfirmDialog` to API call. Mark T045 `[X]` when done. Note is already captured in drawer state; only API call + backend signature need updating.
+
+- [ ] **T062** `src/Ato.Copilot.Dashboard/src/features/csp-inherited-components/ComponentDetailDrawer.tsx` — Add "Unarchive" button (CSP-Admin only, shown when `capability.status === 'Archived'`). Wire to T058 endpoint. On success refresh capability list and show confirmation. Depends on T058.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/src/Ato.Copilot.Dashboard/src/__tests__/auth/ImpersonationBanner.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/auth/ImpersonationBanner.test.tsx
@@ -191,20 +191,45 @@ describe('ImpersonationBanner (Feature 051 T133–T135)', () => {
     expect(banner.getAttribute('aria-live')).toBe('polite');
   });
 
-  it('Exit button calls the Feature 048 end endpoint and refetches /me', async () => {
-    // Arrange
+  it('Exit button opens confirmation dialog (Wave 6 GAP-221-B)', () => {
+    currentMe = makeMe();
+    renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    expect(screen.getByTestId('impersonation-exit-confirm')).toBeInTheDocument();
+    expect(endImpersonation).not.toHaveBeenCalled();
+  });
+
+  it('Exit confirm dialog: Stay closes without calling end endpoint', () => {
     endImpersonation.mockResolvedValue(undefined);
     currentMe = makeMe();
     renderBanner();
-
-    // Act
     fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    expect(screen.getByTestId('impersonation-exit-confirm')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /stay/i }));
+    expect(screen.queryByTestId('impersonation-exit-confirm')).not.toBeInTheDocument();
+    expect(endImpersonation).not.toHaveBeenCalled();
+  });
 
-    // Assert
+  it('Exit confirm dialog: confirm calls end endpoint and refetches /me', async () => {
+    endImpersonation.mockResolvedValue(undefined);
+    currentMe = makeMe();
+    renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    expect(screen.getByTestId('impersonation-exit-confirm')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('impersonation-exit-confirm-btn'));
     await waitFor(() => {
       expect(endImpersonation).toHaveBeenCalledTimes(1);
       expect(refetch).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('confirmation dialog contains the impersonated tenant name', () => {
+    currentMe = makeMe();
+    renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    const dialog = screen.getByTestId('impersonation-exit-confirm');
+    // makeMe() uses 'Coastal Watch' as the displayName
+    expect(dialog.textContent).toContain('Coastal Watch');
   });
 
   it('Exit navigates to getPreImpersonationUrl() value when one is stored (FR-029)', async () => {
@@ -214,8 +239,9 @@ describe('ImpersonationBanner (Feature 051 T133–T135)', () => {
     currentMe = makeMe();
     renderBanner();
 
-    // Act
+    // Act: open confirm dialog, then confirm (Wave 6 GAP-221-B two-step)
     fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    fireEvent.click(screen.getByTestId('impersonation-exit-confirm-btn'));
 
     // Assert — FR-029: return to the pre-impersonation URL.
     await waitFor(() => {
@@ -235,8 +261,9 @@ describe('ImpersonationBanner (Feature 051 T133–T135)', () => {
     currentMe = makeMe(); // persona = CspAdmin
     renderBanner();
 
-    // Act
+    // Act: open confirm dialog, then confirm (Wave 6 GAP-221-B two-step)
     fireEvent.click(screen.getByRole('button', { name: /exit/i }));
+    fireEvent.click(screen.getByTestId('impersonation-exit-confirm-btn'));
 
     // Assert — falls back to `/` (the CSP-Admin's persona-default landing).
     await waitFor(() => {

--- a/src/Ato.Copilot.Dashboard/src/__tests__/components/csp-dashboard/OrgsTable.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/components/csp-dashboard/OrgsTable.test.tsx
@@ -58,6 +58,7 @@ function makeTenant(overrides: Partial<TenantSummary> = {}): TenantSummary {
     displayName: 'Acme Corp',
     status: 'Active',
     onboardingState: 'Active',
+    organizationCount: 2,
     systemCount: 3,
     atoStatusCounts: { authorized: 1, inProcess: 1, denied: 0 },
     openFindingCount: 5,

--- a/src/Ato.Copilot.Dashboard/src/__tests__/components/csp-dashboard/OrgsTable.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/components/csp-dashboard/OrgsTable.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { TenantSummary, TenantsPage } from '../../../features/csp-dashboard/api';
+
+// ─── Hoisted mocks ──────────────────────────────────────────────────────
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const {
+  getCspDashboardTenants,
+  updateTenantStatus,
+  createCspDashboardTenant,
+} = vi.hoisted(() => ({
+  getCspDashboardTenants: vi.fn(),
+  updateTenantStatus: vi.fn(),
+  createCspDashboardTenant: vi.fn(),
+}));
+
+vi.mock('../../../features/csp-dashboard/api', async () => {
+  const actual = await vi.importActual<typeof import('../../../features/csp-dashboard/api')>(
+    '../../../features/csp-dashboard/api',
+  );
+  return {
+    ...actual,
+    getCspDashboardTenants,
+    updateTenantStatus,
+    createCspDashboardTenant,
+    isUnavailable: (r: unknown) => r === null,
+  };
+});
+
+const { startImpersonation } = vi.hoisted(() => ({ startImpersonation: vi.fn() }));
+vi.mock('../../../features/tenancy/api', async () => {
+  const actual = await vi.importActual<typeof import('../../../features/tenancy/api')>(
+    '../../../features/tenancy/api',
+  );
+  return { ...actual, startImpersonation };
+});
+
+vi.mock('../../../features/tenancy/vestigeTenants', () => ({
+  isVestigeTenant: () => false,
+}));
+
+import OrgsTable from '../../../features/csp-dashboard/OrgsTable';
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+const TEST_TENANT_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+function makeTenant(overrides: Partial<TenantSummary> = {}): TenantSummary {
+  return {
+    tenantId: TEST_TENANT_ID,
+    displayName: 'Acme Corp',
+    status: 'Active',
+    onboardingState: 'Active',
+    systemCount: 3,
+    atoStatusCounts: { authorized: 1, inProcess: 1, denied: 0 },
+    openFindingCount: 5,
+    openPoamCount: 2,
+    openDeviationCount: 1,
+    lastActivityTimestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makePage(items: TenantSummary[]): TenantsPage {
+  return { items, totalCount: items.length, page: 1, pageSize: 25 };
+}
+
+function renderOrgsTable() {
+  return render(<MemoryRouter><OrgsTable /></MemoryRouter>);
+}
+
+beforeEach(() => {
+  navigate.mockReset();
+  startImpersonation.mockReset();
+  updateTenantStatus.mockReset();
+  createCspDashboardTenant.mockReset();
+  getCspDashboardTenants.mockReset();
+  getCspDashboardTenants.mockResolvedValue(makePage([makeTenant()]));
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe('OrgsTable — confirmation dialogs (Wave 6 GAP-221-A)', () => {
+  // ── Button visibility by status ────────────────────────────────────────
+
+  it('renders Suspend button for Active org', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+  });
+
+  it('renders Disable button for Active org', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-disable-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+  });
+
+  it('renders Reinstate but NOT Suspend for Suspended org', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Suspended' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-reinstate-${TEST_TENANT_ID}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`org-suspend-${TEST_TENANT_ID}`)).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders Reinstate for Disabled org', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Disabled' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-reinstate-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+  });
+
+  // ── Dialog appearance ─────────────────────────────────────────────────
+
+  it('clicking Suspend opens a dialog with Suspend heading', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog').textContent).toMatch(/suspend/i);
+    expect(updateTenantStatus).not.toHaveBeenCalled();
+  });
+
+  it('clicking Disable opens a dialog with Disable heading', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-disable-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-disable-${TEST_TENANT_ID}`));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog').textContent).toMatch(/disable/i);
+    expect(updateTenantStatus).not.toHaveBeenCalled();
+  });
+
+  it('clicking Reinstate opens a dialog with Reinstate heading', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Suspended' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-reinstate-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-reinstate-${TEST_TENANT_ID}`));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog').textContent).toMatch(/reinstate/i);
+    expect(updateTenantStatus).not.toHaveBeenCalled();
+  });
+
+  // ── Cancel behavior ───────────────────────────────────────────────────
+
+  it('Cancel closes the dialog without calling updateTenantStatus', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(updateTenantStatus).not.toHaveBeenCalled();
+  });
+
+  // ── Confirm behavior ──────────────────────────────────────────────────
+
+  it('status-action-confirm calls updateTenantStatus with correct arguments', async () => {
+    getCspDashboardTenants.mockResolvedValue(makePage([makeTenant({ status: 'Active' })]));
+    updateTenantStatus.mockResolvedValue(undefined);
+    getCspDashboardTenants
+      .mockResolvedValueOnce(makePage([makeTenant({ status: 'Active' })]))
+      .mockResolvedValue(makePage([makeTenant({ status: 'Suspended' })]));
+
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`));
+    fireEvent.click(screen.getByTestId('status-action-confirm'));
+
+    await waitFor(() => {
+      expect(updateTenantStatus).toHaveBeenCalledWith(TEST_TENANT_ID, 'Suspended', undefined);
+    });
+  });
+
+  // ── Dialog copy ───────────────────────────────────────────────────────
+
+  it('confirmation dialog shows the org display name', async () => {
+    getCspDashboardTenants.mockResolvedValue(
+      makePage([makeTenant({ status: 'Active', displayName: 'Pentagon Logistics' })]),
+    );
+    renderOrgsTable();
+    await waitFor(() => {
+      expect(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId(`org-suspend-${TEST_TENANT_ID}`));
+    expect(screen.getByRole('dialog').textContent).toContain('Pentagon Logistics');
+  });
+});


### PR DESCRIPTION
## Summary

Wave 6 — Epics **#221**, **#223**, **#225**.
Closes tasks **#318, #319, #320, #321, #323, #324**.

---

## Epic #221 — CSP Dashboard: Cross-Tenant Portfolio, Impersonation

### #318 — Tenant status confirmation dialogs (Suspend / Disable / Reinstate)
- `OrgsTable.tsx`: Suspend / Disable / Reinstate action buttons added per row (context-sensitive: shows Suspend+Disable for Active, Reinstate for Suspended/Disabled)
- Confirmation dialog shows tenant display name + action consequence before executing
- Calls new `updateTenantStatus(tenantId, status)` in `csp-dashboard/api.ts` → `PATCH /api/tenants/{tenantId}/status`
- Spinner + inline error on failure; table refreshes on success

### #319 — Impersonation exit confirmation dialog
- `ImpersonationBanner.tsx`: Exit button now opens a **Stay / Exit** confirmation modal before calling `handleExit()`
- Prevents accidental exits during active impersonation sessions
- Modal dismissed on backdrop click (Stay behavior)

### #320 — CSP onboarding-incomplete degraded state banner
- `CspDashboardPage.tsx`: `CSP_ONBOARDING_INCOMPLETE` unavailable reason now renders a specific amber banner with a **Complete CSP Onboarding →** CTA pointing to `/onboarding/csp`
- Previously fell through to the generic `UnavailableSurface` which gave no actionable guidance

---

## Epic #223 — CSP Capabilities & Inherited Controls

### #323 — CspCapabilitiesPage NeedsReview count badge + alert
- `CspCapabilitiesPage.tsx`: amber alert banner shown when any capabilities have `status === 'NeedsReview'`
- Alert shows count + **Filter to NeedsReview →** button that sets the status filter
- Closes the UX gap where admins had no visible signal that review was required

---

## Epic #225 — Capability Library (org-facing CSP catalog)

### #324 — /capability-library route + top nav
- `App.tsx`: `/capability-library` route wired to existing `CapabilityLibrary.tsx` (531 lines, already fully built — org-facing CSP capability catalog with browse, filter, subscribe)
- `PageLayout.tsx`: **Capability Library** added to top navigation

---

## Files Changed

| File | Change |
|---|---|
| `features/csp-dashboard/api.ts` | +`updateTenantStatus()` function (PATCH /tenants/{id}/status) |
| `features/csp-dashboard/OrgsTable.tsx` | Suspend/Disable/Reinstate buttons + confirmation modal |
| `features/csp-dashboard/CspDashboardPage.tsx` | CSP_ONBOARDING_INCOMPLETE special-case banner |
| `features/auth/ImpersonationBanner.tsx` | Exit confirmation modal |
| `features/csp-inherited-components/CspCapabilitiesPage.tsx` | NeedsReview amber alert |
| `App.tsx` | /capability-library route |
| `components/layout/PageLayout.tsx` | Capability Library nav item |

Parent epics: #221, #223, #225 | Owner: Mr. Terrific