### PR TITLE
fix(#132): CS0122 — promote _foundryAgentId to protected (fixes CI on main)

### DIFF
--- a/src/Ato.Copilot.Agents/Common/BaseAgent.cs
+++ b/src/Ato.Copilot.Agents/Common/BaseAgent.cs
@@ -18,7 +18,7 @@ public abstract class BaseAgent
     private readonly IChatClient? _chatClient;
     private protected readonly AzureAiOptions? _azureAiOptions;
     private protected readonly PersistentAgentsClient? _foundryClient;
-    private protected string? _foundryAgentId;
+    protected string? _foundryAgentId;
     private readonly ConcurrentDictionary<string, string> _threadMap = new();
 
     protected BaseAgent(ILogger logger)


### PR DESCRIPTION
## Owner
Cyborg (Victor Stone) — Principal AI & MCP Engineer, Justice League

## Problem Statement
CI on `main` is blocked since PR #333 merged. Every job fails at the **Build + Unit Tests** step with:

```
error CS0122: 'BaseAgent._foundryAgentId' is inaccessible due to its protection level
```

**Root cause — single declaration in `src/Ato.Copilot.Agents/Common/BaseAgent.cs` line 21:**
```csharp
private protected string? _foundryAgentId;   // ← WRONG access modifier
```

`private protected` in C# means: accessible to derived classes **in the same assembly only**.

`TestableFoundryAgent` lives in `Ato.Copilot.Tests.Unit` (a different assembly) and accesses the field directly:
```csharp
// tests/Ato.Copilot.Tests.Unit/Agents/FoundryAgentTests.cs line 347
public string? GetFoundryAgentId() => _foundryAgentId;  // CS0122
```

This is a cross-assembly derived-class access, which `private protected` explicitly prohibits.

Note: `FoundryIntegrationTestAgent` in `Ato.Copilot.Tests.Integration` correctly works around this via reflection (`NonPublic | Instance` flags), which is why that test file compiles — but the unit test file does not.

**File with defect:**
- `src/Ato.Copilot.Agents/Common/BaseAgent.cs` line 21

## Goal / Desired Outcome
CI returns to green on `main`. All 5 blocked jobs (Build + Unit Tests, Dashboard Bundle, VS Code Compile, M365, Terraform Lint) unblocked.

## Scope

**In scope:**
- One-line access modifier change: `private protected` → `protected`

**Out of scope:**
- Refactoring test access patterns
- Changing `_azureAiOptions` or `_foundryClient` (those are `private protected` but only accessed via `_options` parameter / constructor injection — no cross-assembly access needed)

## User Experience Flow
N/A — infrastructure fix.

## Functional Requirements

- **FR-001** — `BaseAgent._foundryAgentId` must be accessible to derived classes across assembly boundaries
- **FR-002** — The field must NOT be accessible to unrelated code (non-subclasses)

## Technical Design Notes

**Before:**
```csharp
private protected string? _foundryAgentId;
// Accessible to: derived classes in Ato.Copilot.Agents only
```

**After:**
```csharp
protected string? _foundryAgentId;
// Accessible to: any derived class regardless of assembly
```

`protected` is the correct modifier when a field needs to be readable by test subclasses in separate test assemblies. No behavioral change — the field is still only accessible to the class hierarchy, not to arbitrary external code.

## Architecture Decisions

| Decision | Rationale |
|---|---|
| Promote to `protected` (not `internal protected`) | `internal protected` would require test assembly to be in the same compilation unit or use `InternalsVisibleTo`. `protected` is simpler and matches the intended semantics: "subclasses can read this". |
| Single field only | `_azureAiOptions` and `_foundryClient` remain `private protected` — they are NOT directly accessed from test assemblies (the integration tests use constructor injection or reflection). |

## Acceptance Criteria

```gherkin
Feature: CI Green on Main

  Scenario: Build succeeds
    Given the fix is merged to main
    When CI runs Build + Unit Tests
    Then dotnet build succeeds with 0 errors

  Scenario: FoundryAgentTests compile
    Given BaseAgent._foundryAgentId is protected
    When TestableFoundryAgent.GetFoundryAgentId() is compiled
    Then CS0122 is not emitted
    And the accessor correctly returns the provisioned agent ID
```

## Non-Functional Requirements

- Zero behavioral change — this is purely a visibility modifier fix
- No new tests needed — existing tests exercise the path

## Test Plan

- [ ] `dotnet build` on `src/Ato.Copilot.Agents/` exits 0
- [ ] `dotnet test tests/Ato.Copilot.Tests.Unit/` — all Foundry tests pass
- [ ] `dotnet test tests/Ato.Copilot.Tests.Integration/` — all Foundry tests pass
- [ ] All 5 CI jobs go green

## Definition of Done

- [x] `private protected string? _foundryAgentId` → `protected string? _foundryAgentId` in `BaseAgent.cs`
- [x] Branch pushed: `fix/foundry-agent-cross-assembly-access`
- [x] PR open against `main`
- [ ] CI green

## Explicit Constraints

**DO NOT:**
- Change `_azureAiOptions` or `_foundryClient` visibility (not needed, would expand API surface unnecessarily)
- Add `[assembly: InternalsVisibleTo(...)]` attributes (adds coupling between test and production assemblies)
- Create a new property accessor in BaseAgent (the field promotion is the minimal correct fix)

## Anti-Patterns

- Using `private protected` for fields that test subclasses in separate assemblies must access directly
- Using reflection as a workaround in unit tests when an access modifier change is cleaner

## Existing File References

- `src/Ato.Copilot.Agents/Common/BaseAgent.cs` line 21 — field declaration **(modified: 1 character change)**
- `tests/Ato.Copilot.Tests.Unit/Agents/FoundryAgentTests.cs` line 347 — `GetFoundryAgentId() => _foundryAgentId` (not modified)
- `tests/Ato.Copilot.Tests.Integration/Agents/FoundryAgentIntegrationTests.cs` — uses reflection (not modified)

## Spec Compliance

Regression fix for Epic #132 (Azure AI Foundry Agent Path — Startup Validation).
PR #333 shipped the tests correctly but the access modifier on `_foundryAgentId` was
set to `private protected` instead of `protected`, blocking cross-assembly test subclasses.

Fixes CI regression introduced by PR #333.
