### PR TITLE
fix(#364): gate X-Simulated-Role interceptors behind import.meta.env.DEV — ADR-002

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/api.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/csp-onboarding/api.ts
@@ -81,18 +81,20 @@ const cspClient = axios.create({
   withCredentials: true,
 });
 
-cspClient.interceptors.request.use((config) => {
-  try {
-    const raw = localStorage.getItem('ato-dashboard-settings');
-    if (raw) {
-      const settings = JSON.parse(raw) as { role?: string };
-      if (settings.role) config.headers['X-Simulated-Role'] = settings.role;
+if (import.meta.env.DEV) {
+  cspClient.interceptors.request.use((config) => {
+    try {
+      const raw = localStorage.getItem('ato-dashboard-settings');
+      if (raw) {
+        const settings = JSON.parse(raw) as { role?: string };
+        if (settings.role) config.headers['X-Simulated-Role'] = settings.role;
+      }
+    } catch {
+      // ignore
     }
-  } catch {
-    // ignore
-  }
-  return config;
-});
+    return config;
+  });
+}
 // Feature 051 T053: MSAL bearer injection (silent renewal + 401 retry).
 attachAuthInterceptor(cspClient, getMsalInstance, DEFAULT_API_SCOPES);
 function unwrap<T>(envelope: Envelope<T>): T {

--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts
@@ -13,21 +13,23 @@ const onboardingApi = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
-onboardingApi.interceptors.request.use((config) => {
-  // Dev-only role spoofing for the dashboard (FR-048 parity).
-  try {
-    const raw = localStorage.getItem('ato-dashboard-settings');
-    if (raw) {
-      const settings = JSON.parse(raw) as { role?: string };
-      if (settings.role) {
-        config.headers['X-Simulated-Role'] = settings.role;
+if (import.meta.env.DEV) {
+  onboardingApi.interceptors.request.use((config) => {
+    // Dev-only role spoofing for the dashboard (FR-048 parity).
+    try {
+      const raw = localStorage.getItem('ato-dashboard-settings');
+      if (raw) {
+        const settings = JSON.parse(raw) as { role?: string };
+        if (settings.role) {
+          config.headers['X-Simulated-Role'] = settings.role;
+        }
       }
+    } catch {
+      // ignore parse errors
     }
-  } catch {
-    // ignore parse errors
-  }
-  return config;
-});
+    return config;
+  });
+}
 
 // Feature 051 T053: MSAL bearer injection (silent renewal + 401 retry).
 attachAuthInterceptor(onboardingApi, getMsalInstance, DEFAULT_API_SCOPES);

--- a/src/Ato.Copilot.Dashboard/src/features/tenancy/api.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/tenancy/api.ts
@@ -124,18 +124,20 @@ const tenancyClient = axios.create({
   withCredentials: true, // impersonation cookie is HttpOnly + cross-path
 });
 
-tenancyClient.interceptors.request.use((config) => {
-  try {
-    const raw = localStorage.getItem('ato-dashboard-settings');
-    if (raw) {
-      const settings = JSON.parse(raw) as { role?: string };
-      if (settings.role) config.headers['X-Simulated-Role'] = settings.role;
+if (import.meta.env.DEV) {
+  tenancyClient.interceptors.request.use((config) => {
+    try {
+      const raw = localStorage.getItem('ato-dashboard-settings');
+      if (raw) {
+        const settings = JSON.parse(raw) as { role?: string };
+        if (settings.role) config.headers['X-Simulated-Role'] = settings.role;
+      }
+    } catch {
+      // ignore
     }
-  } catch {
-    // ignore
-  }
-  return config;
-});
+    return config;
+  });
+}
 
 // Feature 051 T053: MSAL bearer injection (silent renewal + 401 retry).
 attachAuthInterceptor(tenancyClient, getMsalInstance, DEFAULT_API_SCOPES);


### PR DESCRIPTION
## Fix: X-Simulated-Role DEV guard

**ADR:** [ADR-002 — X-Simulated-Role Header Scope](docs/architecture/adr-002-simulated-role-header-scope.md)
**Issue:** Closes #364
**Priority:** HIGH / SECURITY

### Problem
Three axios clients injected `X-Simulated-Role` from `localStorage['ato-dashboard-settings']` into every outbound request without any environment guard. In production, any user who sets this localStorage key could transmit an arbitrary role header (`CSP.Admin`, `ISSO`, `System.Owner`, etc.) to `/api/onboarding/*`, `/api/csp/onboarding/*`, `/api/tenants/*` — potential privilege escalation if server reads this header for AuthZ.

### Solution
Per ADR-002, wrap all three interceptor registrations in `if (import.meta.env.DEV) { ... }`. `import.meta.env.DEV` is `true` only during `vite dev` and is **compile-time eliminated** in all `vite build` outputs — the production bundle cannot execute this code path.

### Changes
| File | Change |
|---|---|
| `features/onboarding/api/onboardingApi.ts` | DEV guard on request interceptor (line 16) |
| `features/csp-onboarding/api.ts` | DEV guard on request interceptor (line 84) |
| `features/tenancy/api.ts` | DEV guard on request interceptor (line 127) |

### Test Plan
| Scenario | Expected |
|---|---|
| `vite dev` + `ato-dashboard-settings` set | `X-Simulated-Role` header sent |
| Production build + `ato-dashboard-settings` set | `X-Simulated-Role` header NOT sent (dead code) |