### PR TITLE
fix(cd): correct AzureCloud env var defaults — AzureGovernment fallback caused revision activation failure

### DIFF
--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -240,11 +240,18 @@ jobs:
           ENV_ARGS_BASE=""
           if [ "${{ inputs.include_mcp_env_vars }}" = "true" ]; then
             ENV_ARGS_BASE="ASPNETCORE_URLS=http://+:3001 ATO_RUN_MODE=http"
-            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_GATEWAY__AZURE__CLOUDENVIRONMENT=${{ vars.ATO_GATEWAY_AZURE_CLOUDENVIRONMENT || 'AzureGovernment' }}"
-            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENABLED=${{ vars.ATO_AZUREAI_ENABLED || 'false' }}"
+            # ATO_GATEWAY_AZURE_CLOUDENVIRONMENT: repo var (required). Safe fallback is AzureCloud
+            # (this deployment targets Azure Commercial, not Azure Government).
+            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_GATEWAY__AZURE__CLOUDENVIRONMENT=${{ vars.ATO_GATEWAY_AZURE_CLOUDENVIRONMENT || 'AzureCloud' }}"
+            # ATO_AZUREAI_ENABLED: repo var (required). Safe fallback is true — AI is needed for
+            # all MCP tool invocations. false causes startup to bypass AI client registration
+            # but the revision still activates; the real issue is empty endpoint + enabled=true.
+            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENABLED=${{ vars.ATO_AZUREAI_ENABLED || 'true' }}"
             ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__PROVIDER=${{ vars.ATO_AZUREAI_PROVIDER || 'OpenAi' }}"
-            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENDPOINT=${{ vars.ATO_AZUREAI_ENDPOINT || '' }}"
-            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__DEPLOYMENTNAME=${{ vars.ATO_AZUREAI_DEPLOYMENTNAME || 'gpt-4o' }}"
+            # ATO_AZUREAI_ENDPOINT: repo var (required). Must be set — empty value prevents
+            # AI client registration and causes revision activation failure.
+            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENDPOINT=${{ vars.ATO_AZUREAI_ENDPOINT }}"
+            ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__DEPLOYMENTNAME=${{ vars.ATO_AZUREAI_DEPLOYMENTNAME || 'gpt-5.4-mini' }}"
           elif [ "${{ inputs.workload }}" = "dashboard" ]; then
             MCP_OVERRIDE="${{ inputs.mcp_base_url_override }}"
             if [ -n "$MCP_OVERRIDE" ]; then


### PR DESCRIPTION
## Problem Statement
Revision `ca-ato-copilot-mcp-v2--0000029` (commit `78f9c99`) failed to activate because three critical env vars were deploying with wrong fallback values in `deploy-containerapp-stage.yml`.

**Files affected:** `.github/workflows/deploy-containerapp-stage.yml`

### Root Cause
Three GitHub Actions repo variables (`ATO_GATEWAY_AZURE_CLOUDENVIRONMENT`, `ATO_AZUREAI_ENABLED`, `ATO_AZUREAI_ENDPOINT`) were **not defined** in the `azurenoops/spin_agent` repo. The workflow fell back to hardcoded defaults:

| Variable | Wrong Default | Correct Value |
|---|---|---|
| `ATO_GATEWAY__AZURE__CLOUDENVIRONMENT` | `AzureGovernment` | `AzureCloud` |
| `ATO_AZUREAI__ENABLED` | `false` | `true` |
| `ATO_AZUREAI__ENDPOINT` | `''` (empty) | `https://ato-copilot.openai.azure.com/` |
| `ATO_AZUREAI__DEPLOYMENTNAME` | `gpt-4o` | `gpt-5.4-mini` |

This deployment targets **Azure Commercial** (not Azure Government). The `AzureGovernment` value causes the Azure SDK to use USGovernment authority endpoints, which fail against the commercial SQL server and OpenAI endpoints.

## Fix

1. **Workflow hardcoded fallbacks updated** — safe fallbacks now default to `AzureCloud` and `true`
2. **Repo variables set** — all 5 variables now configured in `azurenoops/spin_agent` Actions variables

### Repo Variables Set (immediate fix)
- `ATO_GATEWAY_AZURE_CLOUDENVIRONMENT = AzureCloud`
- `ATO_AZUREAI_ENABLED = true`
- `ATO_AZUREAI_ENDPOINT = https://ato-copilot.openai.azure.com/`
- `ATO_AZUREAI_DEPLOYMENTNAME = gpt-5.4-mini`
- `ATO_AZUREAI_PROVIDER = OpenAi`

### Workflow Change
- `AzureGovernment` => `AzureCloud` fallback for `ATO_GATEWAY__AZURE__CLOUDENVIRONMENT`
- `false` => `true` fallback for `ATO_AZUREAI__ENABLED`
- `|| ''` removed for `ATO_AZUREAI__ENDPOINT` (fail loudly if not set rather than silently empty)
- `gpt-4o` => `gpt-5.4-mini` fallback (matches the actually deployed model on `ato-copilot`)

## Acceptance Criteria
- Next CD run produces a revision that activates at 100% traffic
- `ATO_GATEWAY__AZURE__CLOUDENVIRONMENT=AzureCloud` in container app env
- `ATO_AZUREAI__ENABLED=true` in container app env
- `ATO_AZUREAI__ENDPOINT=https://ato-copilot.openai.azure.com/` in container app env