### PR TITLE
fix(#367): consolidate PackageDetail to api/package.ts — ADR-003

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/api/packages.ts
+++ b/src/Ato.Copilot.Dashboard/src/api/packages.ts
@@ -1,4 +1,5 @@
 import apiClient from './client';
+import type { PackageDetail } from './package';
 
 export interface PackageJob {
   packageId: string;
@@ -6,17 +7,6 @@ export interface PackageJob {
   message: string;
 }
 
-export interface PackageDetail {
-  packageId: string;
-  systemId: string;
-  status: string;
-  evidenceMode: string;
-  fileSize?: number;
-  generatedAt?: string;
-  completedAt?: string;
-  expiresAt?: string;
-  failureReason?: string;
-}
 
 /** Enqueue a package generation job. Returns packageId + status. */
 export async function enqueuePackage(


### PR DESCRIPTION
## Fix: PackageDetail consolidation

**ADR:** [ADR-003 — Domain Entity Ownership](docs/architecture/adr-003-domain-entity-ownership.md)
**Issue:** Closes #367
**Priority:** HIGH

### Problem
`api/packages.ts` declared a duplicate `PackageDetail` interface with an incompatible minimal shape — missing `artifacts`, `validation`, `failedArtifactType`, `generatedBy`; fields marked `?` (optional) where the canonical type in `api/package.ts` requires non-null. TypeScript does not catch cross-module name collisions: a consumer that happens to import from `api/packages.ts` instead of `api/package.ts` gets silent `undefined` at runtime on any extended field access.

### Solution
Per ADR-003 (one canonical type file per domain entity):
1. Removed the duplicate `PackageDetail` interface from `api/packages.ts`
2. Added `import type { PackageDetail } from './package';` — `packages.ts` re-uses the canonical type for its function signatures

### Consumer audit
`PackageGenerationDialog.tsx` (the only `PackageDetail` consumer) already imports from the canonical `api/package.ts`. Zero import-site changes needed.

### Changes
| File | Change |
|---|---|
| `api/packages.ts` | Remove duplicate interface; add `import type { PackageDetail } from './package'` |

### tsc --noEmit
`PackageDetail` in `packages.ts` function signatures (`getPackageStatus`) now resolves to the canonical full shape. No type errors introduced.