### PR TITLE
feat(#128): VS Code Extension v1.0 — Marketplace metadata, ato.openRmfOverview, vsce release workflow

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -1,0 +1,46 @@
+name: Release VS Code Extension
+
+on:
+  push:
+    tags:
+      - 'vscode-v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: extensions/vscode
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: extensions/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile extension
+        run: npm run compile
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Package extension
+        run: vsce package --out ato-copilot-${{ github.ref_name }}.vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ato-copilot-vsix
+          path: extensions/vscode/ato-copilot-${{ github.ref_name }}.vsix
+          retention-days: 90
+
+      - name: Publish to Marketplace
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        run: vsce publish --packagePath ato-copilot-${{ github.ref_name }}.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,14 +2,20 @@
   "name": "ato-copilot-vscode",
   "displayName": "ATO Copilot",
   "description": "GitHub Copilot Chat participant for ATO compliance assessments, NIST 800-53 controls, and infrastructure-as-code generation",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "publisher": "ato-copilot",
+  "categories": [
+    "Chat",
+    "Other"
+  ],
+  "keywords": ["ato", "compliance", "nist", "rmf", "fedramp", "dod", "fisma", "stig", "oscal"],
+  "icon": "media/icon.png",
+  "galleryBanner": { "color": "#1e3a5f", "theme": "dark" },
+  "repository": { "type": "git", "url": "https://github.com/azurenoops/ato-copilot" },
+  "license": "MIT",
   "engines": {
     "vscode": "^1.90.0"
   },
-  "categories": [
-    "Chat"
-  ],
   "activationEvents": [
     "onChatParticipant:ato"
   ],
@@ -84,6 +90,17 @@
         "command": "ato.requestFalsePositive",
         "title": "ATO Copilot: Request False Positive",
         "category": "ATO Copilot"
+      },
+      {
+        "command": "ato.saveTemplate",
+        "title": "ATO Copilot: Save Template",
+        "category": "ATO Copilot"
+      },
+      {
+        "command": "ato.openRmfOverview",
+        "title": "ATO Copilot: Open RMF Overview",
+        "category": "ATO Copilot",
+        "icon": "$(book)"
       }
     ],
     "menus": {
@@ -92,6 +109,18 @@
           "command": "ato.requestFalsePositive",
           "when": "editorTextFocus",
           "group": "ATO Copilot"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "ato.openRmfOverview",
+          "when": "editorIsOpen",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "ato.openRmfOverview"
         }
       ]
     },

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -186,6 +186,19 @@ export function activate(context: vscode.ExtensionContext): void {
     )
   );
 
+  // RMF Overview panel command (GAP-009 T170)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ato.openRmfOverview', () => {
+      const panel = vscode.window.createWebviewPanel(
+        'rmfOverview',
+        'RMF Overview',
+        vscode.ViewColumn.One,
+        { enableScripts: false }
+      );
+      panel.webview.html = getRmfOverviewHtml();
+    })
+  );
+
   // Refresh client when settings change
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
@@ -219,6 +232,22 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   outputChannel.appendLine("ATO Copilot extension activated");
+}
+
+function getRmfOverviewHtml(): string {
+  return `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>RMF Overview</title>
+  <style>body{font-family:var(--vscode-font-family);padding:16px;color:var(--vscode-foreground);background:var(--vscode-editor-background)}
+  h1{color:var(--vscode-textLink-foreground)}table{border-collapse:collapse;width:100%}th,td{border:1px solid var(--vscode-panel-border);padding:6px 10px;text-align:left}
+  th{background:var(--vscode-editor-selectionBackground)}</style></head>
+  <body><h1>NIST RMF Steps</h1>
+  <table><tr><th>Step</th><th>Name</th><th>Purpose</th></tr>
+  <tr><td>1</td><td>Categorize</td><td>Determine system impact level (Low/Moderate/High)</td></tr>
+  <tr><td>2</td><td>Select</td><td>Choose NIST 800-53 control baseline</td></tr>
+  <tr><td>3</td><td>Implement</td><td>Document control implementations in SSP</td></tr>
+  <tr><td>4</td><td>Assess</td><td>Test controls for effectiveness</td></tr>
+  <tr><td>5</td><td>Authorize</td><td>AO issues Authorization Decision</td></tr>
+  <tr><td>6</td><td>Monitor</td><td>Continuous monitoring and ConMon reporting</td></tr>
+  </table></body></html>`;
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
Closes #128
Closes #170
Closes #171

## Changes
- `extensions/vscode/package.json`: bump to v1.0.0, Marketplace categories/keywords/icon/galleryBanner/repository/license, add `ato.saveTemplate` + `ato.openRmfOverview` to contributes.commands, add `editor/title` + `commandPalette` menu entries
- `extensions/vscode/src/extension.ts`: register `ato.openRmfOverview` command opening RMF step overview webview panel
- `.github/workflows/release-vscode.yml`: CI/CD pipeline triggered on `vscode-v*` tag — npm ci → compile → vsce package → upload artifact → vsce publish (skipped on -rc tags)

## Task Issues
- #170 package.json Marketplace metadata + commands ✅
- #171 release-vscode.yml workflow ✅