### PR TITLE
docs(arch): ADR-001 / ADR-002 / ADR-003 — auth error semantics, simulated role scope, domain entity ownership

### DIFF
--- a/docs/architecture/adr-001-auth-error-class-semantics.md
+++ b/docs/architecture/adr-001-auth-error-class-semantics.md
@@ -1,0 +1,99 @@
+# ADR-001 — Auth Error Class Semantics: 401 vs 403 in RequireAuth
+
+**Status:** Accepted  
+**Date:** 2026-06-09  
+**Author:** Batman (Chief Systems Architect)  
+**Relates to:** Issue [#362](https://github.com/azurenoops/spin_agent/issues/362), Feature 051, Feature 048  
+**Files affected:** `src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx`
+
+---
+
+## Context
+
+`RequireAuth.tsx` probes `GET /api/auth/me` to gate every protected route. Prior to this ADR, both HTTP 401 and HTTP 403 responses triggered `instance.loginRedirect()`.
+
+This conflation causes a **permanent redirect loop** for any user who holds a valid Entra account but has no SPIN Agent tenant assignment:
+
+1. User hits protected route → `GET /api/auth/me` returns **403** (authenticated, no tenant)
+2. `RequireAuth` calls `loginRedirect` → Entra authenticates the user again
+3. User returns with a fresh token → `GET /api/auth/me` returns **403** again
+4. Loop never terminates — browser eventually surfaces "Too many redirects"
+
+This is a security boundary ambiguity: **401 means "who are you?" — 403 means "I know who you are; you don't have access here."** Treating them identically collapses a meaningful distinction that determines the correct UX path.
+
+---
+
+## Decision
+
+**401 and 403 MUST trigger different behaviors in `RequireAuth` and in all future auth-gated components.**
+
+### Canonical Error Class Contract
+
+| HTTP Status | Semantic | Client Action |
+|-------------|----------|---------------|
+| `401 Unauthorized` | Unauthenticated — no valid session/token | `loginRedirect()` to re-establish identity |
+| `403 Forbidden` | Authenticated but unauthorized — no tenant assignment or insufficient role | Navigate to `/login/error?errorClass=<reason>` — **no MSAL redirect** |
+
+### `RequireAuth.tsx` Implementation
+
+```ts
+if (status === 401) {
+  setState('redirecting');
+  const deepLink =
+    window.location.pathname + window.location.search + window.location.hash;
+  void instance.loginRedirect({ scopes: DEFAULT_API_SCOPES, state: deepLink });
+} else if (status === 403) {
+  // Authenticated but no tenant assignment — route to error page, not MSAL.
+  navigate('/login/error?errorClass=NoTenantAssignment', { replace: true });
+}
+```
+
+### Error Page Query Params
+
+The `/login/error` page MUST accept `?errorClass=` and render contextual guidance:
+
+| `errorClass` | Display message |
+|---|---|
+| `NoTenantAssignment` | "Your account does not have access to a SPIN Agent tenant. Contact your system administrator." |
+| `InsufficientRole` | "You do not have the required role for this resource. Contact your tenant administrator." |
+| *(default / missing)* | Generic auth failure message |
+
+### Server-Side Contract (non-negotiable)
+
+The `GET /api/auth/me` endpoint MUST return:
+
+- **`401`** — token absent, expired, or invalid signature
+- **`403`** — valid token, authenticated principal, but `TenantMemberships` is empty or the caller is not in a required PIM role
+
+No other 4xx status is permitted from `/api/auth/me`. The SPA contract depends on this being strictly enforced.
+
+---
+
+## Consequences
+
+**Positive:**
+- Eliminates the redirect loop for valid Entra users without tenant assignments
+- Establishes a clear semantic contract all future protected routes can rely on
+- `/login/error` can display actionable guidance rather than looping
+
+**Negative / Trade-offs:**
+- All future protected route components MUST follow this two-branch pattern; a code review gate is required to enforce it
+- The `/login/error` page must be extended to accept and render `errorClass` (see Issue #362 fix)
+
+---
+
+## Alternatives Considered
+
+**A. Single redirect for all 4xx** — Rejected. Already proven to cause infinite loops; harms valid users.
+
+**B. Client-side Entra group membership check before probing `/me`** — Rejected. Requires reading group claims from MSAL's local cache, which doesn't reflect server-side tenant assignment state. Server is the source of truth.
+
+**C. 403 → navigate to `/unauthorized` (separate page)** — Acceptable, but `/login/error?errorClass=` provides richer extensibility without additional routes.
+
+---
+
+## Enforcement
+
+- Code review MUST reject any PR that adds `status === 403` → `loginRedirect()` in any component
+- `RequireAuth.tsx` is the **single gating component** for all protected routes — do not replicate auth logic in individual page components
+- ADR-001 MUST be referenced in Feature 051 spec and any auth-adjacent feature specs going forward

--- a/docs/architecture/adr-002-simulated-role-header-scope.md
+++ b/docs/architecture/adr-002-simulated-role-header-scope.md
@@ -1,0 +1,119 @@
+# ADR-002 — X-Simulated-Role Header: Dev-Only Scope and Server-Side Enforcement
+
+**Status:** Accepted  
+**Date:** 2026-06-09  
+**Author:** Batman (Chief Systems Architect)  
+**Relates to:** Issue [#364](https://github.com/azurenoops/spin_agent/issues/364), Feature 048  
+**Files affected:**  
+- `src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts`  
+- `src/Ato.Copilot.Dashboard/src/features/csp-onboarding/api.ts`  
+- `src/Ato.Copilot.Dashboard/src/features/tenancy/api.ts`
+
+---
+
+## Context
+
+Three axios API clients inject `X-Simulated-Role` from `localStorage['ato-dashboard-settings'].role` into every outbound request. None of these interceptors are guarded with `import.meta.env.DEV`.
+
+**In production today**, any user who sets `ato-dashboard-settings` in their browser's localStorage can transmit an arbitrary role value (`CSP.Admin`, `ISSO`, `System.Owner`, etc.) as a request header to:
+- `/api/onboarding/*`
+- `/api/csp/onboarding/*`
+- `/api/tenants/*`
+
+Whether the server uses, ignores, or logs this header is undocumented. The ambiguity is the vulnerability — the header's production behavior has no contract.
+
+### Risk Assessment
+
+| Scenario | Impact |
+|---|---|
+| Server reads `X-Simulated-Role` and uses it for AuthZ in any code path | Direct privilege escalation — any user can claim CSP.Admin |
+| Server ignores it in production | No functional harm, but the header leaks role enumeration (attacker can probe which roles exist by reading the localStorage key) |
+| Server logs it | Noise in audit logs; could complicate forensic investigation of real auth events |
+
+For a DoD application that supports ATO workflows under NIST RMF, any undocumented privileged header in production is a security finding.
+
+---
+
+## Decision
+
+### 1. Frontend: DEV guard on all three interceptors (immediate fix)
+
+All three `X-Simulated-Role` interceptor registrations MUST be wrapped in `import.meta.env.DEV`:
+
+```ts
+if (import.meta.env.DEV) {
+  apiClient.interceptors.request.use((config) => {
+    try {
+      const raw = localStorage.getItem('ato-dashboard-settings');
+      if (raw) {
+        const settings = JSON.parse(raw) as { role?: string };
+        if (settings.role) config.headers['X-Simulated-Role'] = settings.role;
+      }
+    } catch {
+      // ignore parse errors
+    }
+    return config;
+  });
+}
+```
+
+`import.meta.env.DEV` is `true` only during Vite dev server (`vite dev`). It is `false` in all `vite build` outputs. This is the correct compile-time elimination — no runtime overhead, no prod leakage.
+
+### 2. Server-side: Explicit null-out of `X-Simulated-Role` in non-Development environments
+
+The server (ASP.NET Core MCP API) MUST explicitly strip or null `X-Simulated-Role` from inbound requests when `ASPNETCORE_ENVIRONMENT != Development`. This is the defense-in-depth layer.
+
+Recommended implementation: a middleware shim that runs before any role-reading logic:
+
+```csharp
+// In Program.cs or middleware pipeline, before UseAuthorization()
+app.Use(async (context, next) =>
+{
+    if (!app.Environment.IsDevelopment())
+    {
+        context.Request.Headers.Remove("X-Simulated-Role");
+    }
+    await next();
+});
+```
+
+This ensures even if the frontend DEV guard is bypassed (e.g., a future regression, a raw API call, a different client), the production server treats the header as non-existent.
+
+### 3. Document `X-Simulated-Role` in the security architecture
+
+`docs/architecture/security.md` MUST document:
+- `X-Simulated-Role` is a **development-only** header
+- Frontend: guarded by `import.meta.env.DEV`
+- Backend: stripped by middleware in non-Development environments
+- The header value maps to: `System.Owner`, `ISSO`, `CSP.Admin` (see Feature 048 role table)
+
+---
+
+## Consequences
+
+**Positive:**
+- Eliminates the privilege escalation surface in production
+- Defense-in-depth: frontend guard + backend strip — neither alone is sufficient
+- Documented contract prevents future regressions
+
+**Negative / Trade-offs:**
+- Any developer who forgets the DEV guard in a future new axios client will reintroduce the vulnerability; must be part of PR review checklist
+- Backend middleware adds one header-read per request (negligible overhead)
+
+---
+
+## Alternatives Considered
+
+**A. Remove `X-Simulated-Role` entirely** — Rejected. The dev simulation workflow is valuable and actively used. The risk is the missing environment guard, not the header itself.
+
+**B. Frontend-only DEV guard** — Rejected as insufficient. Defense-in-depth requires server-side enforcement. A raw `curl` call, Postman test, or future regression could bypass frontend guards.
+
+**C. Use a signed/HMAC header instead of a plain string** — Considered for future hardening. Out of scope for this fix; the simulated role workflow is dev-only and doesn't need cryptographic integrity.
+
+---
+
+## Enforcement
+
+- PR review checklist: any new axios client that reads `ato-dashboard-settings` from localStorage MUST have the `import.meta.env.DEV` guard
+- `docs/architecture/security.md` "CAC Simulation Mode" section MUST be updated to include `X-Simulated-Role` behavior
+- Server-side middleware strip MUST be present before any production deployment of the MCP API

--- a/docs/architecture/adr-003-domain-entity-ownership.md
+++ b/docs/architecture/adr-003-domain-entity-ownership.md
@@ -1,0 +1,103 @@
+# ADR-003 — Domain Entity Ownership: One File per Domain Type
+
+**Status:** Accepted  
+**Date:** 2026-06-09  
+**Author:** Batman (Chief Systems Architect)  
+**Relates to:** Issue [#367](https://github.com/azurenoops/spin_agent/issues/367)  
+**Files affected:**  
+- `src/Ato.Copilot.Dashboard/src/api/packages.ts`  
+- `src/Ato.Copilot.Dashboard/src/api/package.ts`
+
+---
+
+## Context
+
+Two API files in the `api/` directory both export an interface named `PackageDetail` with **incompatible shapes**:
+
+| File | `PackageDetail` fields |
+|------|----------------------|
+| `api/packages.ts` | `packageId`, `systemId`, `status`, `evidenceMode`, `fileSize?`, `generatedAt?`, `completedAt?`, `expiresAt?`, `failureReason?` — minimal job-status shape |
+| `api/package.ts` | Full shape — adds `artifacts: PackageArtifact[]`, `validation: PackageValidation \| null`, `failedArtifactType`, `generatedBy`, plus stricter nullability (`fileSize: number \| null` vs `fileSize?: number`) |
+
+TypeScript does **not** catch cross-module name collisions. A component that imports `PackageDetail` from the wrong module receives a structurally incomplete object at runtime, causing silent `undefined` field access — no build error, no type error, no warning.
+
+### Root Cause Pattern
+
+This is a symptom of a broader file organization anti-pattern: `packages.ts` (plural) grew alongside `package.ts` (singular) without a canonical ownership rule. The identical export name was introduced as both files iterated independently.
+
+---
+
+## Decision
+
+### 1. One canonical type file per domain entity
+
+**The rule:** For any domain entity in `api/`, exactly one file owns the authoritative type definition. All other files that reference that entity MUST import from the canonical owner — never re-declare or re-define.
+
+**For the `Package` domain:**
+
+| File | Purpose |
+|------|---------|
+| `api/package.ts` | **Canonical owner** — full `PackageDetail`, `PackageSummary`, `PackageArtifact`, `PackageValidation`, `ValidationFinding`, `PackageListResponse`, `GeneratePackageResponse`, all package-domain types |
+| `api/packages.ts` | **Operations file** — `enqueuePackage`, `getPackageStatus`, `getPackageDownloadUrl`, `enqueueEmassExport`; imports `PackageDetail` from `api/package.ts` — does NOT redeclare it |
+
+### 2. Immediate consolidation steps
+
+1. **Remove `PackageDetail` from `api/packages.ts`** — delete the interface declaration
+2. **Add import** to `api/packages.ts`: `import type { PackageDetail } from './package';`
+3. **Audit all consumers** — search for `import.*PackageDetail.*from.*packages` and update to `./package`
+4. **Verify build passes** — `tsc --noEmit` must be green
+
+The minimal `PackageDetail` shape in `packages.ts` was a polling-convenience subset. `getPackageStatus()` already returns `Promise<PackageDetail>` — it should return the full canonical shape. If the server's polling endpoint only returns a subset of fields, that is a server contract issue to resolve in the OpenAPI spec — not a reason to maintain two incompatible client types.
+
+### 3. Naming convention
+
+To prevent recurrence:
+
+| Pattern | Rule |
+|---------|------|
+| `api/<entity>.ts` | Canonical: defines the entity's types + the primary CRUD API functions |
+| `api/<entities>.ts` (plural) | **Discouraged.** If it exists, it MUST only contain list-query helpers and import types from the singular file. No type declarations. |
+| `api/<feature>Api.ts` | Feature-scoped client (e.g., `onboardingApi.ts`) — may define feature-local types, but MUST NOT shadow types from domain entity files |
+
+### 4. TypeScript path alias (recommended, not required)
+
+Consider adding a barrel export in `api/index.ts` that re-exports all canonical entity types. This makes the import path unambiguous and allows `eslint-plugin-import` rules to enforce the convention:
+
+```ts
+// api/index.ts
+export type { PackageDetail, PackageSummary, PackageArtifact, PackageValidation } from './package';
+export type { PackageJob } from './packages';
+```
+
+Consumers then import from `'../api'` — one canonical path.
+
+---
+
+## Consequences
+
+**Positive:**
+- Eliminates the silent runtime `undefined` field access risk
+- Single source of truth for `PackageDetail` — all consumers see the same shape
+- Establishes a naming rule that prevents the same issue across other domain entities
+
+**Negative / Trade-offs:**
+- Requires an audit of all `PackageDetail` import sites — small but necessary refactor
+- If `getPackageStatus()` truly only receives a partial shape from the API, the OpenAPI spec and server response must be updated rather than maintaining a thin client type
+
+---
+
+## Alternatives Considered
+
+**A. Rename the `packages.ts` type to `PackageStatusDetail`** — Considered. Rejected because it papering over the root problem: parallel type definitions for the same concept with no ownership rule. The fix should eliminate the duplicate, not rename it.
+
+**B. Use TypeScript `Partial<PackageDetail>` in `packages.ts`** — Rejected. `Partial<>` loses nullability and required field semantics. The server contract should be the definition, not a client-side weakening.
+
+**C. `@ts-nocheck` or type casting** — Rejected immediately. Masks the problem.
+
+---
+
+## Enforcement
+
+- PR review: any new file in `api/` that declares a type matching an existing entity name MUST be rejected — add import, do not redeclare
+- `eslint-plugin-import/no-duplicates` rule should be confirmed active
+- `tsc --noEmit` is a required CI check (it already is per the build pipeline — this ADR reinforces it must stay)


### PR DESCRIPTION
## Summary

Architecture Decision Records for the 3 arch-level findings from Oracle's QA audit (2026-06-09, 191 source files).

---

### ADR-001 — Auth Error Class Semantics: 401 vs 403 in RequireAuth
**Closes #362**

Establishes the canonical client contract:
- `401` → `loginRedirect()` (unauthenticated)
- `403` → `navigate('/login/error?errorClass=NoTenantAssignment', { replace: true })` (authenticated, no access)

Eliminates the infinite redirect loop for valid Entra users with no tenant assignment. Defines `errorClass` query param contract for `/login/error`.

---

### ADR-002 — X-Simulated-Role Header: Dev-Only Scope and Server-Side Enforcement
**Closes #364**

Defines `X-Simulated-Role` as strictly development-only:
- **Frontend:** all three axios interceptors wrapped in `import.meta.env.DEV`
- **Backend:** ASP.NET Core middleware strips the header before any AuthZ logic when `ASPNETCORE_ENVIRONMENT != Development`

Defense-in-depth — neither layer alone is sufficient for a DoD application.

---

### ADR-003 — Domain Entity Ownership: One File per Domain Type
**Closes #367**

Establishes the canonical entity ownership rule:
- `api/package.ts` = authoritative owner of all package-domain types
- `api/packages.ts` = operations only, imports `PackageDetail` from `./package`

Eliminates the silent runtime `undefined` field access from cross-module `PackageDetail` shape conflict.

---

## Review notes
- These ADRs document decisions already made and source-verified against `main`
- Implementation PRs for #362, #364, #367 will reference these ADRs
- Assignee: Mr. Terrific (feature engineering) for implementation
- Review: Batman (arch gate) + Oracle (audit closure)