### PR TITLE
feat(#87-#95): Feature 051 Wave 8 — Login & Auth UX (US1-US9)

### DIFF
--- a/extensions/vscode/src/auth/switchTenantCommand.ts
+++ b/extensions/vscode/src/auth/switchTenantCommand.ts
@@ -1,22 +1,11 @@
-// Feature 051 — VS Code Device-Code Sign-In (T107)
+// Feature 051 — VS Code Device-Code Sign-In (T107 / T108)
 // Contract: specs/051-login/contracts/vscode-extension.md § 3.4
 //
-// `ato.switchTenant` command:
-//   1. Build a QuickPick of tenants the user can switch to.
-//      Sources: (a) tenants we have persisted secrets for in this workspace
-//      (`listKnownTenantsAsync`), and (b) an "Add another tenant…" item that
-//      runs a fresh device-code flow for a new authority.
-//   2. On selection of a known tenant, re-run sign-in with `preferTenantId`
-//      set to the chosen tenant so silent renewal is attempted first.
-//   3. On selection of "Add another tenant…", prompt for the tenant id and
-//      re-run sign-in against `https://login.microsoftonline.{cloud}/<id>`.
-//   4. The previously-active tenant's secrets are NOT deleted (FR-019).
+// VS Code entry-point for `ato.switchTenant`. Binds live VS Code APIs to the
+// pure `runSwitchTenant` core in `switchTenantCore.ts`.
 //
-// NOTE: The server-side `/api/auth/me` response does not enumerate a user's
-// tenant memberships, so we cannot show "every tenant you could pick". The
-// QuickPick is therefore scoped to (a) cached tenants + (b) manual entry,
-// which is the operational reality for VS Code (device-code is a per-tenant
-// grant).
+// See switchTenantCore.ts for documentation on the switch-tenant flow and the
+// DI seam used for unit testing (T108).
 
 import * as vscode from "vscode";
 import { PublicClientApplication } from "@azure/msal-node";
@@ -31,13 +20,20 @@ import {
   readServerBaseUrl,
   fetchActiveTenant,
 } from "./signInCommand";
-import {
-  runDeviceCodeSignIn,
-  type SignInResult,
-} from "./signInCore";
+import { runDeviceCodeSignIn } from "./signInCore";
+import type { SignInDependencies, SignInResult } from "./signInCore";
 import type { SignInStatusBar } from "./statusBar";
+import {
+  runSwitchTenant,
+  rewriteAuthorityTenant,
+  type TenantPickItem,
+  type SwitchTenantDependencies,
+} from "./switchTenantCore";
 
-const ADD_TENANT_ITEM_ID = "__add_tenant__";
+// Re-export the pure helpers so callers that import from this module continue
+// to work without a code-path change.
+export { runSwitchTenant, rewriteAuthorityTenant };
+export type { TenantPickItem, SwitchTenantDependencies };
 
 export async function switchTenantCommand(
   context: vscode.ExtensionContext,
@@ -45,35 +41,37 @@ export async function switchTenantCommand(
   outputChannel?: vscode.OutputChannel,
 ): Promise<SignInResult | { outcome: "cancelled" }> {
   const log = (msg: string) => outputChannel?.appendLine(msg);
-  const known = await listKnownTenantsAsync(context);
-  const active = getActiveTenantId(context);
-
-  const items: vscode.QuickPickItem[] = known.map((id) => ({
-    label: shortTenantLabel(id),
-    description: id === active ? "(active)" : undefined,
-    detail: id,
-  }));
-  items.push({
-    label: "$(add) Sign in to another tenant…",
-    detail: ADD_TENANT_ITEM_ID,
-  });
-
-  const picked = await vscode.window.showQuickPick(items, {
-    placeHolder: "Choose an ATO Copilot tenant",
-    ignoreFocusOut: true,
-  });
-  if (!picked) {
-    return { outcome: "cancelled" };
-  }
-
   const serverBaseUrl = readServerBaseUrl();
 
-  // --- Switch to a previously-cached tenant ---
-  if (picked.detail && picked.detail !== ADD_TENANT_ITEM_ID) {
-    const targetTenantId = picked.detail;
-    return runDeviceCodeSignIn({
+  return runSwitchTenant({
+    context,
+    listKnownTenants: () => listKnownTenantsAsync(context),
+    getActiveTenantId: (ctx) => getActiveTenantId(ctx as vscode.ExtensionContext),
+    showQuickPick: async (items: TenantPickItem[]) => {
+      const result = await vscode.window.showQuickPick(items, {
+        placeHolder: "Choose an ATO Copilot tenant",
+        ignoreFocusOut: true,
+      });
+      return result as TenantPickItem | undefined;
+    },
+    showInputBox: async () => {
+      return await vscode.window.showInputBox({
+        title: "Sign in to another ATO Copilot tenant",
+        prompt:
+          "Enter the Entra tenant id (GUID) to sign in against. The previous tenant's session is kept.",
+        placeHolder: "00000000-0000-0000-0000-000000000000",
+        validateInput: (value) =>
+          /^[0-9a-fA-F-]{32,36}$/.test(value.trim())
+            ? undefined
+            : "Enter a valid GUID.",
+        ignoreFocusOut: true,
+      });
+    },
+    fetchLoginConfig: () => fetchLoginConfig(serverBaseUrl),
+    runSignIn: (signInDeps) => runDeviceCodeSignIn(signInDeps),
+    buildSignInDeps: (overrideFetch, preferTenantId): SignInDependencies => ({
       context,
-      fetchLoginConfig: () => fetchLoginConfig(serverBaseUrl),
+      fetchLoginConfig: overrideFetch ?? (() => fetchLoginConfig(serverBaseUrl)),
       fetchActiveTenant: (token) => fetchActiveTenant(token, serverBaseUrl),
       createPca: (config, msalLog) =>
         new PublicClientApplication(
@@ -86,88 +84,7 @@ export async function switchTenantCommand(
       writeClipboard: (text) => vscode.env.clipboard.writeText(text),
       updateStatusBar: (state) => statusBar.update(state),
       log,
-      preferTenantId: targetTenantId,
-    });
-  }
-
-  // --- "Sign in to another tenant…" — prompt for the new tenant id ---
-  const newTenantId = await vscode.window.showInputBox({
-    title: "Sign in to another ATO Copilot tenant",
-    prompt:
-      "Enter the Entra tenant id (GUID) to sign in against. The previous tenant's session is kept.",
-    placeHolder: "00000000-0000-0000-0000-000000000000",
-    validateInput: (value) =>
-      /^[0-9a-fA-F-]{32,36}$/.test(value.trim())
-        ? undefined
-        : "Enter a valid GUID.",
-    ignoreFocusOut: true,
+      preferTenantId,
+    }),
   });
-  if (!newTenantId) {
-    return { outcome: "cancelled" };
-  }
-  const trimmed = newTenantId.trim();
-
-  // We rewrite the authority on the way in by patching the fetched
-  // login-config. The cloud value comes from the server (single source of
-  // truth) — the validator in `runDeviceCodeSignIn` checks the device-code
-  // URL against THAT cloud.
-  return runDeviceCodeSignIn({
-    context,
-    fetchLoginConfig: async () => {
-      const cfg = await fetchLoginConfig(serverBaseUrl);
-      return {
-        ...cfg,
-        authority: rewriteAuthorityTenant(cfg.authority, trimmed),
-      };
-    },
-    fetchActiveTenant: async (token) => {
-      // The orchestrator's `finalizeSuccess` writes the per-tenant
-      // secrets + active-tenant id, so this lambda only resolves the
-      // tenant from the freshly-acquired bearer.
-      return fetchActiveTenant(token, serverBaseUrl);
-    },
-    createPca: (config, msalLog) =>
-      new PublicClientApplication(
-        buildMsalNodeConfig(config, { debug: msalLog }),
-      ),
-    showInfoMessage: (msg, ...actions) =>
-      vscode.window.showInformationMessage(msg, ...actions),
-    showErrorMessage: (msg) => vscode.window.showErrorMessage(msg),
-    openExternal: (uri) => vscode.env.openExternal(vscode.Uri.parse(uri)),
-    writeClipboard: (text) => vscode.env.clipboard.writeText(text),
-    updateStatusBar: (state) => statusBar.update(state),
-    log,
-    // Intentionally no preferTenantId — this path is "sign in to a NEW
-    // tenant", so silent renewal must NOT short-circuit it.
-  });
-}
-
-function shortTenantLabel(id: string): string {
-  return id.length > 8 ? `Tenant ${id.slice(0, 8)}…` : `Tenant ${id}`;
-}
-
-/**
- * Replace the tenant segment in an authority URL. Accepts both
- * `https://login.microsoftonline.com/<tid>` and
- * `https://login.microsoftonline.us/<tid>`; leaves the cloud host alone.
- */
-export function rewriteAuthorityTenant(
-  authority: string,
-  newTenantId: string,
-): string {
-  try {
-    const u = new URL(authority);
-    // path of the form /<tenant>/[...]
-    const segments = u.pathname.split("/").filter((s) => s.length > 0);
-    if (segments.length === 0) {
-      u.pathname = `/${newTenantId}`;
-    } else {
-      segments[0] = newTenantId;
-      u.pathname = `/${segments.join("/")}`;
-    }
-    return u.toString().replace(/\/$/, "");
-  } catch {
-    // Fall back to a best-effort string rewrite when authority is malformed.
-    return authority.replace(/\/[0-9a-fA-F-]{32,36}/, `/${newTenantId}`);
-  }
 }

--- a/extensions/vscode/src/auth/switchTenantCore.ts
+++ b/extensions/vscode/src/auth/switchTenantCore.ts
@@ -1,0 +1,130 @@
+// Feature 051 — VS Code `ato.switchTenant` — pure orchestration core (T108)
+// Contract: specs/051-login/contracts/vscode-extension.md § 3.4
+//
+// Pure module — no `vscode` imports. Safe to unit-test from plain Node mocha.
+// `switchTenantCommand.ts` is the thin VS Code wrapper that binds the seam.
+// Mirrors the signInCore.ts / signInCommand.ts split pattern.
+
+import type { VsCodeLoginConfig } from "./msalNode";
+import type { SecretStorageContext } from "./secretStorage";
+import type { SignInDependencies, SignInResult } from "./signInCore";
+
+const ADD_TENANT_ITEM_ID = "__add_tenant__";
+
+// ─── DI seam types ──────────────────────────────────────────────────────────
+
+/** Single QuickPick item shape. */
+export interface TenantPickItem {
+  label: string;
+  description?: string;
+  detail?: string;
+}
+
+/**
+ * Injectable dependencies for `runSwitchTenant`. VS Code APIs are never
+ * referenced here — the production wrapper in `switchTenantCommand.ts`
+ * resolves them from the live extension context.
+ */
+export interface SwitchTenantDependencies {
+  context: SecretStorageContext;
+  listKnownTenants: () => Promise<string[]>;
+  getActiveTenantId: (ctx: SecretStorageContext) => string | undefined;
+  showQuickPick: (items: TenantPickItem[]) => Promise<TenantPickItem | undefined>;
+  showInputBox: () => Promise<string | undefined>;
+  fetchLoginConfig: () => Promise<VsCodeLoginConfig>;
+  runSignIn: (
+    deps: SignInDependencies,
+  ) => Promise<SignInResult | { outcome: "cancelled" }>;
+  buildSignInDeps: (
+    overrideFetchLoginConfig?: SignInDependencies["fetchLoginConfig"],
+    preferTenantId?: string,
+  ) => SignInDependencies;
+}
+
+// ─── Core orchestration ─────────────────────────────────────────────────────
+
+/**
+ * Pure orchestration logic for the tenant-switch flow. VS Code-free; suitable
+ * for direct unit testing (T108 acceptance). Called by `switchTenantCommand`.
+ */
+export async function runSwitchTenant(
+  deps: SwitchTenantDependencies,
+): Promise<SignInResult | { outcome: "cancelled" }> {
+  const known = await deps.listKnownTenants();
+  const active = deps.getActiveTenantId(deps.context);
+
+  const items: TenantPickItem[] = known.map((id) => ({
+    label: shortTenantLabel(id),
+    description: id === active ? "(active)" : undefined,
+    detail: id,
+  }));
+  items.push({
+    label: "$(add) Sign in to another tenant…",
+    detail: ADD_TENANT_ITEM_ID,
+  });
+
+  const picked = await deps.showQuickPick(items);
+  if (!picked) {
+    return { outcome: "cancelled" };
+  }
+
+  // --- Switch to a previously-cached tenant ---
+  if (picked.detail && picked.detail !== ADD_TENANT_ITEM_ID) {
+    const targetTenantId = picked.detail;
+    return deps.runSignIn(deps.buildSignInDeps(undefined, targetTenantId));
+  }
+
+  // --- "Sign in to another tenant…" — prompt for the new tenant id ---
+  const newTenantId = await deps.showInputBox();
+  if (!newTenantId) {
+    return { outcome: "cancelled" };
+  }
+  const trimmed = newTenantId.trim();
+
+  // Rewrite the authority fetched from the server to the chosen tenant.
+  // The cloud value comes from the server (single source of truth) — the
+  // validator in `runDeviceCodeSignIn` checks the device-code URL against it.
+  const overrideFetch: SignInDependencies["fetchLoginConfig"] = async () => {
+    const cfg = await deps.fetchLoginConfig();
+    return {
+      ...cfg,
+      authority: rewriteAuthorityTenant(cfg.authority, trimmed),
+    };
+  };
+
+  // Intentionally no preferTenantId — fresh sign-in to a NEW tenant must
+  // NOT short-circuit via silent renewal (FR-019).
+  return deps.runSignIn(deps.buildSignInDeps(overrideFetch, undefined));
+}
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
+
+function shortTenantLabel(id: string): string {
+  return id.length > 8 ? `Tenant ${id.slice(0, 8)}…` : `Tenant ${id}`;
+}
+
+/**
+ * Replace the tenant segment in an authority URL. Accepts both
+ * `https://login.microsoftonline.com/<tid>` and
+ * `https://login.microsoftonline.us/<tid>`; leaves the cloud host alone.
+ */
+export function rewriteAuthorityTenant(
+  authority: string,
+  newTenantId: string,
+): string {
+  try {
+    const u = new URL(authority);
+    // path of the form /<tenant>/[...]
+    const segments = u.pathname.split("/").filter((s) => s.length > 0);
+    if (segments.length === 0) {
+      u.pathname = `/${newTenantId}`;
+    } else {
+      segments[0] = newTenantId;
+      u.pathname = `/${segments.join("/")}`;
+    }
+    return u.toString().replace(/\/$/, "");
+  } catch {
+    // Fall back to a best-effort string rewrite when authority is malformed.
+    return authority.replace(/\/[0-9a-fA-F-]{32,36}/, `/${newTenantId}`);
+  }
+}

--- a/extensions/vscode/test/auth/switchTenantCommand.test.ts
+++ b/extensions/vscode/test/auth/switchTenantCommand.test.ts
@@ -1,0 +1,317 @@
+// Feature 051 — VS Code `ato.switchTenant` command tests (T108 RED → GREEN)
+// Contract: specs/051-login/contracts/vscode-extension.md § 3.4
+//
+// Tests the pure `runSwitchTenant(deps)` orchestrator in `switchTenantCore.ts`
+// via its DI seam — no VS Code Extension Host required.
+// Mirrors the pattern from `signInCommand.test.ts` (T104) which tests
+// `runDeviceCodeSignIn` from `signInCore.ts` directly.
+//
+// Behaviours pinned:
+//   1. QuickPick dismissed  → { outcome: "cancelled" }; runSignIn not called.
+//   2. Known tenant selected → runSignIn called with preferTenantId set.
+//   3. Active tenant marked "(active)" in the picker list.
+//   4. Inactive tenant NOT marked "(active)".
+//   5. "Add another tenant…" → InputBox dismissed → { outcome: "cancelled" }.
+//   6. "Add another tenant…" → tenant id entered → runSignIn called without
+//      preferTenantId; override fetchLoginConfig rewrites the authority.
+// Additionally covers `rewriteAuthorityTenant` (pure function, no stubs).
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import {
+  runSwitchTenant,
+  rewriteAuthorityTenant,
+  type SwitchTenantDependencies,
+  type TenantPickItem,
+} from "../../src/auth/switchTenantCore";
+import type { SignInDependencies, SignInResult } from "../../src/auth/signInCore";
+import type { SecretStorageContext } from "../../src/auth/secretStorage";
+import type { VsCodeLoginConfig } from "../../src/auth/msalNode";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const NEW_TENANT = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const SERVER_URL = "http://localhost:5000";
+
+function makeContext(): SecretStorageContext {
+  const secretsMap = new Map<string, string>();
+  const stateMap = new Map<string, unknown>();
+  return {
+    secrets: {
+      get: async (k: string) => secretsMap.get(k),
+      store: async (k: string, v: string) => { secretsMap.set(k, v); },
+      delete: async (k: string) => { secretsMap.delete(k); },
+    },
+    workspaceState: {
+      get: <T,>(k: string): T | undefined => stateMap.get(k) as T | undefined,
+      update: async (k: string, v: unknown) => {
+        if (v === undefined) stateMap.delete(k);
+        else stateMap.set(k, v);
+      },
+    },
+  };
+}
+
+function makeLoginConfig(authorityTenantId: string = TENANT_A): VsCodeLoginConfig {
+  return {
+    clientId: "test-client-id",
+    authority: `https://login.microsoftonline.com/${authorityTenantId}`,
+    scopes: ["api://ato-copilot/.default"],
+    serverBaseUrl: SERVER_URL,
+    cloud: "AzurePublic",
+  };
+}
+
+interface HarnessOptions {
+  knownTenants?: string[];
+  activeTenantId?: string | undefined;
+  quickPickResult?: TenantPickItem | undefined;
+  inputBoxResult?: string | undefined;
+  loginConfig?: VsCodeLoginConfig;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const context = makeContext();
+  const capturedSignInDeps: SignInDependencies[] = [];
+
+  const listKnownTenants = sinon.stub().resolves(options.knownTenants ?? [TENANT_A, TENANT_B]);
+  const getActiveTenantIdStub = sinon.stub().returns(options.activeTenantId ?? TENANT_A);
+  const showQuickPick = sinon.stub().resolves(options.quickPickResult);
+  const showInputBox = sinon.stub().resolves(options.inputBoxResult);
+  const fetchLoginConfig = sinon.stub().resolves(options.loginConfig ?? makeLoginConfig());
+
+  const runSignIn = sinon.stub().callsFake(async (deps: SignInDependencies) => {
+    capturedSignInDeps.push(deps);
+    return {
+      outcome: "signedIn" as const,
+      tenantId: deps.preferTenantId ?? NEW_TENANT,
+    };
+  });
+
+  const buildSignInDeps = sinon.stub().callsFake(
+    (overrideFetch?: SignInDependencies["fetchLoginConfig"], preferTenantId?: string): SignInDependencies => ({
+      context,
+      fetchLoginConfig: overrideFetch ?? fetchLoginConfig,
+      fetchActiveTenant: async () => ({ id: preferTenantId ?? TENANT_A, displayName: "Test" }),
+      createPca: () => ({
+        acquireTokenSilent: sinon.stub().resolves(null),
+        acquireTokenByDeviceCode: sinon.stub().resolves(null),
+      }),
+      showInfoMessage: sinon.stub().resolves(undefined),
+      showErrorMessage: sinon.stub().resolves(undefined),
+      openExternal: sinon.stub().resolves(true),
+      writeClipboard: sinon.stub().resolves(),
+      updateStatusBar: sinon.stub(),
+      log: () => { /* noop */ },
+      preferTenantId,
+    }),
+  );
+
+  const deps: SwitchTenantDependencies = {
+    context,
+    listKnownTenants,
+    getActiveTenantId: getActiveTenantIdStub,
+    showQuickPick,
+    showInputBox,
+    fetchLoginConfig,
+    runSignIn,
+    buildSignInDeps,
+  };
+
+  return {
+    deps,
+    listKnownTenants,
+    getActiveTenantIdStub,
+    showQuickPick,
+    showInputBox,
+    fetchLoginConfig,
+    runSignIn,
+    buildSignInDeps,
+    capturedSignInDeps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — runSwitchTenant orchestration
+// ---------------------------------------------------------------------------
+
+describe("Feature 051 — auth/switchTenantCore (T108)", () => {
+
+  // ─── 1. QuickPick cancelled ──────────────────────────────────────────────
+
+  it("returns { outcome: 'cancelled' } and never calls runSignIn when QuickPick is dismissed", async () => {
+    const { deps, runSignIn } = makeHarness({ quickPickResult: undefined });
+
+    const result = await runSwitchTenant(deps);
+
+    expect(result).to.deep.equal({ outcome: "cancelled" });
+    expect(runSignIn.called).to.be.false;
+  });
+
+  // ─── 2. Known tenant selected ────────────────────────────────────────────
+
+  it("calls runSignIn with preferTenantId set when a known tenant is selected", async () => {
+    const item: TenantPickItem = {
+      label: `Tenant ${TENANT_B.slice(0, 8)}…`,
+      detail: TENANT_B,
+    };
+    const { deps, runSignIn, buildSignInDeps } = makeHarness({ quickPickResult: item });
+
+    const result = (await runSwitchTenant(deps)) as SignInResult;
+
+    expect(result.outcome).to.equal("signedIn");
+    expect(result.tenantId).to.equal(TENANT_B);
+    expect(runSignIn.calledOnce).to.be.true;
+    const [, preferTenantId] = buildSignInDeps.firstCall.args as [unknown, string];
+    expect(preferTenantId).to.equal(TENANT_B);
+  });
+
+  // ─── 3. Active-tenant label ──────────────────────────────────────────────
+
+  it("marks the active tenant with description '(active)' in the QuickPick items", async () => {
+    const { deps, showQuickPick } = makeHarness({
+      activeTenantId: TENANT_A,
+      quickPickResult: undefined,
+    });
+
+    await runSwitchTenant(deps);
+
+    const items = showQuickPick.firstCall.args[0] as TenantPickItem[];
+    const activeTenantItem = items.find((i) => i.detail === TENANT_A);
+    expect(activeTenantItem).to.not.be.undefined;
+    expect(activeTenantItem!.description).to.equal("(active)");
+  });
+
+  it("does NOT mark inactive tenants with '(active)'", async () => {
+    const { deps, showQuickPick } = makeHarness({
+      activeTenantId: TENANT_A,
+      quickPickResult: undefined,
+    });
+
+    await runSwitchTenant(deps);
+
+    const items = showQuickPick.firstCall.args[0] as TenantPickItem[];
+    const inactiveItem = items.find((i) => i.detail === TENANT_B);
+    expect(inactiveItem).to.not.be.undefined;
+    expect(inactiveItem!.description).to.be.undefined;
+  });
+
+  // ─── 4. "Add another tenant…" — InputBox cancelled ──────────────────────
+
+  it("returns { outcome: 'cancelled' } when InputBox is dismissed on the add-tenant path", async () => {
+    const addTenantItem: TenantPickItem = {
+      label: "$(add) Sign in to another tenant…",
+      detail: "__add_tenant__",
+    };
+    const { deps, runSignIn } = makeHarness({
+      quickPickResult: addTenantItem,
+      inputBoxResult: undefined,
+    });
+
+    const result = await runSwitchTenant(deps);
+
+    expect(result).to.deep.equal({ outcome: "cancelled" });
+    expect(runSignIn.called).to.be.false;
+  });
+
+  // ─── 5. "Add another tenant…" — new tenant id entered ───────────────────
+
+  it("calls runSignIn WITHOUT preferTenantId when a new tenant id is entered", async () => {
+    const addTenantItem: TenantPickItem = {
+      label: "$(add) Sign in to another tenant…",
+      detail: "__add_tenant__",
+    };
+    const { deps, runSignIn, buildSignInDeps } = makeHarness({
+      quickPickResult: addTenantItem,
+      inputBoxResult: NEW_TENANT,
+    });
+
+    await runSwitchTenant(deps);
+
+    expect(runSignIn.calledOnce).to.be.true;
+    const [overrideFetch, preferTenantId] = buildSignInDeps.firstCall.args as [
+      SignInDependencies["fetchLoginConfig"] | undefined,
+      string | undefined,
+    ];
+    // preferTenantId MUST be undefined (new tenant = fresh sign-in, no silent renewal)
+    expect(preferTenantId).to.be.undefined;
+    // An override fetchLoginConfig MUST be supplied to rewrite the authority
+    expect(overrideFetch).to.be.a("function");
+  });
+
+  it("rewrites the authority to the new tenant id in the override fetchLoginConfig", async () => {
+    const addTenantItem: TenantPickItem = {
+      label: "$(add) Sign in to another tenant…",
+      detail: "__add_tenant__",
+    };
+    const originalConfig = makeLoginConfig(TENANT_A);
+    const { deps, buildSignInDeps } = makeHarness({
+      quickPickResult: addTenantItem,
+      inputBoxResult: NEW_TENANT,
+      loginConfig: originalConfig,
+    });
+
+    await runSwitchTenant(deps);
+
+    const [overrideFetch] = buildSignInDeps.firstCall.args as [
+      SignInDependencies["fetchLoginConfig"],
+    ];
+    // Invoke the override and verify the authority has been rewritten.
+    const cfg = await overrideFetch(originalConfig.serverBaseUrl);
+    expect(cfg.authority).to.include(NEW_TENANT);
+    expect(cfg.authority).to.not.include(TENANT_A);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteAuthorityTenant — pure function; no stubs required
+// ---------------------------------------------------------------------------
+
+describe("rewriteAuthorityTenant", () => {
+  const NEW_TID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+  it("rewrites AzurePublic authority", () => {
+    const result = rewriteAuthorityTenant(
+      `https://login.microsoftonline.com/${TENANT_A}`,
+      NEW_TID,
+    );
+    expect(result).to.equal(`https://login.microsoftonline.com/${NEW_TID}`);
+  });
+
+  it("rewrites AzureUSGovernment authority", () => {
+    const result = rewriteAuthorityTenant(
+      `https://login.microsoftonline.us/${TENANT_A}`,
+      NEW_TID,
+    );
+    expect(result).to.equal(`https://login.microsoftonline.us/${NEW_TID}`);
+  });
+
+  it("handles authorities with a trailing path segment", () => {
+    const result = rewriteAuthorityTenant(
+      `https://login.microsoftonline.com/${TENANT_A}/v2.0`,
+      NEW_TID,
+    );
+    expect(result).to.include(NEW_TID);
+    expect(result).to.include("/v2.0");
+    expect(result).to.not.include(TENANT_A);
+  });
+
+  it("handles authority with no existing tenant path segment", () => {
+    const result = rewriteAuthorityTenant(
+      "https://login.microsoftonline.com",
+      NEW_TID,
+    );
+    expect(result).to.include(NEW_TID);
+  });
+
+  it("falls back gracefully for a malformed authority URL string", () => {
+    const malformed = `not-a-url/${TENANT_A}`;
+    const result = rewriteAuthorityTenant(malformed, NEW_TID);
+    expect(result).to.include(NEW_TID);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 8 — Feature 051 Login & Auth UX — formal closing PR for US1–US9.

All backend endpoints and frontend components were implemented and merged to `main` in earlier waves. This PR completes the formal Wave 8 scope by:

1. **Adding T108 test coverage** for `ato.switchTenant` (US5 / FR-019) — the one gap in the existing auth test suite.
2. **Refactoring `switchTenantCommand.ts`** to extract pure orchestration into `switchTenantCore.ts`, mirroring the `signInCore.ts` / `signInCommand.ts` split so the core logic is VS Code-free and directly unit-testable.

### Test results

```
Feature 051 — auth/switchTenantCore (T108)
  ✔ returns { outcome: 'cancelled' } and never calls runSignIn when QuickPick is dismissed
  ✔ calls runSignIn with preferTenantId set when a known tenant is selected
  ✔ marks the active tenant with description '(active)' in the QuickPick items
  ✔ does NOT mark inactive tenants with '(active)'
  ✔ returns { outcome: 'cancelled' } when InputBox is dismissed on the add-tenant path
  ✔ calls runSignIn WITHOUT preferTenantId when a new tenant id is entered
  ✔ rewrites the authority to the new tenant id in the override fetchLoginConfig

rewriteAuthorityTenant
  ✔ rewrites AzurePublic authority
  ✔ rewrites AzureUSGovernment authority
  ✔ handles authorities with a trailing path segment
  ✔ handles authority with no existing tenant path segment
  ✔ falls back gracefully for a malformed authority URL string

12 passing (43ms)
```

### Issues closed

Closes #87 (US1 — First-Time Login from the Dashboard)
Closes #88 (US2 — Sign Out and Idle Sign-Out)
Closes #89 (US3 — Tenant / Organization Picker on Login)
Closes #90 (US4 — Login Error States)
Closes #91 (US5 — Login from VS Code Extension)
Closes #92 (US6 — Login from M365 / Teams Bot)
Closes #93 (US7 — Dev Simulation Login Without Restart)
Closes #94 (US8 — CSP-Admin Tenant Switching Mid-Session)
Closes #95 (US9 — Account Menu and Profile Surface)

> **Note:** #96 (US10 — Audit Trail) is held pending Cyborg's `LoginAuditService` fix (#98). US10 will ship in a follow-on PR once his fix merges.

### Spec Compliance

- FR-017 / FR-018 / FR-019: VS Code device-code sign-in, SecretStorage persistence, `@ato sign out` — code-complete T101–T110, T108 tests green.
- FR-020 / FR-021 / FR-022: M365 Teams bot auth dispatcher — code-complete T112–T118.
- FR-023 / FR-024 / FR-025: Dev simulation panel, `POST /api/auth/simulate`, `X-Simulated` cookie — code-complete.
- FR-008 / FR-009 / FR-012: Sign-out + idle sign-out + tenant picker + remember cookie — code-complete.
- FR-030 / FR-031: Account menu + PIM role countdown — code-complete.
