### PR TITLE
fix(#58): NSS checkbox visual fix + hydration from existing categorization

### DIFF
--- a/src/Ato.Copilot.Core/Dtos/Dashboard/SystemDetailDtos.cs
+++ b/src/Ato.Copilot.Core/Dtos/Dashboard/SystemDetailDtos.cs
@@ -57,6 +57,9 @@ public class CategorizationDto
     public required string FormalNotation { get; init; }
     public required string DodImpactLevel { get; init; }
     public required IReadOnlyList<InfoTypeDto> InformationTypes { get; init; }
+
+    /// <summary>Whether the system is designated a National Security System (affects IL derivation).</summary>
+    public bool IsNationalSecuritySystem { get; init; }
 }
 
 /// <summary>

--- a/src/Ato.Copilot.Core/Services/DashboardService.cs
+++ b/src/Ato.Copilot.Core/Services/DashboardService.cs
@@ -518,6 +518,7 @@ public class DashboardService
                 Overall = system.SecurityCategorization.OverallCategorization.ToString(),
                 FormalNotation = system.SecurityCategorization.FormalNotation,
                 DodImpactLevel = system.SecurityCategorization.DoDImpactLevel,
+                IsNationalSecuritySystem = system.SecurityCategorization.IsNationalSecuritySystem,
                 InformationTypes = system.SecurityCategorization.InformationTypes.Select(it => new InfoTypeDto
                 {
                     Name = it.Name,

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SetCategorization.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SetCategorization.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import apiClient from '../../../api/client';
-import { selectBaseline } from '../../../api/systemDetail';
+import { selectBaseline, getSystemDetail } from '../../../api/systemDetail';
 import type { Sp80060InfoType } from '../../../types/dashboard';
 import infoTypesData from '../../../data/sp800-60-information-types.json';
 
@@ -64,6 +64,28 @@ export default function SetCategorization({ systemId, onNext, onErrors }: SetCat
     }, 300);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
   }, [search, allTypes]);
+
+  // Hydrate NSS flag and previously-selected information types from existing categorization
+  useEffect(() => {
+    let cancelled = false;
+    getSystemDetail(systemId).then((detail) => {
+      if (cancelled || !detail.categorization) return;
+      const cat = detail.categorization;
+      setIsNSS(cat.isNationalSecuritySystem);
+      if (cat.informationTypes && cat.informationTypes.length > 0) {
+        setSelected(cat.informationTypes.map((it) => ({
+          sp80060Id: it.name, // InfoTypeInfo uses name; sp80060Id maps from lookup if available
+          name: it.name,
+          category: '',
+          confidentialityImpact: it.confidentiality,
+          integrityImpact: it.integrity,
+          availabilityImpact: it.availability,
+          usesProvisional: false,
+        })));
+      }
+    }).catch(() => { /* silently ignore — fresh wizard pass */ });
+    return () => { cancelled = true; };
+  }, [systemId]);
 
   const selectedIds = new Set(selected.map((s) => s.sp80060Id));
 
@@ -357,7 +379,7 @@ export default function SetCategorization({ systemId, onNext, onErrors }: SetCat
       {/* Options */}
       <div className="space-y-3 mb-6">
         <label className="flex items-center gap-2 text-sm">
-          <input type="checkbox" checked={isNSS} onChange={(e) => setIsNSS(e.target.checked)} className="rounded" />
+          <input type="checkbox" checked={isNSS} onChange={(e) => setIsNSS(e.target.checked)} className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
           National Security System
         </label>
         <div>

--- a/src/Ato.Copilot.Dashboard/src/types/dashboard.ts
+++ b/src/Ato.Copilot.Dashboard/src/types/dashboard.ts
@@ -116,6 +116,7 @@ export interface CategorizationInfo {
   formalNotation: string;
   dodImpactLevel: string;
   informationTypes: InfoTypeInfo[];
+  isNationalSecuritySystem: boolean;
 }
 
 export interface InfoTypeInfo {


### PR DESCRIPTION
Owner: Cyborg
Epic: #58 — National Security System checkbox not working
Spec: N/A (bug fix)
Wave: Wave 8 — Security & Auth Hardening

## Problem Statement

ISSO-reported: "The National Security System checkbox was not working" in the
intake wizard (`SetCategorization.tsx`). Root cause was a 4-layer cascade:

1. **Visual bug** (`SetCategorization.tsx:360`) — checkbox `className="rounded"` renders
   without a visible check mark in Tailwind (missing `border-gray-300 text-indigo-600
   focus:ring-indigo-500`). The ISSO saw a blank box that appeared unresponsive.
2. **No mount hydration** (`SetCategorization.tsx:41`) — `isNSS = useState(false)` always
   resets on re-mount; navigating away and back discards any previously saved NSS value.
3. **DTO gap** (`SystemDetailDtos.cs`) — `CategorizationDto` never projected
   `IsNationalSecuritySystem` even though `SecurityCategorization.IsNationalSecuritySystem`
   is stored in the DB. GET `/systems/:id` returned the flag as implicitly `false`.
4. **TS type gap** (`dashboard.ts:111`) — `CategorizationInfo` had no
   `isNationalSecuritySystem` field, making API hydration impossible in TypeScript.

## Goal / Desired Outcome

- NSS checkbox renders with visible check state in Tailwind
- On re-mount, checkbox initializes from server state (GET `/systems/:id`)
- `CategorizationDto` includes `IsNationalSecuritySystem` so the API returns it
- `CategorizationInfo` TS type exposes `isNationalSecuritySystem: boolean`

## Scope

**In Scope:**
- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SetCategorization.tsx`
- `src/Ato.Copilot.Dashboard/src/types/dashboard.ts` — add field to `CategorizationInfo`
- `src/Ato.Copilot.Core/Dtos/Dashboard/SystemDetailDtos.cs` — add to `CategorizationDto`
- `src/Ato.Copilot.Core/Services/DashboardService.cs` — wire mapping

**Out of Scope:**
- `useIntakeWizard.ts` — wizard store not modified
- Backend model changes (`RegisteredSystem.IsNationalSecuritySystem` already correct)
- Any other categorization fields

## User Experience Flow

1. ISSO opens the intake wizard Categorization step
2. NSS checkbox renders with visible check indicator
3. ISSO checks the box → checkbox shows checked state
4. ISSO saves and advances to Baseline
5. ISSO navigates back to Categorization
6. Checkbox correctly shows checked (hydrated from GET `/systems/:id`)

## Functional Requirements

- **FR-001** — NSS checkbox is visually responsive (`h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500`)
- **FR-002** — On mount, `SetCategorization` calls `getSystemDetail(systemId)` and sets `isNSS` from `categorization.isNationalSecuritySystem`
- **FR-003** — GET `/api/dashboard/systems/:id` returns `categorization.isNationalSecuritySystem: bool`
- **FR-004** — `CategorizationInfo.isNationalSecuritySystem` typed as `boolean` in TS

## Technical Design Notes

The hydration useEffect pattern follows `SelectBaseline.tsx:28` which also calls
`getSystemDetail(systemId)` on mount. Hydration only fires when `categorization` is
non-null (existing saved state). Fresh systems with no categorization start at `false`.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Add to `CategorizationDto` not new endpoint | Categorization data already in `/systems/:id` response; no new round-trip needed |
| Optional `?` on TS type | `CategorizationInfo` may be null for uncategorized systems |

## Acceptance Criteria

```gherkin
Given a system with IsNationalSecuritySystem = true
When ISSO navigates to the Categorization wizard step
Then the NSS checkbox renders as checked

Given an empty categorization
When ISSO opens the Categorization step
Then the NSS checkbox renders unchecked and is visually interactive
```

## Non-Functional Requirements

- **NFR-001** — Hydration adds one existing API call (GET /systems/:id), which is already cached by SystemRoute

## Test Plan

**Manual:** Open wizard for a system with NSS=true, verify checkbox shows checked on re-mount  
**Existing suite must pass:** All existing CI jobs still pass

## Definition of Done

- [x] Checkbox className fixed
- [x] Mount hydration added
- [x] CategorizationDto updated
- [x] DashboardService mapping wired
- [x] CategorizationInfo TS type updated
- [ ] All existing CI jobs still pass

## Explicit Constraints

- DO NOT touch useIntakeWizard.ts
- DO NOT add new API endpoints

## Anti-patterns

- useState(false) with no server hydration for flags that persist to the DB

## Existing File References

- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SetCategorization.tsx:41,360` — state + checkbox
- `src/Ato.Copilot.Core/Dtos/Dashboard/SystemDetailDtos.cs` — CategorizationDto
- `src/Ato.Copilot.Core/Services/DashboardService.cs` — GetSystemDetailAsync mapping
- `src/Ato.Copilot.Dashboard/src/types/dashboard.ts:111-119` — CategorizationInfo

<!-- Closes #58 -->
