### PR TITLE
feat(#226): UF-CSP-01/02/03 — Org Capability Library browse/subscribe/unsubscribe (spec-070)

### DIFF
--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -519,6 +519,12 @@ public class AtoCopilotContext : DbContext
     /// </summary>
     public DbSet<OrgControlOverride> OrgControlOverrides => Set<OrgControlOverride>();
 
+    /// <summary>
+    /// Org-user subscriptions to Published CSP capabilities
+    /// (UF-CSP-01/02/03 — spec-070).
+    /// </summary>
+    public DbSet<CapabilitySubscription> CapabilitySubscriptions => Set<CapabilitySubscription>();
+
     //
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -3620,6 +3626,22 @@ public class AtoCopilotContext : DbContext
             entity.HasIndex(e => new { e.TenantId, e.ControlId })
                 .IsUnique()
                 .HasDatabaseName("IX_OrgControlOverride_TenantId_ControlId");
+        });
+
+        // ─── CapabilitySubscription (UF-CSP-01/02/03 — spec-070) ────────────
+        // Org-user subscriptions to Mapped CSP capabilities.
+        // Soft-delete pattern: IsActive=false instead of row deletion.
+        // Index on (RegisteredSystemId, CspInheritedCapabilityId) for the
+        // duplicate-check and per-system list queries.
+        modelBuilder.Entity<CapabilitySubscription>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(36).IsRequired();
+            entity.Property(e => e.RegisteredSystemId).HasMaxLength(36).IsRequired();
+            entity.Property(e => e.CspInheritedCapabilityId).HasMaxLength(36).IsRequired();
+            entity.Property(e => e.SubscribedBy).HasMaxLength(254);
+            entity.HasIndex(e => new { e.RegisteredSystemId, e.CspInheritedCapabilityId })
+                .HasDatabaseName("IX_CapabilitySubscription_System_Capability");
         });
     }
 

--- a/src/Ato.Copilot.Core/Data/Migrations/20260608000000_AddCapabilitySubscription.cs
+++ b/src/Ato.Copilot.Core/Data/Migrations/20260608000000_AddCapabilitySubscription.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ato.Copilot.Core.Data.Migrations;
+
+/// <summary>
+/// Adds the CapabilitySubscriptions table for UF-CSP-01/02/03 (spec-070).
+/// Org-users subscribe their registered systems to Published CSP capabilities
+/// so inherited control coverage is tracked automatically.
+/// </summary>
+public partial class AddCapabilitySubscription : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "CapabilitySubscriptions",
+            columns: table => new
+            {
+                Id = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                RegisteredSystemId = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                CspInheritedCapabilityId = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                SubscribedBy = table.Column<string>(type: "nvarchar(254)", maxLength: 254, nullable: false, defaultValue: "dashboard-user"),
+                SubscribedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_CapabilitySubscriptions", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CapabilitySubscription_System_Capability",
+            table: "CapabilitySubscriptions",
+            columns: new[] { "RegisteredSystemId", "CspInheritedCapabilityId" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "CapabilitySubscriptions");
+    }
+}

--- a/src/Ato.Copilot.Core/Models/Compliance/CapabilitySubscription.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/CapabilitySubscription.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+/// <summary>
+/// Records that an org-user system has subscribed to a
+/// CspInheritedCapability published by the CSP (UF-CSP-01 / spec-070).
+/// Soft-deleted via <see cref="IsActive"/> = false rather than row removal
+/// so the audit trail is preserved.
+/// </summary>
+public class CapabilitySubscription
+{
+    /// <summary>Surrogate PK (GUID string for consistency with rest of schema).</summary>
+    [Key]
+    [MaxLength(36)]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>FK to the tenant's RegisteredSystem (string id).</summary>
+    [Required, MaxLength(36)]
+    public string RegisteredSystemId { get; set; } = string.Empty;
+
+    /// <summary>FK to the published CspInheritedCapability (Guid stored as string).</summary>
+    [Required, MaxLength(36)]
+    public string CspInheritedCapabilityId { get; set; } = string.Empty;
+
+    /// <summary>UPN or OID of the user that created the subscription.</summary>
+    [MaxLength(254)]
+    public string SubscribedBy { get; set; } = "dashboard-user";
+
+    /// <summary>UTC timestamp when the subscription was created.</summary>
+    public DateTime SubscribedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// False when the user has unsubscribed (UF-CSP-03 / #228).
+    /// Soft-delete preserves the audit trail.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+}

--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -40,6 +40,8 @@ import TenantOnboardingGuard from './features/onboarding/TenantWizard/TenantOnbo
 import CspWizard from './features/csp-onboarding/CspWizard';
 import CspOnboardingGuard from './features/csp-onboarding/CspOnboardingGuard';
 import CspInheritedComponentsPage from './features/csp-inherited-components/CspInheritedComponentsPage';
+import OrgCapabilityLibraryPage from './pages/OrgCapabilityLibraryPage';
+import OrgCapabilityDetailPage from './pages/OrgCapabilityDetailPage';
 import ImportedDocumentsView from './features/admin/imported-documents/ImportedDocumentsView';
 import TemplatesAdminPage from './pages/TemplatesAdminPage';
 import AzureSettingsPage from './pages/AzureSettingsPage';
@@ -125,6 +127,9 @@ function AppContent() {
               resolves at `/` via PortfolioRoute for CSP-Admins. The standalone
               `/csp-dashboard` route has been retired. */}
           <Route path="/csp/inherited-components" element={<RequireAuth><CspInheritedComponentsPage /></RequireAuth>} />
+          {/* UF-CSP-01: Org-user capability library (spec-070) */}
+          <Route path="/capability-library" element={<RequireAuth><OrgCapabilityLibraryPage /></RequireAuth>} />
+          <Route path="/capability-library/:capabilityId" element={<RequireAuth><OrgCapabilityDetailPage /></RequireAuth>} />
           <Route path="/admin/imported-documents" element={<RequireAuth><ImportedDocumentsView /></RequireAuth>} />
           <Route path="/admin/templates" element={<RequireAuth><TemplatesAdminPage /></RequireAuth>} />
           {/* Wave 6 GAP-007: retired /csp-dashboard redirect */}

--- a/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityDetailPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityDetailPage.tsx
@@ -101,14 +101,14 @@ export default function OrgCapabilityDetailPage() {
 
   if (loading)
     return (
-      <PageLayout>
+      <PageLayout title="Capability Detail">
         <div className="py-16 text-center text-sm text-gray-500">Loading capability…</div>
       </PageLayout>
     );
 
   if (notFound || !capability)
     return (
-      <PageLayout>
+      <PageLayout title="Capability Not Found">
         <div className="py-16 text-center">
           <p className="text-sm text-gray-500">Capability not found.</p>
           <Link
@@ -122,7 +122,7 @@ export default function OrgCapabilityDetailPage() {
     );
 
   return (
-    <PageLayout>
+    <PageLayout title={capability?.name ?? "Capability Detail"}>
       {/* Breadcrumb */}
       <div className="mb-4">
         <Link

--- a/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityDetailPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityDetailPage.tsx
@@ -1,0 +1,265 @@
+import { useState, useEffect } from 'react';
+import { useParams, useSearchParams, Link } from 'react-router-dom';
+import PageLayout from '../components/layout/PageLayout';
+import PageHero from '../components/layout/PageHero';
+import apiClient from '../api/client';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface CapabilityDetail {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+  componentName: string;
+  mappedControls: string[];
+  mappingConfidence: number | null;
+  reviewerNote: string | null;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  isSubscribed: boolean;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Derive a human-readable inheritance type label from a control ID.
+// In the current data model, CspInheritedCapability stores control IDs as a flat list.
+// The inheritance type (Inherited / Shared / Customer Responsible) would come from
+// CapabilityControlMapping.Role — for now we default to Inherited for all capability
+// controls and note this is a future enrichment once per-control inheritance types
+// are plumbed through the org-user API.
+function inferInheritanceType(_controlId: string): 'Inherited' | 'Shared' | 'Customer Responsible' {
+  return 'Inherited';
+}
+
+const INHERITANCE_BADGE: Record<string, string> = {
+  Inherited: 'bg-green-100 text-green-800',
+  Shared: 'bg-yellow-100 text-yellow-800',
+  'Customer Responsible': 'bg-red-100 text-red-800',
+};
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+/**
+ * UF-CSP-02 — View Capability Control Coverage Detail (spec-070 T017–T018).
+ *
+ * Shows a single CSP capability's full control coverage table for an org user
+ * (ISSO/SCA) to evaluate before subscribing.
+ *
+ * Route: /capability-library/:capabilityId?systemId=<id>
+ */
+export default function OrgCapabilityDetailPage() {
+  const { capabilityId } = useParams<{ capabilityId: string }>();
+  const [searchParams] = useSearchParams();
+  const systemId = searchParams.get('systemId') ?? undefined;
+
+  const [capability, setCapability] = useState<CapabilityDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [subscribing, setSubscribing] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  useEffect(() => {
+    if (!capabilityId) return;
+    setLoading(true);
+
+    const params: Record<string, string> = {};
+    if (systemId) params.systemId = systemId;
+
+    apiClient
+      .get<CapabilityDetail>(`/capability-library/${capabilityId}`, { params })
+      .then((res) => setCapability(res.data))
+      .catch((err) => {
+        if ((err as { response?: { status?: number } }).response?.status === 404)
+          setNotFound(true);
+      })
+      .finally(() => setLoading(false));
+  }, [capabilityId, systemId]);
+
+  const handleSubscribeToggle = async () => {
+    if (!systemId || !capability) return;
+    setSubscribing(true);
+    try {
+      if (capability.isSubscribed) {
+        await apiClient.delete(`/systems/${systemId}/capability-subscriptions/${capability.id}`);
+        setCapability((prev) => prev ? { ...prev, isSubscribed: false } : prev);
+        setToast({ message: `Unsubscribed from ${capability.name}`, type: 'success' });
+      } else {
+        await apiClient.post(`/systems/${systemId}/capability-subscriptions`, {
+          capabilityId: capability.id,
+        });
+        setCapability((prev) => prev ? { ...prev, isSubscribed: true } : prev);
+        setToast({ message: `Subscribed to ${capability.name}`, type: 'success' });
+      }
+    } catch {
+      setToast({ message: 'Action failed — please try again.', type: 'error' });
+    } finally {
+      setSubscribing(false);
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  if (loading)
+    return (
+      <PageLayout>
+        <div className="py-16 text-center text-sm text-gray-500">Loading capability…</div>
+      </PageLayout>
+    );
+
+  if (notFound || !capability)
+    return (
+      <PageLayout>
+        <div className="py-16 text-center">
+          <p className="text-sm text-gray-500">Capability not found.</p>
+          <Link
+            to={`/capability-library${systemId ? `?systemId=${systemId}` : ''}`}
+            className="mt-3 inline-block text-sm text-indigo-600 hover:underline"
+          >
+            ← Back to Library
+          </Link>
+        </div>
+      </PageLayout>
+    );
+
+  return (
+    <PageLayout>
+      {/* Breadcrumb */}
+      <div className="mb-4">
+        <Link
+          to={`/capability-library${systemId ? `?systemId=${systemId}` : ''}`}
+          className="text-sm text-indigo-600 hover:underline"
+        >
+          ← Back to Capability Library
+        </Link>
+      </div>
+
+      <PageHero
+        title={capability.name}
+        description={capability.description}
+      />
+
+      {/* Toast */}
+      {toast && (
+        <div
+          className={`mb-4 rounded-md px-4 py-3 text-sm font-medium ${
+            toast.type === 'success' ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-800'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+
+      {/* Header metadata */}
+      <div className="mb-6 flex flex-wrap items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Provider</p>
+          <p className="mt-0.5 text-sm text-gray-900">{capability.provider}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Component</p>
+          <p className="mt-0.5 text-sm text-gray-900">{capability.componentName}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Controls</p>
+          <p className="mt-0.5 text-sm text-gray-900">{capability.mappedControls.length}</p>
+        </div>
+        {capability.mappingConfidence != null && (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">AI Confidence</p>
+            <p className="mt-0.5 text-sm text-gray-900">
+              {(capability.mappingConfidence * 100).toFixed(0)}%
+            </p>
+          </div>
+        )}
+        {capability.reviewedBy && (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Reviewed By</p>
+            <p className="mt-0.5 text-sm text-gray-900">{capability.reviewedBy}</p>
+          </div>
+        )}
+        {/* Subscribe / Unsubscribe action */}
+        {systemId && (
+          <div className="ml-auto">
+            <button
+              type="button"
+              onClick={() => void handleSubscribeToggle()}
+              disabled={subscribing}
+              className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
+                capability.isSubscribed
+                  ? 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                  : 'bg-indigo-600 text-white hover:bg-indigo-700'
+              }`}
+            >
+              {subscribing
+                ? '…'
+                : capability.isSubscribed
+                ? 'Unsubscribe from System'
+                : 'Subscribe to System'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Reviewer note */}
+      {capability.reviewerNote && (
+        <div className="mb-5 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+          <span className="font-medium">CSP Admin Note:</span> {capability.reviewerNote}
+        </div>
+      )}
+
+      {/* Control Coverage Table */}
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 px-5 py-4">
+          <h2 className="text-base font-semibold text-gray-900">Control Coverage</h2>
+          <p className="mt-0.5 text-sm text-gray-500">
+            NIST SP 800-53 controls addressed by this capability.
+          </p>
+        </div>
+        {capability.mappedControls.length === 0 ? (
+          <div className="px-5 py-10 text-center text-sm text-gray-500">
+            No control mappings on record.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  {['Control ID', 'Inheritance Type'].map((h) => (
+                    <th
+                      key={h}
+                      scope="col"
+                      className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {capability.mappedControls.map((controlId) => {
+                  const inheritanceType = inferInheritanceType(controlId);
+                  return (
+                    <tr key={controlId} className="hover:bg-gray-50">
+                      <td className="whitespace-nowrap px-5 py-3 text-sm font-medium text-gray-900">
+                        {controlId}
+                      </td>
+                      <td className="px-5 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                            INHERITANCE_BADGE[inheritanceType]
+                          }`}
+                        >
+                          {inheritanceType}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx
@@ -1,0 +1,289 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import PageLayout from '../components/layout/PageLayout';
+import PageHero from '../components/layout/PageHero';
+import apiClient from '../api/client';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface OrgCapability {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+  componentName: string;
+  controlCount: number;
+  mappedControls: string[];
+  isSubscribed: boolean;
+}
+
+interface ListResponse {
+  items: OrgCapability[];
+  totalCount: number;
+}
+
+// ─── NIST control family labels ───────────────────────────────────────────────
+
+const NIST_FAMILIES: Record<string, string> = {
+  AC: 'Access Control', AT: 'Awareness & Training', AU: 'Audit & Accountability',
+  CA: 'Assessment, Authorization & Monitoring', CM: 'Configuration Management',
+  CP: 'Contingency Planning', IA: 'Identification & Authentication',
+  IR: 'Incident Response', MA: 'Maintenance', MP: 'Media Protection',
+  PE: 'Physical & Environmental Protection', PL: 'Planning',
+  PM: 'Program Management', PS: 'Personnel Security',
+  RA: 'Risk Assessment', SA: 'System & Services Acquisition',
+  SC: 'System & Communications Protection', SI: 'System & Information Integrity',
+};
+
+const PROVIDER_OPTIONS = ['Infrastructure', 'Platform', 'Service', 'Identity'];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function controlFamilies(controls: string[]): string[] {
+  const families = new Set<string>();
+  for (const c of controls) {
+    const family = c.split('-')[0].toUpperCase();
+    if (family) families.add(family);
+  }
+  return Array.from(families).sort();
+}
+
+// ─── Capability card ──────────────────────────────────────────────────────────
+
+function CapabilityCard({
+  capability,
+  systemId,
+  onSubscribeToggle,
+  subscribing,
+}: {
+  capability: OrgCapability;
+  systemId?: string;
+  onSubscribeToggle: (cap: OrgCapability) => Promise<void>;
+  subscribing: boolean;
+}) {
+  const families = controlFamilies(capability.mappedControls);
+
+  return (
+    <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-5 shadow-sm hover:shadow-md transition-shadow">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-sm font-semibold text-gray-900 truncate">{capability.name}</h3>
+            {capability.isSubscribed && (
+              <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+                ✓ Subscribed
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-gray-500">{capability.provider} · {capability.componentName}</p>
+        </div>
+        <span className="flex-shrink-0 rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">
+          {capability.controlCount} controls
+        </span>
+      </div>
+
+      {/* Description */}
+      <p className="mt-3 text-sm text-gray-600 line-clamp-2">{capability.description}</p>
+
+      {/* Control families */}
+      {families.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1">
+          {families.slice(0, 6).map((f) => (
+            <span key={f} className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600">
+              {f}
+            </span>
+          ))}
+          {families.length > 6 && (
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-400">
+              +{families.length - 6}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="mt-4 flex items-center gap-3 border-t border-gray-100 pt-3">
+        <Link
+          to={`/capability-library/${capability.id}${systemId ? `?systemId=${systemId}` : ''}`}
+          className="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+        >
+          View Details →
+        </Link>
+        {systemId && (
+          <button
+            type="button"
+            onClick={() => onSubscribeToggle(capability)}
+            disabled={subscribing}
+            className={`ml-auto rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+              capability.isSubscribed
+                ? 'border border-gray-300 text-gray-700 hover:bg-gray-50'
+                : 'bg-indigo-600 text-white hover:bg-indigo-700'
+            }`}
+          >
+            {capability.isSubscribed ? 'Subscribed' : 'Subscribe to System'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+/**
+ * UF-CSP-01 — Browse Capability Library & Subscribe (spec-070 T013–T016).
+ *
+ * Org-user view of the Published CSP capability catalog. Distinct from the
+ * CSP-Admin CapabilityLibrary.tsx at /capabilities — this page is for ISSOs
+ * and ISSMs to browse and subscribe capabilities to their systems.
+ *
+ * Route: /capability-library?systemId=<id>
+ * systemId is optional — without it the page is read-only (no Subscribe button).
+ */
+export default function OrgCapabilityLibraryPage() {
+  const [searchParams] = useSearchParams();
+  const systemId = searchParams.get('systemId') ?? undefined;
+
+  const [capabilities, setCapabilities] = useState<OrgCapability[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [providerFilter, setProviderFilter] = useState('');
+  const [familyFilter, setFamilyFilter] = useState('');
+  const [subscribing, setSubscribing] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  const fetchCapabilities = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: Record<string, string> = {};
+      if (search) params.search = search;
+      if (providerFilter) params.provider = providerFilter;
+      if (systemId) params.systemId = systemId;
+
+      const res = await apiClient.get<ListResponse>('/capability-library', { params });
+      setCapabilities(res.data.items);
+    } catch {
+      setCapabilities([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [search, providerFilter, systemId]);
+
+  useEffect(() => {
+    void fetchCapabilities();
+  }, [fetchCapabilities]);
+
+  // Client-side family filter
+  const filtered = familyFilter
+    ? capabilities.filter((c) =>
+        controlFamilies(c.mappedControls).includes(familyFilter))
+    : capabilities;
+
+  const handleSubscribeToggle = useCallback(async (cap: OrgCapability) => {
+    if (!systemId) return;
+    setSubscribing(true);
+    try {
+      if (cap.isSubscribed) {
+        await apiClient.delete(`/systems/${systemId}/capability-subscriptions/${cap.id}`);
+        setCapabilities((prev) =>
+          prev.map((c) => c.id === cap.id ? { ...c, isSubscribed: false } : c));
+        setToast({ message: `Unsubscribed from ${cap.name}`, type: 'success' });
+      } else {
+        await apiClient.post(`/systems/${systemId}/capability-subscriptions`, {
+          capabilityId: cap.id,
+        });
+        setCapabilities((prev) =>
+          prev.map((c) => c.id === cap.id ? { ...c, isSubscribed: true } : c));
+        setToast({ message: `Subscribed to ${cap.name}`, type: 'success' });
+      }
+    } catch {
+      setToast({ message: 'Action failed — please try again.', type: 'error' });
+    } finally {
+      setSubscribing(false);
+      setTimeout(() => setToast(null), 3000);
+    }
+  }, [systemId]);
+
+  // Available families from current results
+  const allFamilies = Array.from(
+    new Set(capabilities.flatMap((c) => controlFamilies(c.mappedControls))),
+  ).sort();
+
+  return (
+    <PageLayout>
+      <PageHero
+        title="Capability Library"
+        description="Browse CSP-published capabilities and subscribe to add inherited controls to your system's SSP."
+      />
+
+      {/* Toast */}
+      {toast && (
+        <div
+          className={`mb-4 rounded-md px-4 py-3 text-sm font-medium ${
+            toast.type === 'success' ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-800'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="mb-5 flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          placeholder="Search capabilities…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+        <select
+          value={providerFilter}
+          onChange={(e) => setProviderFilter(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm"
+        >
+          <option value="">All providers</option>
+          {PROVIDER_OPTIONS.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <select
+          value={familyFilter}
+          onChange={(e) => setFamilyFilter(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm"
+        >
+          <option value="">All control families</option>
+          {allFamilies.map((f) => (
+            <option key={f} value={f}>{f} — {NIST_FAMILIES[f] ?? f}</option>
+          ))}
+        </select>
+        {systemId && (
+          <span className="ml-auto rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs text-indigo-700">
+            System context: {systemId}
+          </span>
+        )}
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <div className="py-12 text-center text-sm text-gray-500">Loading capabilities…</div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 py-16 text-center">
+          <p className="text-sm text-gray-500">No capabilities match your filters.</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((cap) => (
+            <CapabilityCard
+              key={cap.id}
+              capability={cap}
+              systemId={systemId}
+              onSubscribeToggle={handleSubscribeToggle}
+              subscribing={subscribing}
+            />
+          ))}
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx
@@ -42,7 +42,7 @@ const PROVIDER_OPTIONS = ['Infrastructure', 'Platform', 'Service', 'Identity'];
 function controlFamilies(controls: string[]): string[] {
   const families = new Set<string>();
   for (const c of controls) {
-    const family = c.split('-')[0].toUpperCase();
+    const family = c.split('-')[0]?.toUpperCase();
     if (family) families.add(family);
   }
   return Array.from(families).sort();
@@ -211,7 +211,7 @@ export default function OrgCapabilityLibraryPage() {
   ).sort();
 
   return (
-    <PageLayout>
+    <PageLayout title="Capability Library">
       <PageHero
         title="Capability Library"
         description="Browse CSP-published capabilities and subscribe to add inherited controls to your system's SSP."

--- a/src/Ato.Copilot.Mcp/Endpoints/CapabilitySubscriptionEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/CapabilitySubscriptionEndpoints.cs
@@ -1,0 +1,320 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Models.Compliance;
+using Ato.Copilot.Core.Models.Tenancy;
+
+namespace Ato.Copilot.Mcp.Endpoints;
+
+/// <summary>
+/// Org-user Capability Library endpoints (UF-CSP-01/02/03 — spec-070).
+///
+/// These endpoints serve the org-user (ISSO/ISSM/SCA) view of the CSP capability
+/// catalog. Only CspInheritedCapabilities with Status == Mapped are returned —
+/// NeedsReview and Archived capabilities are filtered out at the query level.
+///
+/// Separate from CSP-admin endpoints at /api/csp/inherited-components.
+///
+/// Routes:
+///   GET    /api/dashboard/capability-library
+///   GET    /api/dashboard/capability-library/{id}
+///   POST   /api/dashboard/systems/{systemId}/capability-subscriptions
+///   GET    /api/dashboard/systems/{systemId}/capability-subscriptions
+///   DELETE /api/dashboard/systems/{systemId}/capability-subscriptions/{capabilityId}
+/// </summary>
+public static class CapabilitySubscriptionEndpoints
+{
+    public static IEndpointRouteBuilder MapCapabilitySubscriptionEndpoints(
+        this IEndpointRouteBuilder app)
+    {
+        // ─── Capability Library — org-user browse ────────────────────────────
+
+        // GET /api/dashboard/capability-library
+        // Returns CSP capabilities with Status == Mapped, in org-user projection.
+        // Optional query params: search (name/description), provider (ComponentType enum),
+        // systemId (annotates isSubscribed per capability).
+        app.MapGet("/api/dashboard/capability-library", async (
+            string? search,
+            string? provider,
+            string? systemId,
+            AtoCopilotContext db,
+            CancellationToken ct) =>
+        {
+            // Base query: only Mapped (consumable by org tenants)
+            var query = db.CspInheritedCapabilities
+                .Include(c => c.CspInheritedComponent)
+                .Where(c => c.Status == CspInheritedCapabilityStatus.Mapped)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(search))
+                query = query.Where(c =>
+                    c.Name.Contains(search) || c.Description.Contains(search));
+
+            if (!string.IsNullOrWhiteSpace(provider) &&
+                Enum.TryParse<CspComponentType>(provider, ignoreCase: true, out var providerEnum))
+                query = query.Where(c => c.CspInheritedComponent.ComponentType == providerEnum);
+
+            var capabilities = await query
+                .OrderBy(c => c.Name)
+                .Select(c => new
+                {
+                    id = c.Id.ToString(),
+                    name = c.Name,
+                    description = c.Description,
+                    provider = c.CspInheritedComponent.ComponentType.ToString(),
+                    componentName = c.CspInheritedComponent.Name,
+                    controlCount = c.MappedNistControlIds.Count,
+                    mappedControls = c.MappedNistControlIds,
+                })
+                .ToListAsync(ct);
+
+            // Annotate subscription status if caller provided their systemId
+            HashSet<string> subscribed = new(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(systemId))
+            {
+                subscribed = (await db.CapabilitySubscriptions
+                    .Where(s => s.RegisteredSystemId == systemId && s.IsActive)
+                    .Select(s => s.CspInheritedCapabilityId)
+                    .ToListAsync(ct))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var result = capabilities.Select(c => new
+            {
+                c.id, c.name, c.description, c.provider,
+                c.componentName, c.controlCount, c.mappedControls,
+                isSubscribed = subscribed.Contains(c.id),
+            });
+
+            return Results.Ok(new { items = result, totalCount = result.Count() });
+        })
+        .WithName("ListCapabilityLibrary")
+        .WithTags("Capability Library");
+
+        // ─────────────────────────────────────────────────────────────────────
+
+        // GET /api/dashboard/capability-library/{id}
+        // Returns a single Mapped capability with full control detail.
+        // Used by UF-CSP-02 (OrgCapabilityDetailPage).
+        app.MapGet("/api/dashboard/capability-library/{id:guid}", async (
+            Guid id,
+            string? systemId,
+            AtoCopilotContext db,
+            CancellationToken ct) =>
+        {
+            var capability = await db.CspInheritedCapabilities
+                .Include(c => c.CspInheritedComponent)
+                .FirstOrDefaultAsync(c =>
+                    c.Id == id && c.Status == CspInheritedCapabilityStatus.Mapped, ct);
+
+            if (capability is null)
+                return Results.NotFound(new { error = "Capability not found", errorCode = "NOT_FOUND" });
+
+            // Check subscription if systemId provided
+            bool isSubscribed = false;
+            if (!string.IsNullOrWhiteSpace(systemId))
+            {
+                isSubscribed = await db.CapabilitySubscriptions.AnyAsync(s =>
+                    s.RegisteredSystemId == systemId &&
+                    s.CspInheritedCapabilityId == id.ToString() &&
+                    s.IsActive, ct);
+            }
+
+            return Results.Ok(new
+            {
+                id = capability.Id.ToString(),
+                name = capability.Name,
+                description = capability.Description,
+                provider = capability.CspInheritedComponent.ComponentType.ToString(),
+                componentName = capability.CspInheritedComponent.Name,
+                mappedControls = capability.MappedNistControlIds,
+                mappingConfidence = capability.MappingConfidence,
+                reviewerNote = capability.ReviewerNote,
+                reviewedBy = capability.ReviewedBy,
+                reviewedAt = capability.ReviewedAt,
+                isSubscribed,
+            });
+        })
+        .WithName("GetCapabilityLibraryDetail")
+        .WithTags("Capability Library");
+
+        // ─── Capability Subscriptions — per-system ────────────────────────────
+
+        // POST /api/dashboard/systems/{systemId}/capability-subscriptions
+        // Subscribe a system to a Mapped CSP capability (UF-CSP-01).
+        // Idempotent: re-subscribe after unsubscribe reactivates the record.
+        app.MapPost("/api/dashboard/systems/{systemId}/capability-subscriptions", async (
+            string systemId,
+            SubscribeCapabilityRequest body,
+            AtoCopilotContext db,
+            CancellationToken ct) =>
+        {
+            // Validate capability exists and is Mapped
+            if (!Guid.TryParse(body.CapabilityId, out var capGuid))
+                return Results.BadRequest(new { error = "Invalid capabilityId", errorCode = "INVALID_INPUT" });
+
+            var capability = await db.CspInheritedCapabilities
+                .FirstOrDefaultAsync(c => c.Id == capGuid, ct);
+
+            if (capability is null)
+                return Results.NotFound(new { error = "Capability not found", errorCode = "NOT_FOUND" });
+
+            if (capability.Status != CspInheritedCapabilityStatus.Mapped)
+                return Results.BadRequest(new
+                {
+                    error = "Only Mapped capabilities can be subscribed to.",
+                    errorCode = "CAPABILITY_NOT_MAPPED",
+                });
+
+            // Idempotency: re-activate if previously unsubscribed
+            var existing = await db.CapabilitySubscriptions.FirstOrDefaultAsync(s =>
+                s.RegisteredSystemId == systemId &&
+                s.CspInheritedCapabilityId == body.CapabilityId, ct);
+
+            if (existing is not null)
+            {
+                if (existing.IsActive)
+                    return Results.Ok(new { id = existing.Id, alreadySubscribed = true });
+
+                existing.IsActive = true;
+                existing.SubscribedAt = DateTime.UtcNow;
+                existing.SubscribedBy = body.SubscribedBy ?? "dashboard-user";
+                await db.SaveChangesAsync(ct);
+                return Results.Ok(new { id = existing.Id, alreadySubscribed = false });
+            }
+
+            var subscription = new CapabilitySubscription
+            {
+                RegisteredSystemId = systemId,
+                CspInheritedCapabilityId = body.CapabilityId,
+                SubscribedBy = body.SubscribedBy ?? "dashboard-user",
+            };
+
+            db.CapabilitySubscriptions.Add(subscription);
+
+            db.DashboardActivities.Add(new DashboardActivity
+            {
+                RegisteredSystemId = systemId,
+                EventType = "CapabilitySubscribed",
+                Actor = body.SubscribedBy ?? "dashboard-user",
+                Summary = $"Subscribed to CSP capability: {capability.Name}",
+                RelatedEntityType = "CapabilitySubscription",
+                RelatedEntityId = subscription.Id,
+            });
+
+            await db.SaveChangesAsync(ct);
+
+            return Results.Created(
+                $"/api/dashboard/systems/{systemId}/capability-subscriptions/{subscription.Id}",
+                new { id = subscription.Id, alreadySubscribed = false });
+        })
+        .WithName("SubscribeToCapability")
+        .WithTags("Capability Library");
+
+        // ─────────────────────────────────────────────────────────────────────
+
+        // GET /api/dashboard/systems/{systemId}/capability-subscriptions
+        // Lists active capability subscriptions for a system.
+        app.MapGet("/api/dashboard/systems/{systemId}/capability-subscriptions", async (
+            string systemId,
+            AtoCopilotContext db,
+            CancellationToken ct) =>
+        {
+            // Fetch subscriptions + enrich with capability names from CspInheritedCapabilities
+            var subs = await db.CapabilitySubscriptions
+                .Where(s => s.RegisteredSystemId == systemId && s.IsActive)
+                .OrderBy(s => s.SubscribedAt)
+                .Select(s => new
+                {
+                    id = s.Id,
+                    capabilityId = s.CspInheritedCapabilityId,
+                    subscribedBy = s.SubscribedBy,
+                    subscribedAt = s.SubscribedAt,
+                })
+                .ToListAsync(ct);
+
+            // Resolve capability names in one secondary query
+            var capIds = subs.Select(s => s.capabilityId).Distinct().ToList();
+            var capGuids = capIds
+                .Select(id => Guid.TryParse(id, out var g) ? (Guid?)g : null)
+                .Where(g => g.HasValue)
+                .Select(g => g!.Value)
+                .ToList();
+
+            var capNames = await db.CspInheritedCapabilities
+                .Where(c => capGuids.Contains(c.Id))
+                .Select(c => new { id = c.Id.ToString(), c.Name })
+                .ToListAsync(ct);
+
+            var nameMap = capNames.ToDictionary(c => c.id, c => c.Name);
+
+            var result = subs.Select(s => new
+            {
+                s.id, s.capabilityId,
+                capabilityName = nameMap.TryGetValue(s.capabilityId, out var n) ? n : s.capabilityId,
+                s.subscribedBy, s.subscribedAt,
+            });
+
+            return Results.Ok(new { items = result, totalCount = result.Count() });
+        })
+        .WithName("ListCapabilitySubscriptions")
+        .WithTags("Capability Library");
+
+        // ─────────────────────────────────────────────────────────────────────
+
+        // DELETE /api/dashboard/systems/{systemId}/capability-subscriptions/{capabilityId}
+        // Unsubscribes a system from a CSP capability (UF-CSP-03).
+        // Soft-delete: sets IsActive=false to preserve audit trail.
+        app.MapDelete(
+            "/api/dashboard/systems/{systemId}/capability-subscriptions/{capabilityId}",
+            async (
+                string systemId,
+                string capabilityId,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var sub = await db.CapabilitySubscriptions.FirstOrDefaultAsync(s =>
+                s.RegisteredSystemId == systemId &&
+                s.CspInheritedCapabilityId == capabilityId &&
+                s.IsActive, ct);
+
+            if (sub is null)
+                return Results.NotFound(new { error = "Active subscription not found", errorCode = "NOT_FOUND" });
+
+            sub.IsActive = false;
+
+            // Capability name for audit log
+            Guid.TryParse(capabilityId, out var capGuid);
+            var capabilityName = (await db.CspInheritedCapabilities
+                .Where(c => c.Id == capGuid)
+                .Select(c => c.Name)
+                .FirstOrDefaultAsync(ct)) ?? capabilityId;
+
+            db.DashboardActivities.Add(new DashboardActivity
+            {
+                RegisteredSystemId = systemId,
+                EventType = "CapabilityUnsubscribed",
+                Actor = "dashboard-user",
+                Summary = $"Unsubscribed from CSP capability: {capabilityName}",
+                RelatedEntityType = "CapabilitySubscription",
+                RelatedEntityId = sub.Id,
+            });
+
+            await db.SaveChangesAsync(ct);
+
+            return Results.Ok(new { id = sub.Id, unsubscribed = true });
+        })
+        .WithName("UnsubscribeFromCapability")
+        .WithTags("Capability Library");
+
+        return app;
+    }
+
+    // ─── Request DTOs ──────────────────────────────────────────────────────────
+
+    private record SubscribeCapabilityRequest(
+        string CapabilityId,
+        string? SubscribedBy);
+}

--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -666,6 +666,9 @@ async Task RunHttpModeAsync(string[] args)
     // Feature 048 follow-up (user ask #2): per-org NIST control override surface.
     app.MapOrgControlOverrideEndpoints();
 
+    // UF-CSP-01/02/03 — Org-user capability library & subscriptions (spec-070)
+    app.MapCapabilitySubscriptionEndpoints();
+
     // Map SignalR notification hub
     app.MapHub<Ato.Copilot.Mcp.Hubs.NotificationHub>("/hubs/notifications");
     app.MapHub<Ato.Copilot.Mcp.Hubs.PackageHub>("/hubs/package");


### PR DESCRIPTION
## Owner
Cyborg (Victor Stone) — Principal AI & MCP Engineer, Justice League

## Problem Statement
Issues #226, #227, #228 identify a complete gap in the org-user experience for discovering and subscribing to CSP-published capabilities.

**Missing components prior to this PR:**
- `src/Ato.Copilot.Core/Models/Compliance/CapabilitySubscription.cs` — entity did not exist
- `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs` — no DbSet or EF config for CapabilitySubscription
- No EF migration for CapabilitySubscriptions table
- `src/Ato.Copilot.Mcp/Endpoints/CapabilitySubscriptionEndpoints.cs` — all 5 org-user capability endpoints missing
- `src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx` — org browse library did not exist (existing CapabilityLibrary.tsx is CSP-Admin only)
- `src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityDetailPage.tsx` — capability detail page did not exist
- Routes `/capability-library` and `/capability-library/:id` not registered in App.tsx

## Goal / Desired Outcome
ISSOs and ISSMs can browse the CSP capability catalog, subscribe to capabilities to add inherited controls to their SSP, view per-capability control coverage, and unsubscribe when needed — all from the dashboard.

## Scope

**In scope:**
- CapabilitySubscription entity + EF migration
- 5 org-user API endpoints (list library, get detail, subscribe, list subscriptions, unsubscribe)
- OrgCapabilityLibraryPage.tsx (UF-CSP-01)
- OrgCapabilityDetailPage.tsx (UF-CSP-02 + UF-CSP-03)
- App.tsx route registration

**Out of scope:**
- Per-control InheritanceType surface (requires Phase 2 enrichment — mapped controls are stored as flat List<string> on CspInheritedCapability; InheritanceType is on SecurityCapability/CapabilityControlMapping which is org-scoped)
- SSP Inherited Controls tab integration (separate epic)
- RBAC role gates (FR-026 — tracked separately)

## User Experience Flow

1. ISSO navigates to `/capability-library?systemId=<id>` from sidebar or portfolio
2. `OrgCapabilityLibraryPage` loads — grid of Mapped CSP capability cards
3. ISSO filters by provider (Infrastructure/Platform/Service/Identity) or NIST control family
4. ISSO clicks **Subscribe to System** → POST fires → card shows green "✓ Subscribed" badge
5. ISSO clicks **View Details →** → navigates to `/capability-library/:id?systemId=<id>`
6. `OrgCapabilityDetailPage` shows control coverage table with Inherited/Shared/Customer Responsible badges
7. ISSO clicks **Unsubscribe from System** → confirmation is the button state → DELETE fires
8. Audit log entries created for both subscribe and unsubscribe events

## Functional Requirements

- **FR-001** — `GET /api/dashboard/capability-library` returns only CspInheritedCapabilities with `Status == Mapped`
- **FR-002** — `isSubscribed` flag annotated on each capability when `systemId` query param provided
- **FR-003** — Subscribe action idempotent: re-subscribing a previously unsubscribed record re-activates it (no duplicate row)
- **FR-004** — Unsubscribe soft-deletes: `IsActive=false`, row preserved for audit trail
- **FR-005** — Both subscribe and unsubscribe write `DashboardActivity` entries
- **FR-006** — Org library page: search by name/description, filter by provider + control family
- **FR-007** — Detail page: all `MappedNistControlIds` shown in a table with inheritance type badges
- **FR-008** — Routes `/capability-library` and `/capability-library/:capabilityId` registered in App.tsx

## Technical Design Notes

- `CapabilitySubscription` uses string PKs (GUID as string) for schema consistency with rest of project
- `CspInheritedCapabilityId` is stored as string (GUID string) to match subscription.Id pattern; cast to `Guid` at query time
- Capability Status enum: `Mapped` (0) = consumable by org users; `NeedsReview` (1) and `Archived` (2) excluded
- `ComponentType` is `CspComponentType` enum (Infrastructure/Platform/Service/Identity)
- Frontend routes do NOT collide with CSP-Admin `/capabilities` route

## Architecture Decisions

| Decision | Rationale |
|---|---|
| Separate CapabilitySubscriptionEndpoints.cs file | Keeps org-user capability logic separate from the 8300-line DashboardEndpoints.cs |
| Soft-delete (IsActive=false) | Preserves audit trail for ATO package evidence |
| Idempotent re-subscribe | ISSO should not get errors when subscribing to something they previously unsubscribed |
| OrgCapabilityLibraryPage not CapabilityLibrary | CapabilityLibrary.tsx is CSP-admin scope; separate page prevents confusion and collision |

## Acceptance Criteria

```gherkin
Feature: Org Capability Library

  Scenario: Browse Mapped capabilities
    Given a CSP-Admin has published capabilities with Status=Mapped
    When an ISSO navigates to /capability-library
    Then they see a grid of capability cards
    And NeedsReview and Archived capabilities are not shown

  Scenario: Subscribe to capability
    Given an ISSO is on /capability-library?systemId=sys1
    When they click Subscribe on a capability
    Then POST /api/dashboard/systems/sys1/capability-subscriptions fires
    And the card shows "✓ Subscribed" badge
    And a DashboardActivity event is recorded

  Scenario: Unsubscribe from capability
    Given an ISSO has subscribed to a capability
    When they click Unsubscribe from System
    Then DELETE /api/dashboard/systems/sys1/capability-subscriptions/:id fires
    And the card shows the subscribe button again
    And the subscription row has IsActive=false

  Scenario: View detail page
    Given an ISSO clicks View Details on a capability
    When OrgCapabilityDetailPage loads
    Then a control coverage table shows all MappedNistControlIds
    And each control shows an inheritance type badge

  Scenario: Idempotent subscribe
    Given a capability was previously unsubscribed
    When the ISSO subscribes again
    Then the existing row is reactivated (no duplicate row created)
    And the response returns alreadySubscribed=false
```

## Non-Functional Requirements

- Library page loads in < 1s (client-side filter after initial fetch)
- Subscribe/Unsubscribe API response < 200ms (single row insert/update)
- No pagination needed at MVP scale (CSP catalogs typically < 100 capabilities)

## Test Plan

- [ ] Navigate to `/capability-library?systemId=<id>` → grid renders
- [ ] Filter by provider → correct subset shown
- [ ] Search by control ID (e.g., "AC-2") → capabilities with that control appear
- [ ] Subscribe → badge turns green, unsubscribe reverts
- [ ] Navigate to detail → control table shows, Subscribe button present

## Definition of Done

- [x] CapabilitySubscription entity created
- [x] EF migration created (manual — dotnet CLI not available on build host)
- [x] AtoCopilotContext DbSet + OnModelCreating config added
- [x] CapabilitySubscriptionEndpoints.cs — all 5 endpoints implemented
- [x] Program.cs — endpoint registered
- [x] OrgCapabilityLibraryPage.tsx — browse + subscribe + filter
- [x] OrgCapabilityDetailPage.tsx — detail + control table + subscribe/unsubscribe
- [x] App.tsx — routes registered
- [x] Branch pushed, PR open against main
- [ ] CI green

## Explicit Constraints

**DO NOT:**
- Modify `CapabilityLibrary.tsx` — it is the CSP-Admin page (different route/scope)
- Use hard-delete on subscriptions — soft-delete is mandatory for ATO audit trail
- Return NeedsReview or Archived capabilities to org users

## Anti-Patterns

- Using `string` comparison for CspInheritedCapabilityId without `Guid.TryParse` guard
- Adding per-row inheritance type before the CapabilityControlMapping FK is plumbed through the org-user API
- Combining the org-user library with the CSP-admin library — different personas, different scopes

## Existing File References

- `src/Ato.Copilot.Dashboard/src/pages/CapabilityLibrary.tsx` line 51 — CSP-Admin page (NOT modified)
- `src/Ato.Copilot.Core/Models/Tenancy/CspInheritedCapability.cs` — entity with `MappedNistControlIds: List<string>` and `Status: CspInheritedCapabilityStatus`
- `src/Ato.Copilot.Core/Models/Tenancy/CspInheritedCapabilityStatus.cs` — `Mapped=0, NeedsReview=1, Archived=2`
- `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs` line 520 — DbSet insertion point (modified)

## Spec Compliance

Maps to `specs/070-capability-library-org/tasks.md`:
- T001–T002: Backend endpoint registration ✅
- T003–T006: CapabilitySubscription entity + migration ✅
- T007–T012: All 5 org-user endpoints ✅
- T013–T016: OrgCapabilityLibraryPage + App.tsx routes ✅
- T017–T018: OrgCapabilityDetailPage ✅

Closes #226 #227 #228
Related: #337 (entity+migration), #338 (endpoints), #339 (library page), #340 (detail page), #341 (unsubscribe)
