### PR TITLE
fix(#362): split 401/403 in RequireAuth — ADR-001

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useMsal } from '@azure/msal-react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { DEFAULT_API_SCOPES } from './msalInstance';
 
@@ -30,6 +31,7 @@ import { DEFAULT_API_SCOPES } from './msalInstance';
  */
 export default function RequireAuth({ children }: { children: ReactNode }) {
   const { instance } = useMsal();
+  const navigate = useNavigate();
   const [state, setState] = useState<'probing' | 'authenticated' | 'redirecting'>('probing');
 
   useEffect(() => {
@@ -50,9 +52,10 @@ export default function RequireAuth({ children }: { children: ReactNode }) {
             ? (err as { response?: { status?: number } }).response?.status
             : undefined;
 
-        if (status === 401 || status === 403) {
-          // Not authenticated AND not a simulation session. Punt to
-          // Entra via MSAL with the deep-link state preserved.
+        if (status === 401) {
+          // Not authenticated. Punt to Entra via MSAL with the deep-link
+          // state preserved so the post-login callback returns the user
+          // to the page they requested.
           setState('redirecting');
           const deepLink =
             window.location.pathname + window.location.search + window.location.hash;
@@ -60,6 +63,13 @@ export default function RequireAuth({ children }: { children: ReactNode }) {
             scopes: DEFAULT_API_SCOPES,
             state: deepLink,
           });
+        } else if (status === 403) {
+          // Authenticated Entra identity but no SPIN Agent tenant assignment.
+          // Fix #362: previously treated 403 same as 401 → loginRedirect →
+          // user re-authenticates → gets 403 again → infinite loop.
+          // Navigate to the error page instead so the user gets actionable copy.
+          setState('redirecting');
+          navigate('/login/error?errorClass=NoTenantAssignment', { replace: true });
         } else {
           // Network / server error — show the login page so the user
           // can retry rather than spinning indefinitely.


### PR DESCRIPTION
## Fix: RequireAuth 401 vs 403 split

**ADR:** [ADR-001 — Auth Error Class Semantics](docs/architecture/adr-001-auth-error-class-semantics.md)  
**Issue:** Closes #362  
**Priority:** CRIT

### Problem
`RequireAuth.tsx` treated HTTP 401 and HTTP 403 identically: both called `loginRedirect()`. A valid Entra user with no tenant assignment receives 403, re-authenticates successfully, receives 403 again, infinite loop. Browser eventually surfaces 'Too many redirects'.

### Solution
Per ADR-001, split into two branches:

| Status | Semantic | Action |
|--------|----------|--------|
| 401 | Unauthenticated | `loginRedirect()` (unchanged) |
| 403 | Authenticated, no tenant | `navigate('/login/error?errorClass=NoTenantAssignment')` |

`errorCopy.ts` already defines `NoTenantAssignment` copy. `LoginErrorPage` already accepts `?errorClass=`. This change wires them together.

### Changes
- `RequireAuth.tsx`: add `useNavigate` import + hook; split 401/403 conditional

### Test Plan
| Scenario | Expected |
|---|---|
| Unauthenticated request → 401 | `loginRedirect()` fires |
| Authenticated Entra user, no tenant → 403 | Lands on `/login/error?errorClass=NoTenantAssignment` |
| 403 does NOT call `loginRedirect` | No redirect loop |