### PR TITLE
feat(#134): NIST Knowledge Base — OverlayDocument overlays, CRUD endpoints, CNSSI-1253 seed, KBMgmtPage

### DIFF
--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -98,6 +98,9 @@ public class AtoCopilotContext : DbContext
     /// <summary>NIST 800-53 Rev 5 controls loaded from OSCAL catalog.</summary>
     public DbSet<NistControl> NistControls => Set<NistControl>();
 
+    /// <summary>Command-specific overlay documents that extend NIST 800-53 baseline guidance.</summary>
+    public DbSet<OverlayDocument> OverlayDocuments => Set<OverlayDocument>();
+
     /// <summary>Audit log entries for all compliance actions (730-day retention).</summary>
     public DbSet<AuditLogEntry> AuditLogs => Set<AuditLogEntry>();
 

--- a/src/Ato.Copilot.Core/Data/Seed/OverlayDocumentSeed.cs
+++ b/src/Ato.Copilot.Core/Data/Seed/OverlayDocumentSeed.cs
@@ -1,0 +1,58 @@
+using Ato.Copilot.Core.Models.Compliance;
+
+namespace Ato.Copilot.Core.Data.Seed;
+
+/// <summary>
+/// Seed data for CNSSI-1253 SC and SI overlay guidance.
+/// These extend NIST 800-53 Rev 5 for National Security Systems.
+/// </summary>
+public static class OverlayDocumentSeed
+{
+    public static IEnumerable<OverlayDocument> GetSeedData() =>
+    [
+        new()
+        {
+            Id = Guid.Parse("10000000-0000-0000-0000-000000000001"),
+            Type = "CNSSI-1253",
+            Title = "CNSSI-1253 SC Family Overlay — System and Communications Protection",
+            ControlId = "SC-1",
+            Content = "CNSSI-1253 NSS Overlay for SC-1: Organizations operating National Security Systems must implement SC controls at the HIGH baseline. CNSS-approved cryptographic modules (FIPS 140-3 validated) are mandatory for all data in transit and at rest. Refer to CNSSI No. 1253 Annex D for NSS-specific parameter assignments.",
+            SourceReference = "CNSSI No. 1253 Annex D, SC Family",
+            IsActive = true,
+            CreatedBy = "seed"
+        },
+        new()
+        {
+            Id = Guid.Parse("10000000-0000-0000-0000-000000000002"),
+            Type = "CNSSI-1253",
+            Title = "CNSSI-1253 SI Family Overlay — System and Information Integrity",
+            ControlId = "SI-1",
+            Content = "CNSSI-1253 NSS Overlay for SI-1: National Security Systems require continuous integrity monitoring at the HIGH baseline. Anti-malware tools must be CNSS-approved. Integrity verification of software and firmware is mandatory before deployment. Refer to CNSSI No. 1253 Annex D for SI parameter assignments.",
+            SourceReference = "CNSSI No. 1253 Annex D, SI Family",
+            IsActive = true,
+            CreatedBy = "seed"
+        },
+        new()
+        {
+            Id = Guid.Parse("10000000-0000-0000-0000-000000000003"),
+            Type = "SECNAVINST",
+            Title = "SECNAVINST 5239.3C — Navy RMF Policy Overlay for AC Controls",
+            ControlId = "AC-1",
+            Content = "SECNAVINST 5239.3C requires all DON information systems to implement access control policies consistent with the DON RMF Process Guide. AC-1 must reference SECNAVINST 5239.3C as the governing authority. CIO N2/N6 is the DAA for Navy IT systems. Access control policies must be reviewed annually.",
+            SourceReference = "SECNAVINST 5239.3C, Para 5.a",
+            IsActive = true,
+            CreatedBy = "seed"
+        },
+        new()
+        {
+            Id = Guid.Parse("10000000-0000-0000-0000-000000000004"),
+            Type = "DoD-8140",
+            Title = "DoD 8140 Cyberspace Workforce Overlay for IA Controls",
+            ControlId = "AT-1",
+            Content = "DoD Instruction 8140.01 requires all DoD personnel with privileged access to information systems to hold DCWF role-qualified certifications. AT-1 policies must reference DoDI 8140.01 and specify the applicable DCWF work roles. IAT Level II or III certification required for system administrators.",
+            SourceReference = "DoDI 8140.01, Enclosure 3",
+            IsActive = true,
+            CreatedBy = "seed"
+        }
+    ];
+}

--- a/src/Ato.Copilot.Core/Migrations/20260609000001_Feature134_OverlayDocument.cs
+++ b/src/Ato.Copilot.Core/Migrations/20260609000001_Feature134_OverlayDocument.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ato.Copilot.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class Feature134_OverlayDocument : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OverlayDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    ControlId = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SourceReference = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    TenantId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OverlayDocuments", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OverlayDocuments_ControlId",
+                table: "OverlayDocuments",
+                column: "ControlId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OverlayDocuments_TenantId",
+                table: "OverlayDocuments",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OverlayDocuments_Type",
+                table: "OverlayDocuments",
+                column: "Type");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OverlayDocuments");
+        }
+    }
+}

--- a/src/Ato.Copilot.Core/Models/Compliance/OverlayDocument.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/OverlayDocument.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+/// <summary>
+/// Represents an overlay document that extends the NIST 800-53 baseline with
+/// command-specific instructions: Navy SECNAVINST/OPNAVINST, DoD 8140/8570,
+/// CNSSI-1253 NSS overlays, and NSA IA baseline controls.
+/// </summary>
+public class OverlayDocument
+{
+    /// <summary>Primary key.</summary>
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Overlay type identifier (e.g. "CNSSI-1253", "DoD-8140", "SECNAVINST").</summary>
+    [Required, MaxLength(64)]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Human-readable title for this overlay.</summary>
+    [Required, MaxLength(256)]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>The NIST control ID this overlay applies to (e.g. "AC-1").</summary>
+    [Required, MaxLength(32)]
+    public string ControlId { get; set; } = string.Empty;
+
+    /// <summary>Overlay guidance content in markdown or plain text.</summary>
+    [Required]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>Authority/source reference (e.g. "SECNAVINST 5239.3C Para 4.b").</summary>
+    [MaxLength(512)]
+    public string? SourceReference { get; set; }
+
+    /// <summary>Tenant that owns this overlay (null = platform-wide).</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Whether this overlay is active.</summary>
+    public bool IsActive { get; set; } = true;
+
+    public string CreatedBy { get; set; } = "system";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string? ModifiedBy { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+}

--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -47,6 +47,7 @@ import AzureSettingsPage from './pages/AzureSettingsPage';
 import GapAnalysis from './pages/GapAnalysis';
 import AuditLogPage from './pages/AuditLogPage';
 import AdminMigrationPage from './pages/AdminMigrationPage';
+import KnowledgeBaseManagementPage from './pages/KnowledgeBaseManagementPage';
 import LoginPage from './features/auth/LoginPage';
 import LoginCallbackPage from './features/auth/LoginCallbackPage';
 import TenantPickerPage from './features/auth/TenantPickerPage';
@@ -135,6 +136,8 @@ function AppContent() {
           <Route path="/audit" element={<RequireAuth><AuditLogPage /></RequireAuth>} />
           {/* Wave 6 GAP-017: Admin Migration */}
           <Route path="/admin/migration" element={<RequireAuth><AdminMigrationPage /></RequireAuth>} />
+          {/* Epic #134: NIST Knowledge Base */}
+          <Route path="/admin/knowledge-base" element={<RequireAuth><KnowledgeBaseManagementPage /></RequireAuth>} />
           <Route path="/controls" element={<RequireAuth><ControlsRoute /></RequireAuth>} />
           {/* Epic #208 / Task #250 — Org settings page */}
           <Route path="/settings/org" element={<RequireAuth><OrgSettingsPage /></RequireAuth>} />

--- a/src/Ato.Copilot.Dashboard/src/components/layout/PageLayout.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/layout/PageLayout.tsx
@@ -29,6 +29,8 @@ const navItems = [
   { to: '/controls', label: 'Controls' },
   // Wave 6 GAP-016
   { to: '/audit', label: 'Audit Log' },
+  // Epic #134 NIST Knowledge Base
+  { to: '/admin/knowledge-base', label: '📚 Knowledge Base' },
 ];
 
 interface PageLayoutProps {

--- a/src/Ato.Copilot.Dashboard/src/pages/KnowledgeBaseManagementPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/KnowledgeBaseManagementPage.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback } from 'react';
+import apiClient from '../api/client';
+
+interface OverlayDoc {
+  id: string;
+  type: string;
+  title: string;
+  controlId: string;
+  content: string;
+  sourceReference?: string;
+  isActive: boolean;
+  createdBy: string;
+  createdAt: string;
+}
+
+export default function KnowledgeBaseManagementPage() {
+  const [docs, setDocs] = useState<OverlayDoc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filterType, setFilterType] = useState('');
+  const [filterControl, setFilterControl] = useState('');
+  const [selected, setSelected] = useState<OverlayDoc | null>(null);
+
+  const fetchDocs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (filterType) params.set('type', filterType);
+      if (filterControl) params.set('controlId', filterControl);
+      const res = await apiClient.get<OverlayDoc[]>(
+        `/api/v1/admin/overlay-documents${params.size ? '?' + params.toString() : ''}`
+      );
+      setDocs(res.data);
+    } catch (e: unknown) {
+      setError((e as Error).message ?? 'Failed to load overlay documents');
+    } finally {
+      setLoading(false);
+    }
+  }, [filterType, filterControl]);
+
+  useEffect(() => { void fetchDocs(); }, [fetchDocs]);
+
+  const overlayTypes = ['CNSSI-1253', 'SECNAVINST', 'OPNAVINST', 'DoD-8140', 'DoD-8570'];
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">Knowledge Base Management</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Manage NIST 800-53 overlay documents: Navy Instructions, DoD Directives, CNSSI-1253 NSS overlays.
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <select
+          value={filterType}
+          onChange={e => setFilterType(e.target.value)}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+        >
+          <option value="">All Types</option>
+          {overlayTypes.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+        <input
+          type="text"
+          placeholder="Filter by control ID (e.g. AC-1)"
+          value={filterControl}
+          onChange={e => setFilterControl(e.target.value.toUpperCase())}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 w-56"
+        />
+        <button
+          onClick={() => void fetchDocs()}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Apply
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-700">{error}</div>
+      )}
+
+      {/* Table */}
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading overlay documents…</div>
+      ) : docs.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
+          <p className="text-sm text-gray-400">No overlay documents found. Add command-specific guidance above.</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Control</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Type</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Title</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Source</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white">
+              {docs.map(doc => (
+                <tr
+                  key={doc.id}
+                  onClick={() => setSelected(doc)}
+                  className="cursor-pointer hover:bg-indigo-50 transition-colors"
+                >
+                  <td className="px-4 py-3 font-mono text-indigo-700">{doc.controlId}</td>
+                  <td className="px-4 py-3">
+                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+                      {doc.type}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-900">{doc.title}</td>
+                  <td className="px-4 py-3 text-gray-500 text-xs">{doc.sourceReference ?? '—'}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      doc.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'
+                    }`}>
+                      {doc.isActive ? 'Active' : 'Inactive'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Detail drawer */}
+      {selected && (
+        <div className="fixed inset-0 z-40 bg-black/30" onClick={() => setSelected(null)}>
+          <aside
+            className="absolute right-0 top-0 h-full w-full max-w-lg bg-white shadow-2xl overflow-y-auto"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+              <h2 className="text-base font-semibold text-gray-900">{selected.title}</h2>
+              <button onClick={() => setSelected(null)} className="text-gray-400 hover:text-gray-600">
+                ×
+              </button>
+            </div>
+            <div className="p-5 space-y-4">
+              <div className="flex gap-3 text-sm">
+                <span className="font-mono text-indigo-700 bg-indigo-50 px-2 py-1 rounded">{selected.controlId}</span>
+                <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-xs font-medium">{selected.type}</span>
+              </div>
+              {selected.sourceReference && (
+                <p className="text-xs text-gray-500"><strong>Source:</strong> {selected.sourceReference}</p>
+              )}
+              <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
+                <p className="text-sm text-gray-700 whitespace-pre-wrap">{selected.content}</p>
+              </div>
+              <p className="text-xs text-gray-400">Added by {selected.createdBy} · {new Date(selected.createdAt).toLocaleDateString()}</p>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Ato.Copilot.Mcp/Endpoints/OverlayDocumentEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/OverlayDocumentEndpoints.cs
@@ -1,0 +1,129 @@
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ato.Copilot.Mcp.Endpoints;
+
+/// <summary>
+/// Admin-only CRUD endpoints for NIST control overlay documents.
+/// Overlays extend the SP 800-53 baseline with Navy, DoD, and NSS-specific guidance.
+/// </summary>
+public static class OverlayDocumentEndpoints
+{
+    public static IEndpointRouteBuilder MapOverlayDocumentEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/admin/overlay-documents")
+            .WithTags("OverlayDocuments")
+            .RequireAuthorization("AdminOnly");
+
+        group.MapGet("/", async (
+                string? controlId,
+                string? type,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var query = db.OverlayDocuments.Where(o => o.IsActive);
+            if (!string.IsNullOrEmpty(controlId))
+                query = query.Where(o => o.ControlId == controlId.ToUpperInvariant());
+            if (!string.IsNullOrEmpty(type))
+                query = query.Where(o => o.Type == type);
+
+            var items = await query
+                .OrderBy(o => o.ControlId).ThenBy(o => o.Type)
+                .Select(o => new OverlayDocumentDto(o))
+                .ToListAsync(ct);
+            return Results.Ok(items);
+        }).WithName("ListOverlayDocuments");
+
+        group.MapGet("/{id:guid}", async (
+                Guid id,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var doc = await db.OverlayDocuments.FindAsync([id], ct);
+            return doc is null ? Results.NotFound() : Results.Ok(new OverlayDocumentDto(doc));
+        }).WithName("GetOverlayDocument");
+
+        group.MapPost("/", async (
+                CreateOverlayDocumentRequest req,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var doc = new OverlayDocument
+            {
+                Type = req.Type,
+                Title = req.Title,
+                ControlId = req.ControlId.ToUpperInvariant(),
+                Content = req.Content,
+                SourceReference = req.SourceReference,
+                TenantId = req.TenantId,
+                IsActive = true,
+                CreatedBy = "admin"
+            };
+            db.OverlayDocuments.Add(doc);
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/api/v1/admin/overlay-documents/{doc.Id}", new OverlayDocumentDto(doc));
+        }).WithName("CreateOverlayDocument");
+
+        group.MapPut("/{id:guid}", async (
+                Guid id,
+                UpdateOverlayDocumentRequest req,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var doc = await db.OverlayDocuments.FindAsync([id], ct);
+            if (doc is null) return Results.NotFound();
+
+            doc.Title = req.Title ?? doc.Title;
+            doc.Content = req.Content ?? doc.Content;
+            doc.SourceReference = req.SourceReference ?? doc.SourceReference;
+            doc.IsActive = req.IsActive ?? doc.IsActive;
+            doc.ModifiedBy = "admin";
+            doc.ModifiedAt = DateTime.UtcNow;
+
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(new OverlayDocumentDto(doc));
+        }).WithName("UpdateOverlayDocument");
+
+        group.MapDelete("/{id:guid}", async (
+                Guid id,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+        {
+            var doc = await db.OverlayDocuments.FindAsync([id], ct);
+            if (doc is null) return Results.NotFound();
+            doc.IsActive = false;
+            doc.ModifiedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return Results.NoContent();
+        }).WithName("DeleteOverlayDocument");
+
+        return app;
+    }
+}
+
+public record OverlayDocumentDto(Guid Id, string Type, string Title, string ControlId,
+    string Content, string? SourceReference, Guid? TenantId, bool IsActive,
+    string CreatedBy, DateTime CreatedAt, string? ModifiedBy, DateTime? ModifiedAt)
+{
+    public OverlayDocumentDto(OverlayDocument o)
+        : this(o.Id, o.Type, o.Title, o.ControlId, o.Content, o.SourceReference,
+               o.TenantId, o.IsActive, o.CreatedBy, o.CreatedAt, o.ModifiedBy, o.ModifiedAt) { }
+}
+
+public record CreateOverlayDocumentRequest(
+    string Type,
+    string Title,
+    string ControlId,
+    string Content,
+    string? SourceReference,
+    Guid? TenantId);
+
+public record UpdateOverlayDocumentRequest(
+    string? Title,
+    string? Content,
+    string? SourceReference,
+    bool? IsActive);


### PR DESCRIPTION
Closes #134
Closes #179

## Changes
**Backend:**
- `OverlayDocument.cs` entity: Type, Title, ControlId, Content, SourceReference, TenantId, IsActive
- EF migration `Feature134_OverlayDocument`: creates OverlayDocuments table with indexes on ControlId, TenantId, Type
- `AtoCopilotContext.cs`: adds `DbSet<OverlayDocument> OverlayDocuments`
- `OverlayDocumentEndpoints.cs`: Admin-only CRUD (GET list/detail, POST, PUT, DELETE soft)
- `OverlayDocumentSeed.cs`: 4 seed records (CNSSI-1253 SC-1/SI-1, SECNAVINST AC-1, DoD-8140 AT-1)

**Frontend:**
- `KnowledgeBaseManagementPage.tsx`: filterable overlay document table with type/control filters + detail drawer
- `App.tsx`: `/admin/knowledge-base` route
- `PageLayout.tsx`: Knowledge Base nav link

## Task Issues
- #179 OverlayDocument entity + CRUD + KBMgmtPage ✅