### PR TITLE
feat(#203): UF-019 — Admin Multi-Tenant Migration Guard

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/__tests__/AdminMigrationPage.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/AdminMigrationPage.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * UF-019 — AdminMigrationPage: typed-confirmation guard tests.
+ *
+ * Validates that the Confirm Migration button is:
+ *   - disabled until BOTH the name input matches AND the checkbox is checked
+ *   - enabled only once both conditions are met
+ *   - disabled again if either condition is un-satisfied
+ *
+ * Also validates the API call sends the X-Admin-Confirm-Migration header.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { LoginConfig } from '../features/auth/types';
+import AdminMigrationPage from '../pages/AdminMigrationPage';
+
+const DEPLOYMENT_NAME = 'ACME ATO Copilot';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../features/auth/LoginConfigContext', () => ({
+  useLoginConfig: (): LoginConfig => ({
+    branding: {
+      deploymentName: DEPLOYMENT_NAME,
+      logoUrl: null,
+      supportEmail: null,
+    },
+    defaultMethod: 'Cac',
+    enabledMethods: [{ id: 'Cac', displayName: 'Sign in with CAC/PIV' }],
+    cloud: 'AzureUSGovernment',
+    idleTimeoutMinutes: 30,
+    rememberTenantCookieDays: 30,
+    simulation: null,
+    msal: {
+      clientId: 'cid',
+      authority: 'https://login.microsoftonline.us/tid',
+      redirectUri: 'http://localhost/login/callback',
+      postLogoutRedirectUri: 'http://localhost/login',
+    },
+  }),
+}));
+
+vi.mock('../components/layout/PageLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../components/layout/PageHero', () => ({
+  default: () => <div data-testid="page-hero" />,
+}));
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const PREVIEW_WITH_MISSING = {
+  data: {
+    tables: [
+      {
+        tableName: 'ControlImplementations',
+        totalRows: 100,
+        rowsMissingTenant: 50,
+        rowsAssignedByOverride: 0,
+        rowsAssignedToDefault: 0,
+      },
+    ],
+  },
+};
+
+async function renderAndOpenConfirm() {
+  mockGet.mockResolvedValue(PREVIEW_WITH_MISSING);
+  render(<AdminMigrationPage />);
+
+  // Wait for preview to load.
+  await waitFor(() => expect(screen.getByText('ControlImplementations')).toBeDefined());
+
+  // Open the confirmation panel.
+  const migrateBtn = screen.getByRole('button', { name: /migrate to multitenant/i });
+  fireEvent.click(migrateBtn);
+
+  return screen.getByRole('button', { name: /confirm migration/i }) as HTMLButtonElement;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('AdminMigrationPage — UF-019 typed-confirmation guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the Confirm button as disabled when the panel first opens', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    expect(confirmBtn.disabled).toBe(true);
+    expect(confirmBtn.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('keeps the Confirm button disabled when ONLY the name is typed correctly', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME } });
+
+    expect(confirmBtn.disabled).toBe(true);
+  });
+
+  it('keeps the Confirm button disabled when ONLY the checkbox is checked', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.click(checkbox);
+
+    expect(confirmBtn.disabled).toBe(true);
+  });
+
+  it('enables the Confirm button when BOTH name matches AND checkbox is checked', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME } });
+    fireEvent.click(checkbox);
+
+    expect(confirmBtn.disabled).toBe(false);
+    expect(confirmBtn.getAttribute('aria-disabled')).toBe('false');
+  });
+
+  it('is case-insensitive: accepts all-lowercase deployment name', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME.toLowerCase() } });
+    fireEvent.click(checkbox);
+
+    expect(confirmBtn.disabled).toBe(false);
+  });
+
+  it('disables the Confirm button again when the name is cleared after being correct', async () => {
+    const confirmBtn = await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME } });
+    fireEvent.click(checkbox);
+    expect(confirmBtn.disabled).toBe(false);
+
+    fireEvent.change(nameInput, { target: { value: '' } });
+    expect(confirmBtn.disabled).toBe(true);
+  });
+
+  it('sends the X-Admin-Confirm-Migration header with the typed value on POST', async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        defaultTenantId: '00000000-0000-0000-0000-000000000001',
+        tables: [],
+        rlsInstalled: false,
+        error: null,
+      },
+    });
+
+    const confirmBtn = await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME } });
+    fireEvent.click(checkbox);
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledOnce());
+
+    const [, , config] = mockPost.mock.calls[0] as [unknown, unknown, { headers: Record<string, string> }];
+    expect(config.headers['X-Admin-Confirm-Migration']).toBe(DEPLOYMENT_NAME);
+  });
+
+  it('Cancel button closes the confirmation panel and resets state', async () => {
+    await renderAndOpenConfirm();
+    const nameInput = screen.getByPlaceholderText(DEPLOYMENT_NAME) as HTMLInputElement;
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: DEPLOYMENT_NAME } });
+    fireEvent.click(checkbox);
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelBtn);
+
+    // Confirmation panel should be gone.
+    expect(screen.queryByPlaceholderText(DEPLOYMENT_NAME)).toBeNull();
+  });
+});

--- a/src/Ato.Copilot.Dashboard/src/pages/AdminMigrationPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/AdminMigrationPage.tsx
@@ -1,47 +1,86 @@
 /**
- * Wave 6 — GAP-017: Admin Migration page.
+ * Wave 8 — UF-019: Admin Multi-Tenant Migration Guard.
  *
  * Guided UI for CSP-Admins to migrate a SingleTenant deployment to MultiTenant.
  * Accessible at /admin/migration.
+ *
+ * UF-019 requirement: the migration MUST NOT be triggerable without an explicit
+ * two-factor confirmation step:
+ *   1. Admin types the deployment name exactly as shown.
+ *   2. Admin checks an irreversibility acknowledgement checkbox.
+ * Only when BOTH are satisfied does the Confirm button become enabled.
+ *
+ * The POST call includes the `X-Admin-Confirm-Migration` header containing the
+ * typed deployment name so the backend guard can validate it independently.
+ *
  * Endpoints:
  *   GET  /api/admin/migrate-to-multitenant/preview
  *   POST /api/admin/migrate-to-multitenant
+ *     Required header: X-Admin-Confirm-Migration: {deploymentName}
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import PageLayout from '../components/layout/PageLayout';
 import PageHero from '../components/layout/PageHero';
 import apiClient from '../api/client';
+import { useLoginConfig } from '../features/auth/LoginConfigContext';
 
-interface MigrationPreview {
-  currentMode: 'SingleTenant' | 'MultiTenant';
-  defaultTenantId: string | null;
-  defaultTenantName: string | null;
-  warnings: string[];
-  canMigrate: boolean;
-  reason: string | null;
+const CONFIRMATION_HEADER = 'X-Admin-Confirm-Migration';
+
+interface TablePreview {
+  tableName: string;
+  totalRows: number;
+  rowsMissingTenant: number;
+  rowsAssignedByOverride: number;
+  rowsAssignedToDefault: number;
 }
 
-interface MigrationResult {
-  success: boolean;
-  newMode: string;
-  message: string;
-  migratedAt: string | null;
+interface MigrationPreview {
+  tables: TablePreview[];
+}
+
+interface MigrationReport {
+  startedAt: string;
+  completedAt: string;
+  defaultTenantId: string;
+  tables: Array<{
+    tableName: string;
+    totalRows: number;
+    rowsAssignedByOverride: number;
+    rowsAssignedToDefault: number;
+    rowsAlreadyAssigned: number;
+  }>;
+  rlsInstalled: boolean;
+  error: string | null;
 }
 
 export default function AdminMigrationPage() {
+  const login = useLoginConfig();
+  const deploymentName = login.branding.deploymentName || 'ATO Copilot';
+
   const [preview, setPreview] = useState<MigrationPreview | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [confirming, setConfirming] = useState(false);
   const [executing, setExecuting] = useState(false);
-  const [result, setResult] = useState<MigrationResult | null>(null);
+  const [report, setReport] = useState<MigrationReport | null>(null);
   const [execError, setExecError] = useState<string | null>(null);
+
+  // UF-019 confirmation state
+  const [typedName, setTypedName] = useState('');
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  // Determine if the confirmation step is fully satisfied
+  const confirmationSatisfied =
+    typedName.trim().toLowerCase() === deploymentName.trim().toLowerCase() &&
+    acknowledged;
+
+  const confirmInputRef = useRef<HTMLInputElement>(null);
 
   const loadPreview = useCallback(async () => {
     setLoading(true);
     setLoadError(null);
     try {
-      const { data } = await apiClient.get<MigrationPreview>(
+      const { data } = await apiClient.get<{ tables: TablePreview[] }>(
         '/admin/migrate-to-multitenant/preview',
       );
       setPreview(data);
@@ -54,15 +93,35 @@ export default function AdminMigrationPage() {
 
   useEffect(() => { void loadPreview(); }, [loadPreview]);
 
+  // Auto-focus the typed-name input when the confirmation panel opens.
+  useEffect(() => {
+    if (confirming) {
+      confirmInputRef.current?.focus();
+    }
+  }, [confirming]);
+
+  // Reset confirmation state when the panel is closed.
+  const cancelConfirm = () => {
+    setConfirming(false);
+    setTypedName('');
+    setAcknowledged(false);
+  };
+
   const handleExecute = async () => {
+    if (!confirmationSatisfied) return;
     setExecuting(true);
     setExecError(null);
     try {
-      const { data } = await apiClient.post<MigrationResult>(
+      const { data } = await apiClient.post<MigrationReport>(
         '/admin/migrate-to-multitenant',
-        { acknowledgedWarnings: true },
+        { installRls: true },
+        {
+          headers: {
+            [CONFIRMATION_HEADER]: typedName.trim(),
+          },
+        },
       );
-      setResult(data);
+      setReport(data);
       setConfirming(false);
     } catch (e: unknown) {
       setExecError((e as Error).message ?? 'Migration failed.');
@@ -70,6 +129,12 @@ export default function AdminMigrationPage() {
       setExecuting(false);
     }
   };
+
+  const totalRowsMissingTenant = (preview?.tables ?? []).reduce(
+    (sum, t) => sum + t.rowsMissingTenant,
+    0,
+  );
+  const isAlreadyMigrated = totalRowsMissingTenant === 0 && preview !== null && !loading;
 
   return (
     <PageLayout title="Admin Migration">
@@ -92,50 +157,60 @@ export default function AdminMigrationPage() {
 
       {preview && !loading && (
         <div className="space-y-6">
+
+          {/* Pre-migration table preview */}
           <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="mb-4 text-base font-semibold text-gray-900">Current Deployment State</h2>
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-              <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Mode</p>
-                <p className="mt-1 text-lg font-bold text-gray-900">{preview.currentMode}</p>
-              </div>
-              {preview.defaultTenantName && (
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Default Tenant</p>
-                  <p className="mt-1 text-sm font-medium text-gray-900">{preview.defaultTenantName}</p>
-                  <p className="text-xs text-gray-400 font-mono">{preview.defaultTenantId}</p>
-                </div>
-              )}
-              <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Can Migrate</p>
-                <p className={`mt-1 text-sm font-bold ${preview.canMigrate ? 'text-green-700' : 'text-red-700'}`}>
-                  {preview.canMigrate ? '✓ Yes' : '✗ No'}
-                </p>
-                {preview.reason && <p className="text-xs text-gray-500 mt-0.5">{preview.reason}</p>}
-              </div>
-            </div>
+            <h2 className="mb-4 text-base font-semibold text-gray-900">Migration Preview</h2>
+            <p className="mb-3 text-sm text-gray-600">
+              Rows with a <code className="text-xs bg-gray-100 px-1 rounded">NULL TenantId</code> will
+              be scoped to the default tenant after migration.
+            </p>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wide border-b border-gray-100">
+                  <th className="pb-2 pr-4">Table</th>
+                  <th className="pb-2 pr-4 text-right">Total Rows</th>
+                  <th className="pb-2 text-right">Missing Tenant</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.tables.map((t) => (
+                  <tr key={t.tableName} className="border-b border-gray-50">
+                    <td className="py-1 pr-4 font-mono text-xs text-gray-700">{t.tableName}</td>
+                    <td className="py-1 pr-4 text-right tabular-nums">{t.totalRows.toLocaleString()}</td>
+                    <td className={`py-1 text-right tabular-nums ${t.rowsMissingTenant > 0 ? 'text-amber-700 font-medium' : 'text-gray-400'}`}>
+                      {t.rowsMissingTenant.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t border-gray-200 font-semibold">
+                  <td className="pt-2 pr-4 text-xs text-gray-700">Total</td>
+                  <td className="pt-2 pr-4 text-right tabular-nums text-sm">
+                    {preview.tables.reduce((s, t) => s + t.totalRows, 0).toLocaleString()}
+                  </td>
+                  <td className={`pt-2 text-right tabular-nums text-sm ${totalRowsMissingTenant > 0 ? 'text-amber-700' : 'text-green-700'}`}>
+                    {totalRowsMissingTenant.toLocaleString()}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
           </div>
 
-          {preview.currentMode === 'MultiTenant' && (
+          {/* Already migrated */}
+          {isAlreadyMigrated && !report && (
             <div className="rounded border border-green-200 bg-green-50 p-4 text-sm text-green-800">
-              ✓ This deployment is already running in MultiTenant mode. No migration needed.
+              ✓ All rows already have a <code className="text-xs">TenantId</code>. No migration needed.
             </div>
           )}
 
-          {result && (
-            <div className={`rounded border p-4 text-sm ${result.success ? 'border-green-300 bg-green-50 text-green-800' : 'border-red-200 bg-red-50 text-red-800'}`}>
-              {result.success
-                ? `✓ Migration successful. Deployment is now ${result.newMode}. ${result.message}`
-                : `Migration failed: ${result.message}`}
-            </div>
-          )}
-
-          {preview.warnings.length > 0 && (
-            <div className="rounded border border-amber-200 bg-amber-50 p-4">
-              <p className="mb-2 text-sm font-semibold text-amber-800">Warnings</p>
-              <ul className="list-disc list-inside space-y-1 text-sm text-amber-700">
-                {preview.warnings.map((w, i) => <li key={i}>{w}</li>)}
-              </ul>
+          {/* Success */}
+          {report && !report.error && (
+            <div className="rounded border border-green-300 bg-green-50 p-4 text-sm text-green-800 space-y-1">
+              <p className="font-semibold">✓ Migration successful</p>
+              <p>Completed at {new Date(report.completedAt).toLocaleString()}</p>
+              {report.rlsInstalled && <p>Row-Level Security policies installed.</p>}
             </div>
           )}
 
@@ -143,7 +218,8 @@ export default function AdminMigrationPage() {
             <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">{execError}</div>
           )}
 
-          {preview.canMigrate && preview.currentMode !== 'MultiTenant' && !result?.success && (
+          {/* Migration action — only show if there's actual work to do and migration hasn't succeeded */}
+          {!isAlreadyMigrated && !report && (
             <>
               {!confirming ? (
                 <button
@@ -153,28 +229,91 @@ export default function AdminMigrationPage() {
                   Migrate to MultiTenant…
                 </button>
               ) : (
-                <div className="rounded-lg border-2 border-red-300 bg-red-50 p-5 space-y-4">
-                  <p className="text-sm font-semibold text-red-900">
-                    ⚠️ This will permanently convert the deployment to MultiTenant mode.
-                    This action <strong>cannot be reversed</strong>.
-                  </p>
-                  <p className="text-sm text-red-700">
-                    All existing data will be scoped to tenant{' '}
-                    <strong>{preview.defaultTenantName ?? preview.defaultTenantId}</strong>.
-                    Confirm you have reviewed all warnings above.
-                  </p>
+                /* ── UF-019 typed-confirmation guard ── */
+                <div
+                  className="rounded-lg border-2 border-red-300 bg-red-50 p-6 space-y-5"
+                  role="dialog"
+                  aria-labelledby="migration-confirm-title"
+                  aria-describedby="migration-confirm-desc"
+                >
+                  <div>
+                    <h3
+                      id="migration-confirm-title"
+                      className="text-base font-semibold text-red-900"
+                    >
+                      ⚠️ Confirm irreversible migration
+                    </h3>
+                    <p id="migration-confirm-desc" className="mt-1 text-sm text-red-700">
+                      This will permanently convert the deployment to MultiTenant mode and scope
+                      all existing data. <strong>This cannot be reversed.</strong>
+                    </p>
+                  </div>
+
+                  {/* Step 1 — type the deployment name */}
+                  <div>
+                    <label
+                      htmlFor="migration-confirm-name"
+                      className="block text-sm font-medium text-red-800 mb-1"
+                    >
+                      Type the deployment name to confirm:{' '}
+                      <code className="bg-red-100 px-1 rounded">{deploymentName}</code>
+                    </label>
+                    <input
+                      id="migration-confirm-name"
+                      ref={confirmInputRef}
+                      type="text"
+                      value={typedName}
+                      onChange={(e) => setTypedName(e.target.value)}
+                      placeholder={deploymentName}
+                      autoComplete="off"
+                      spellCheck={false}
+                      disabled={executing}
+                      className="w-full max-w-sm rounded border border-red-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+                      aria-invalid={typedName.length > 0 && !confirmationSatisfied && !acknowledged ? 'true' : 'false'}
+                    />
+                    {typedName.length > 0 &&
+                      typedName.trim().toLowerCase() !== deploymentName.trim().toLowerCase() && (
+                        <p className="mt-1 text-xs text-red-600">
+                          Name does not match. Type exactly: <strong>{deploymentName}</strong>
+                        </p>
+                      )}
+                  </div>
+
+                  {/* Step 2 — acknowledge irreversibility */}
+                  <div className="flex items-start gap-3">
+                    <input
+                      id="migration-ack"
+                      type="checkbox"
+                      checked={acknowledged}
+                      onChange={(e) => setAcknowledged(e.target.checked)}
+                      disabled={executing}
+                      className="mt-0.5 h-4 w-4 accent-red-600 cursor-pointer disabled:opacity-50"
+                    />
+                    <label htmlFor="migration-ack" className="text-sm text-red-800 cursor-pointer select-none">
+                      I understand this migration is <strong>irreversible</strong>. I have reviewed
+                      the preview above and confirmed the row counts are as expected.
+                    </label>
+                  </div>
+
+                  {/* Actions */}
                   <div className="flex gap-3">
                     <button
                       onClick={() => void handleExecute()}
-                      disabled={executing}
-                      className="inline-flex items-center gap-2 rounded-md bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-50"
+                      disabled={!confirmationSatisfied || executing}
+                      aria-disabled={!confirmationSatisfied || executing}
+                      className="inline-flex items-center gap-2 rounded-md bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed"
                     >
                       {executing ? (
-                        <><span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />Migrating…</>
-                      ) : 'Confirm: Migrate Now'}
+                        <>
+                          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                          Migrating…
+                        </>
+                      ) : (
+                        'Confirm Migration'
+                      )}
                     </button>
                     <button
-                      onClick={() => setConfirming(false)}
+                      onClick={cancelConfirm}
                       disabled={executing}
                       className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                     >

--- a/src/Ato.Copilot.Mcp/Endpoints/AdminMigrationEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/AdminMigrationEndpoints.cs
@@ -5,19 +5,35 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 
 namespace Ato.Copilot.Mcp.Endpoints;
 
 /// <summary>
-/// T124 [FR-073..FR-076]: HTTP surface for
+/// T124 [FR-073..FR-076] / UF-019 — HTTP surface for
 /// <c>/api/admin/migrate-to-multitenant</c> per
 /// <c>specs/048-tenant-isolation/contracts/admin-migration.openapi.yaml</c>.
 /// CSP-Admin only. Delegates the heavy lifting to
 /// <see cref="MultiTenantMigrationService"/>; this layer's job is contract
 /// validation, role enforcement, and envelope shaping.
+///
+/// <para>
+/// UF-019 guard (Wave 8): <c>POST</c> requires the explicit opt-in header
+/// <c>X-Admin-Confirm-Migration: {deploymentName}</c>.  The value MUST equal
+/// the deployment name configured in <c>Auth:Branding:DeploymentName</c>
+/// (case-insensitive, trimmed).  Callers without the header — including direct
+/// API calls without UI confirmation — receive 400
+/// <c>MIGRATION_CONFIRMATION_REQUIRED</c>.
+/// </para>
 /// </summary>
 public static class AdminMigrationEndpoints
 {
+    /// <summary>
+    /// HTTP header name for the UF-019 admin confirmation guard.
+    /// The UI sends this header with the typed deployment name as the value.
+    /// </summary>
+    public const string ConfirmationHeaderName = "X-Admin-Confirm-Migration";
+
     /// <summary>Registers the admin migration routes.</summary>
     public static IEndpointRouteBuilder MapAdminMigrationEndpoints(this IEndpointRouteBuilder app)
     {
@@ -64,6 +80,7 @@ public static class AdminMigrationEndpoints
         ITenantContext tenant,
         MultiTenantMigrationService service,
         [FromBody] MigrateRequest? body,
+        IOptions<Configuration.Auth.AuthOptions> authOptions,
         CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
@@ -75,6 +92,36 @@ public static class AdminMigrationEndpoints
         {
             return Error(sw, StatusCodes.Status400BadRequest, "INVALID_REQUEST",
                 "defaultTenantId is required.");
+        }
+
+        // ─── UF-019 confirmation guard ──────────────────────────────────────
+        // Require the explicit opt-in header so this irreversible operation
+        // cannot be triggered without the UI's typed-confirmation step.
+        // The value must equal the deployment name (case-insensitive, trimmed)
+        // so that the UI—which shows the user the name to type—provides the
+        // only valid confirmation token. Direct API calls without the UI flow
+        // are rejected with a descriptive error.
+        var rawName = authOptions.Value.Branding?.DeploymentName;
+        var deploymentName = string.IsNullOrWhiteSpace(rawName) ? "ATO Copilot" : rawName;
+        if (!http.Request.Headers.TryGetValue(ConfirmationHeaderName, out var headerValues) ||
+            string.IsNullOrWhiteSpace(headerValues.ToString()))
+        {
+            return Error(sw,
+                StatusCodes.Status400BadRequest,
+                "MIGRATION_CONFIRMATION_REQUIRED",
+                $"The '{ConfirmationHeaderName}' header is required.",
+                $"Set '{ConfirmationHeaderName}: {deploymentName}' to confirm you have read the warnings and typed the deployment name in the UI.");
+        }
+
+        var providedConfirmation = headerValues.ToString().Trim();
+        if (!string.Equals(providedConfirmation, deploymentName.Trim(),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Error(sw,
+                StatusCodes.Status400BadRequest,
+                "MIGRATION_CONFIRMATION_MISMATCH",
+                $"The confirmation value '{providedConfirmation}' does not match the deployment name.",
+                $"Type the deployment name exactly as shown: '{deploymentName}'.");
         }
 
         var overrides = body.Overrides?
@@ -110,7 +157,8 @@ public static class AdminMigrationEndpoints
         Error(sw, StatusCodes.Status403Forbidden, "FORBIDDEN_NOT_CSP_ADMIN",
             "Operation requires CSP.Admin role.");
 
-    private static IResult Error(Stopwatch sw, int statusCode, string code, string message) =>
+    private static IResult Error(Stopwatch sw, int statusCode, string code, string message,
+        string? suggestion = null) =>
         Results.Json(new
         {
             status = "error",
@@ -119,7 +167,9 @@ public static class AdminMigrationEndpoints
                 executionTimeMs = sw.ElapsedMilliseconds,
                 timestamp = DateTimeOffset.UtcNow,
             },
-            error = new { errorCode = code, message },
+            error = suggestion is null
+                ? (object)new { errorCode = code, message }
+                : new { errorCode = code, message, suggestion },
         }, statusCode: statusCode);
 
     private static object BuildEnvelope(Stopwatch sw, object data) => new
@@ -133,3 +183,4 @@ public static class AdminMigrationEndpoints
         },
     };
 }
+

--- a/src/Ato.Copilot.Mcp/Endpoints/AdminMigrationEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/AdminMigrationEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Ato.Copilot.Core.Configuration.Auth;
 using Ato.Copilot.Core.Interfaces.Tenancy;
 using Ato.Copilot.Core.Services.Tenancy;
 using Microsoft.AspNetCore.Builder;
@@ -80,7 +81,7 @@ public static class AdminMigrationEndpoints
         ITenantContext tenant,
         MultiTenantMigrationService service,
         [FromBody] MigrateRequest? body,
-        IOptions<Configuration.Auth.AuthOptions> authOptions,
+        IOptions<AuthOptions> authOptions,
         CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();

--- a/tests/Ato.Copilot.Tests.Integration/Tenancy/AdminMigrationEndpointTests.cs
+++ b/tests/Ato.Copilot.Tests.Integration/Tenancy/AdminMigrationEndpointTests.cs
@@ -3,16 +3,24 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Ato.Copilot.Core.Models.Tenancy;
 using Ato.Copilot.Mcp;
+using Ato.Copilot.Mcp.Endpoints;
 using FluentAssertions;
 using Xunit;
 
 namespace Ato.Copilot.Tests.Integration.Tenancy;
 
 /// <summary>
-/// T120 [Phase 9 / FR-073..FR-076]: Validates the
-/// <c>/api/admin/migrate-to-multitenant</c> contract surface against
-/// <c>specs/048-tenant-isolation/contracts/admin-migration.openapi.yaml</c>.
+/// T120 [Phase 9 / FR-073..FR-076] / UF-019 [Wave 8]: Validates the
+/// <c>/api/admin/migrate-to-multitenant</c> contract surface.
 /// </summary>
+/// <remarks>
+/// The UF-019 tests (marked with the region comment) validate the new
+/// <c>X-Admin-Confirm-Migration</c> guard added in Wave 8. Because the test
+/// factory does not configure <c>Auth:Branding:DeploymentName</c>, the
+/// deployment name defaults to <c>"ATO Copilot"</c> (per the endpoint's
+/// null/empty fallback), so tests that need to pass the guard send
+/// <c>X-Admin-Confirm-Migration: ATO Copilot</c>.
+/// </remarks>
 [Collection("Tenancy")]
 public class AdminMigrationEndpointTests
     : IClassFixture<MultiTenantWebApplicationFactory<McpProgram>>
@@ -20,6 +28,12 @@ public class AdminMigrationEndpointTests
     private readonly MultiTenantWebApplicationFactory<McpProgram> _factory;
     private readonly HttpClient _client;
     private readonly Guid _tenantA;
+
+    /// <summary>
+    /// Deployment name used by the confirmation guard when no
+    /// <c>Auth:Branding:DeploymentName</c> is configured in the test factory.
+    /// </summary>
+    private const string DefaultDeploymentName = "ATO Copilot";
 
     public AdminMigrationEndpointTests(MultiTenantWebApplicationFactory<McpProgram> factory)
     {
@@ -32,6 +46,8 @@ public class AdminMigrationEndpointTests
         ctx.IsCspAdmin = true;
         ctx.Status = TenantStatus.Active;
     }
+
+    // ─── Preview endpoint ─────────────────────────────────────────────────────
 
     [Fact]
     public async Task Preview_AsCspAdmin_Returns200_WithPerTableRows()
@@ -58,12 +74,21 @@ public class AdminMigrationEndpointTests
             .Should().Be("FORBIDDEN_NOT_CSP_ADMIN");
     }
 
+    // ─── Execute — existing contract tests (updated to send confirmation header) ─
+
     [Fact]
     public async Task Execute_WithoutDefaultTenantId_Returns400()
     {
-        var resp = await _client.PostAsJsonAsync(
-            "/api/admin/migrate-to-multitenant",
-            new { defaultTenantId = Guid.Empty });
+        // The confirmation guard runs AFTER the body validation for the Guid check,
+        // but the guard runs AFTER IsCspAdmin. We send the header so the guard
+        // is not the test's bottleneck; the 400 here is for the missing Guid.
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req.Content = JsonContent.Create(new { defaultTenantId = Guid.Empty });
+        req.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, DefaultDeploymentName);
+
+        var resp = await _client.SendAsync(req);
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
@@ -72,23 +97,30 @@ public class AdminMigrationEndpointTests
     }
 
     [Fact]
-    public async Task Execute_AsCspAdmin_ReturnsReport_AndIsIdempotent()
+    public async Task Execute_AsCspAdmin_WithConfirmationHeader_ReturnsReport_AndIsIdempotent()
     {
         var defaultId = _tenantA;
 
-        var first = await _client.PostAsJsonAsync(
-            "/api/admin/migrate-to-multitenant",
-            new { defaultTenantId = defaultId, installRls = false });
+        using var req1 = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req1.Content = JsonContent.Create(new { defaultTenantId = defaultId, installRls = false });
+        req1.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, DefaultDeploymentName);
+
+        var first = await _client.SendAsync(req1);
         first.StatusCode.Should().Be(HttpStatusCode.OK);
         var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
         firstBody.GetProperty("status").GetString().Should().Be("success");
         firstBody.GetProperty("data").GetProperty("defaultTenantId").GetGuid().Should().Be(defaultId);
 
-        // Idempotency: re-running should still succeed and report 0 rows
-        // assigned to the default (since the first run already covered them).
-        var second = await _client.PostAsJsonAsync(
-            "/api/admin/migrate-to-multitenant",
-            new { defaultTenantId = defaultId, installRls = false });
+        // Idempotency: re-running should still succeed.
+        using var req2 = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req2.Content = JsonContent.Create(new { defaultTenantId = defaultId, installRls = false });
+        req2.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, DefaultDeploymentName);
+
+        var second = await _client.SendAsync(req2);
         second.StatusCode.Should().Be(HttpStatusCode.OK);
         var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
         secondBody.GetProperty("status").GetString().Should().Be("success");
@@ -99,10 +131,86 @@ public class AdminMigrationEndpointTests
     {
         _factory.GetActiveContext().IsCspAdmin = false;
 
-        var resp = await _client.PostAsJsonAsync(
-            "/api/admin/migrate-to-multitenant",
-            new { defaultTenantId = _tenantA });
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req.Content = JsonContent.Create(new { defaultTenantId = _tenantA });
+        req.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, DefaultDeploymentName);
+
+        var resp = await _client.SendAsync(req);
 
         resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ─── UF-019 confirmation guard ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_WithoutConfirmationHeader_Returns400_ConfirmationRequired()
+    {
+        // Direct API call with no confirmation header — the guard must reject it.
+        var resp = await _client.PostAsJsonAsync(
+            "/api/admin/migrate-to-multitenant",
+            new { defaultTenantId = _tenantA, installRls = false });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("status").GetString().Should().Be("error");
+        body.GetProperty("error").GetProperty("errorCode").GetString()
+            .Should().Be("MIGRATION_CONFIRMATION_REQUIRED");
+        // Suggestion is present and mentions the header name.
+        body.GetProperty("error").GetProperty("suggestion").GetString()
+            .Should().Contain(AdminMigrationEndpoints.ConfirmationHeaderName);
+    }
+
+    [Fact]
+    public async Task Execute_WithEmptyConfirmationHeader_Returns400_ConfirmationRequired()
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req.Content = JsonContent.Create(new { defaultTenantId = _tenantA, installRls = false });
+        req.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, " ");
+
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetProperty("errorCode").GetString()
+            .Should().Be("MIGRATION_CONFIRMATION_REQUIRED");
+    }
+
+    [Fact]
+    public async Task Execute_WithWrongConfirmationValue_Returns400_ConfirmationMismatch()
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req.Content = JsonContent.Create(new { defaultTenantId = _tenantA, installRls = false });
+        req.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, "wrong-deployment-name");
+
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetProperty("errorCode").GetString()
+            .Should().Be("MIGRATION_CONFIRMATION_MISMATCH");
+        // Suggestion must tell the user what the correct name is.
+        body.GetProperty("error").GetProperty("suggestion").GetString()
+            .Should().Contain(DefaultDeploymentName);
+    }
+
+    [Fact]
+    public async Task Execute_WithCaseInsensitiveConfirmationValue_Returns200()
+    {
+        // The guard is case-insensitive, so "ato copilot" must be accepted.
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/admin/migrate-to-multitenant");
+        req.Content = JsonContent.Create(new { defaultTenantId = _tenantA, installRls = false });
+        req.Headers.Add(AdminMigrationEndpoints.ConfirmationHeaderName, "ato copilot");
+
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }


### PR DESCRIPTION
## Summary

UF-019 — Admin Multi-Tenant Migration Guard.

Addresses the known gap documented in #203: `POST /api/admin/migrate-to-multitenant` was live with no confirmation guard — callable directly without any UI confirmation step.

### Changes

#### Backend — `AdminMigrationEndpoints.cs`

Adds a confirmation header gate to the `POST` handler:

| Header | Required | Value |
|--------|----------|-------|
| `X-Admin-Confirm-Migration` | ✅ Yes | Must equal `Auth:Branding:DeploymentName` (case-insensitive, trimmed; fallback: `"ATO Copilot"`) |

**Error codes:**
- Missing/empty header → `400 MIGRATION_CONFIRMATION_REQUIRED`
- Wrong value → `400 MIGRATION_CONFIRMATION_MISMATCH` (with suggestion showing the correct name)

Both error responses include a `suggestion` field per the API contract pattern in `AuthEndpoints`.

#### Frontend — `AdminMigrationPage.tsx`

Replaces the simple click-through with a UF-019 compliant two-factor confirmation dialog:

1. **Typed name** — admin must type the deployment name exactly as shown (case-insensitive; live mismatch hint shown below the input).
2. **Acknowledgement checkbox** — admin must explicitly check "I understand this migration is irreversible."

The Confirm button is `disabled` + `aria-disabled="true"` until **both** conditions are satisfied. `Cancel` resets both fields. The POST includes the `X-Admin-Confirm-Migration` header with the typed value.

Preview section upgraded from a simple `canMigrate` flag to a full per-table breakdown showing row counts and null-TenantId counts so admins can verify scope before confirming.

### Tests

**Integration (xUnit):** `AdminMigrationEndpointTests.cs` — 4 new guard tests:
- Missing header → 400 `MIGRATION_CONFIRMATION_REQUIRED`
- Empty (whitespace) header → 400 `MIGRATION_CONFIRMATION_REQUIRED`  
- Wrong value → 400 `MIGRATION_CONFIRMATION_MISMATCH` with correct name in suggestion
- Case-insensitive match (lowercase) → 200 OK

Existing execute tests updated to send the confirmation header.

**Unit (Vitest):** `AdminMigrationPage.test.tsx` — 8 tests:
- Button disabled with no input
- Button disabled with name only / checkbox only
- Button enabled with both satisfied
- Case-insensitive match enables button
- Clearing name re-disables button
- POST sends `X-Admin-Confirm-Migration` header
- Cancel resets state

### Acceptance Criteria (from #203)

- ✅ Migration only triggerable through UI with explicit confirmation step
- ✅ Direct API call requires admin-scoped token + confirmation header
- ✅ Pre-migration validation: per-table row counts displayed
- ✅ Post-migration: success/error shown inline

Closes #203
