### PR TITLE
fix(wave8): security & auth hardening — #365 #366 #368 #96

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/cards/GateActionDialog.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/cards/GateActionDialog.tsx
@@ -7,8 +7,10 @@ import {
   setCategorization,
   selectBaseline,
 } from '../../api/systemDetail';
-import { assignRole, fetchRoles, deleteRole } from '../../api/roles';
-import type { RoleAssignment } from '../../api/roles';
+// Issue #366 — migrate from deprecated fetchRoles/assignRole/deleteRole to rolesApi
+// (FR-008 / FR-010 / FR-011 unified role endpoints, Feature 049).
+import { rolesApi } from '../../api/roles';
+import type { ResolvedRoleAssignment, RmfRole } from '../../types/roles';
 import { listComponents } from '../../api/components';
 import type { OrgComponentDto } from '../../api/components';
 import type {
@@ -103,9 +105,9 @@ export default function GateActionDialog({ action, systemId, onClose, onSuccess 
   const [personComponents, setPersonComponents] = useState<OrgComponentDto[]>([]);
   const [personSearch, setPersonSearch] = useState('');
   const [selectedPerson, setSelectedPerson] = useState<OrgComponentDto | null>(null);
-  const [existingRoles, setExistingRoles] = useState<RoleAssignment[]>([]);
+  const [existingRoles, setExistingRoles] = useState<ResolvedRoleAssignment[]>([]);
   const [rolesLoading, setRolesLoading] = useState(false);
-  const [deletingRoleId, setDeletingRoleId] = useState<string | null>(null);
+  const [deletingRoleKey, setDeletingRoleKey] = useState<string | null>(null);
 
   // Load Person components and existing roles for the roles action
   useEffect(() => {
@@ -113,10 +115,10 @@ export default function GateActionDialog({ action, systemId, onClose, onSuccess 
     setRolesLoading(true);
     Promise.all([
       listComponents({ type: 'Person', pageSize: 200 }),
-      fetchRoles(systemId),
+      rolesApi.getSystemRoles(systemId),
     ]).then(([compResult, rolesResult]) => {
       setPersonComponents(compResult.items);
-      setExistingRoles(rolesResult);
+      setExistingRoles(rolesResult.roles.filter((r) => r.source !== 'not-assigned'));
     }).finally(() => setRolesLoading(false));
   }, [action, systemId]);
 
@@ -124,14 +126,15 @@ export default function GateActionDialog({ action, systemId, onClose, onSuccess 
     (c) => !personSearch || c.name.toLowerCase().includes(personSearch.toLowerCase()),
   );
 
-  const handleDeleteRole = async (roleId: string) => {
-    setDeletingRoleId(roleId);
+  const handleDeleteRole = async (role: RmfRole, personId: string) => {
+    const key = `${role}:${personId}`;
+    setDeletingRoleKey(key);
     try {
-      await deleteRole(systemId, roleId);
-      const updated = await fetchRoles(systemId);
-      setExistingRoles(updated);
+      await rolesApi.removeSystemRole(systemId, role, personId);
+      const updated = await rolesApi.getSystemRoles(systemId);
+      setExistingRoles(updated.roles.filter((r) => r.source !== 'not-assigned'));
     } finally {
-      setDeletingRoleId(null);
+      setDeletingRoleKey(null);
     }
   };
 
@@ -201,13 +204,18 @@ export default function GateActionDialog({ action, systemId, onClose, onSuccess 
           break;
         case 'roles': {
           if (!selectedPerson) { setError('Select a person to assign'); setLoading(false); return; }
-          await assignRole(systemId, {
-            role: roleSelected,
-            userDisplayName: selectedPerson.name,
+          const result = await rolesApi.assignSystemRole(systemId, {
+            role: roleSelected as RmfRole,
+            personId: selectedPerson.id,
           });
+          if (result.status === 'error') {
+            setError(result.error?.message ?? 'Role assignment failed');
+            setLoading(false);
+            return;
+          }
           // Refresh existing roles list
-          const updated = await fetchRoles(systemId);
-          setExistingRoles(updated);
+          const updated = await rolesApi.getSystemRoles(systemId);
+          setExistingRoles(updated.roles.filter((r) => r.source !== 'not-assigned'));
           setSelectedPerson(null);
           setLoading(false);
           return; // Don't close — let user assign more roles
@@ -466,19 +474,22 @@ export default function GateActionDialog({ action, systemId, onClose, onSuccess 
                   <p className="text-xs font-medium text-gray-700 mb-1.5">Current Assignments</p>
                   <div className="divide-y divide-gray-100 rounded-md border border-gray-200">
                     {existingRoles.map((r) => (
-                      <div key={r.id} className="flex items-center justify-between px-3 py-2">
+                      <div key={`${r.role}:${r.person?.id ?? 'none'}`} className="flex items-center justify-between px-3 py-2">
                         <div className="flex items-center gap-2 min-w-0">
                           <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${roleBadgeColor(r.role)}`}>
                             {roleLabel(r.role)}
                           </span>
-                          <span className="text-sm text-gray-900 truncate">{r.userDisplayName ?? r.userId}</span>
+                          <span className="text-sm text-gray-900 truncate">{r.person?.displayName ?? '—'}</span>
+                          {r.source === 'inherited' && (
+                            <span className="text-xs text-gray-400 italic">(inherited)</span>
+                          )}
                         </div>
                         <button
                           type="button"
-                          onClick={() => handleDeleteRole(r.id)}
-                          disabled={deletingRoleId === r.id}
+                          onClick={() => r.person && void handleDeleteRole(r.role, r.person.id)}
+                          disabled={!r.person || r.source === 'inherited' || deletingRoleKey === `${r.role}:${r.person?.id}`}
                           className="text-gray-400 hover:text-red-600 transition-colors disabled:opacity-50"
-                          title="Remove"
+                          title={r.source === 'inherited' ? 'Inherited — remove via Org settings' : 'Remove'}
                         >
                           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
-import { fetchRoles, assignRole } from '../../../api/roles';
-import type { RoleAssignment } from '../../../api/roles';
+// Issue #366 — migrate from deprecated fetchRoles/assignRole to rolesApi
+// (FR-008 / FR-010 unified role endpoints, Feature 049).
+import { rolesApi } from '../../../api/roles';
+import type { ResolvedRoleAssignment, RmfRole } from '../../../types/roles';
 import apiClient from '../../../api/client';
 
 const RMF_ROLES = [
@@ -32,12 +34,14 @@ interface AssignRolesProps {
 }
 
 export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesProps) {
-  const [assignments, setAssignments] = useState<RoleAssignment[]>([]);
+  const [assignments, setAssignments] = useState<ResolvedRoleAssignment[]>([]);
   const [persons, setPersons] = useState<PersonOption[]>([]);
   const [saving, setSaving] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchRoles(systemId).then(setAssignments).catch(() => {});
+    rolesApi.getSystemRoles(systemId)
+      .then((res) => setAssignments(res.roles.filter((r) => r.source !== 'not-assigned')))
+      .catch(() => {});
     apiClient.get('/components', { params: { type: 'Person', pageSize: 200 } })
       .then((res) => setPersons(res.data.items ?? []))
       .catch(() => {});
@@ -48,12 +52,16 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
   const handleAssign = async (role: string, person: PersonOption) => {
     setSaving(role);
     try {
-      const result = await assignRole(systemId, {
-        role,
-        userId: person.id,
-        userDisplayName: person.personName || person.name,
+      const result = await rolesApi.assignSystemRole(systemId, {
+        role: role as RmfRole,
+        personId: person.id,
       });
-      setAssignments((prev) => [...prev.filter((a) => a.role !== role), result]);
+      if (result.status === 'error') {
+        onErrors({ [role]: [result.error?.message ?? 'Failed to assign role'] });
+        return;
+      }
+      const updated = await rolesApi.getSystemRoles(systemId);
+      setAssignments(updated.roles.filter((r) => r.source !== 'not-assigned'));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to assign role';
       onErrors({ [role]: [msg] });
@@ -76,14 +84,14 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
                 <div className="text-sm font-medium text-gray-900">{ROLE_LABELS[role]}</div>
                 {current ? (
                   <div className="text-xs text-green-600 mt-0.5">
-                    Assigned to: {current.userDisplayName ?? current.userId}
+                    Assigned to: {current.person?.displayName ?? '—'}
                   </div>
                 ) : (
                   <div className="text-xs text-gray-400 mt-0.5">Unassigned</div>
                 )}
               </div>
               <select
-                value={current?.userId ?? ''}
+                value={current?.person?.id ?? ''}
                 onChange={(e) => {
                   const person = persons.find((p) => p.id === e.target.value);
                   if (person) handleAssign(role, person);

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/VerifyRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/VerifyRoles.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
-import { fetchRoles } from '../../../api/roles';
-import type { RoleAssignment } from '../../../api/roles';
+// Issue #366 — migrate from deprecated fetchRoles to rolesApi
+// (FR-008 unified role endpoints, Feature 049).
+import { rolesApi } from '../../../api/roles';
+import type { ResolvedRoleAssignment } from '../../../types/roles';
 
 const ROLE_LABELS: Record<string, string> = {
   AuthorizingOfficial: 'Authorizing Official (AO)',
@@ -16,12 +18,12 @@ interface VerifyRolesProps {
 }
 
 export default function VerifyRoles({ systemId, onNext }: VerifyRolesProps) {
-  const [assignments, setAssignments] = useState<RoleAssignment[]>([]);
+  const [assignments, setAssignments] = useState<ResolvedRoleAssignment[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchRoles(systemId)
-      .then(setAssignments)
+    rolesApi.getSystemRoles(systemId)
+      .then((res) => setAssignments(res.roles.filter((r) => r.source !== 'not-assigned')))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [systemId]);
@@ -44,20 +46,20 @@ export default function VerifyRoles({ systemId, onNext }: VerifyRolesProps) {
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Role</th>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Assigned Person</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Assignment Date</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Source</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {assignments.map((a) => (
-                <tr key={a.id}>
+                <tr key={`${a.role}:${a.person?.id ?? 'none'}`}>
                   <td className="px-4 py-3 text-sm font-medium text-gray-900">
                     {ROLE_LABELS[a.role] ?? a.role}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-600">
-                    {a.userDisplayName ?? a.userId}
+                    {a.person?.displayName ?? '—'}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500">
-                    {new Date(a.assignedAt).toLocaleDateString()}
+                    {a.source}
                   </td>
                 </tr>
               ))}

--- a/src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts
@@ -11,6 +11,11 @@ import { getMsalInstance, DEFAULT_API_SCOPES } from '../../auth/msalInstance';
 const onboardingApi = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL_ONBOARDING || '/api/onboarding',
   headers: { 'Content-Type': 'application/json' },
+  // Issue #365 — withCredentials must be true so that the browser sends the
+  // MSAL session cookie alongside the Authorization: Bearer header in
+  // cross-origin configurations. Without this the backend 401s on CORS
+  // pre-flight + credentialed request pairs (FR-005, Feature 051 § 3.3).
+  withCredentials: true,
 });
 
 if (import.meta.env.DEV) {

--- a/src/Ato.Copilot.Dashboard/src/hooks/useNotifications.ts
+++ b/src/Ato.Copilot.Dashboard/src/hooks/useNotifications.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import * as signalR from '@microsoft/signalr';
 import apiClient from '../api/client';
+import { getMsalInstance, DEFAULT_API_SCOPES } from '../features/auth/msalInstance';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -86,8 +87,28 @@ export function useNotifications(userId: string = 'dashboard-user') {
     const baseUrl = import.meta.env.VITE_API_BASE_URL?.replace('/api/dashboard', '') || '';
     const hubUrl = `${baseUrl}/hubs/notifications`;
 
+    // Issue #368 — accessTokenFactory wires MSAL bearer into the SignalR
+    // WebSocket upgrade handshake (and reconnects). Without it the hub's
+    // [Authorize] attribute returns 401 on the negotiate request, silently
+    // falling back to the no-op error path and never receiving real-time
+    // push events (Feature 051 § 3.3, FR-005).
     const connection = new signalR.HubConnectionBuilder()
-      .withUrl(hubUrl)
+      .withUrl(hubUrl, {
+        accessTokenFactory: async () => {
+          try {
+            const msal = getMsalInstance();
+            const accounts = msal.getAllAccounts();
+            if (!accounts.length) return '';
+            const result = await msal.acquireTokenSilent({
+              scopes: DEFAULT_API_SCOPES,
+              account: accounts[0]!,
+            });
+            return result.accessToken;
+          } catch {
+            return '';
+          }
+        },
+      })
       .withAutomaticReconnect()
       .build();
 

--- a/src/Ato.Copilot.Dashboard/src/pages/AuditLogPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/AuditLogPage.tsx
@@ -1,7 +1,12 @@
 /**
  * Wave 6 — GAP-016: Audit Log page.
+ * Wave 8 — Feature 051 / US10: Login event audit trail (FR-032–FR-038).
  *
  * Surfaces GET /api/audit with filterable, sortable, paginated event table.
+ * Login-specific event types (LoginSuccess, LoginFailure, IdleSignOut,
+ * SimulationBlocked, ImpersonationStart, ImpersonationEnd, TenantSwitch)
+ * include surface + correlationId columns per FR-032.
+ *
  * Accessible at /audit (RequireAuth + CSP.Admin / Auditor).
  */
 import { useState, useCallback } from 'react';
@@ -22,6 +27,9 @@ interface AuditLogEntry {
   impersonatedTenantName: string | null;
   timestamp: string;
   ipAddress: string | null;
+  // Feature 051 / US10 (FR-032) — login-event-specific fields.
+  surface: string | null;
+  correlationId: string | null;
 }
 
 interface AuditLogPage {
@@ -33,14 +41,22 @@ interface AuditLogPage {
 
 const PAGE_SIZE = 50;
 
+// Feature 051 / US10 — expanded to cover all login event types (FR-032, FR-035).
 const ACTION_COLORS: Record<string, string> = {
   Impersonation: 'bg-violet-100 text-violet-800',
   ImpersonationEnd: 'bg-violet-100 text-violet-600',
+  ImpersonationStart: 'bg-violet-100 text-violet-800',
   TenantStatusChange: 'bg-amber-100 text-amber-800',
+  TenantSwitch: 'bg-amber-100 text-amber-700',
   Login: 'bg-green-100 text-green-700',
+  LoginSuccess: 'bg-green-100 text-green-700',
+  LoginFailure: 'bg-red-100 text-red-700',
+  IdleSignOut: 'bg-orange-100 text-orange-700',
   Logout: 'bg-gray-100 text-gray-600',
   Export: 'bg-indigo-100 text-indigo-700',
   Migration: 'bg-red-100 text-red-700',
+  SimulationBlocked: 'bg-rose-100 text-rose-800',
+  SimulatedLogin: 'bg-yellow-100 text-yellow-800',
 };
 
 function ActionBadge({ action }: { action: string }) {
@@ -143,15 +159,17 @@ export default function AuditLogPage() {
               <th className="px-4 py-3 text-left">Timestamp</th>
               <th className="px-4 py-3 text-left">Action</th>
               <th className="px-4 py-3 text-left">Actor</th>
+              <th className="px-4 py-3 text-left">Surface</th>
               <th className="px-4 py-3 text-left">Entity</th>
               <th className="px-4 py-3 text-left">Detail</th>
+              <th className="px-4 py-3 text-left">Correlation ID</th>
               <th className="px-4 py-3 text-left">IP</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
             {loading && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-gray-400">
+                <td colSpan={8} className="px-4 py-8 text-center text-gray-400">
                   <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent mr-2" />
                   Loading audit log…
                 </td>
@@ -159,7 +177,7 @@ export default function AuditLogPage() {
             )}
             {!loading && data?.items.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-gray-400">No events match your filters.</td>
+                <td colSpan={8} className="px-4 py-8 text-center text-gray-400">No events match your filters.</td>
               </tr>
             )}
             {!loading && data?.items.map((entry) => (
@@ -176,11 +194,17 @@ export default function AuditLogPage() {
                     <span className="ml-1 text-xs text-violet-600">(impersonating {entry.impersonatedTenantName})</span>
                   )}
                 </td>
+                <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-500">
+                  {entry.surface ?? '—'}
+                </td>
                 <td className="px-4 py-2 text-xs text-gray-500">
                   {entry.entityType ? `${entry.entityType} ${entry.entityId ?? ''}` : '—'}
                 </td>
                 <td className="px-4 py-2 max-w-[280px] truncate text-gray-600 text-xs">
                   {entry.detail ?? '—'}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs text-gray-400 max-w-[140px] truncate" title={entry.correlationId ?? ''}>
+                  {entry.correlationId ? entry.correlationId.substring(0, 8) + '…' : '—'}
                 </td>
                 <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-gray-400">
                   {entry.ipAddress ?? '—'}


### PR DESCRIPTION
## Summary
All four Wave 8 security & auth hardening issues addressed in a single branch off `main`. Each fix is an atomic commit; they can be cherry-picked individually if needed.

---

## Changes

### Commit 1 — #365 `fix(auth): add withCredentials:true to onboardingApi`
**File:** `src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts`

The `onboardingApi` axios instance was created without `withCredentials: true`. In cross-origin containerapp deployments the browser omits the MSAL session cookie from the CORS preflight + credentialed request, causing the backend to return 401. The `apiClient` and `rolesClient` instances already set this correctly; this aligns `onboardingApi` (Feature 051 § 3.3, FR-005).

### Commit 2 — #366 `fix(roles): replace 3 deprecated roles API calls with rolesApi`
**Files:** `GateActionDialog.tsx`, `AssignRoles.tsx`, `VerifyRoles.tsx`

Three production components still called the deprecated legacy API (`fetchRoles`, `assignRole`, `deleteRole`) targeting the old `RmfRoleAssignments` table. All three migrated to the Feature 049 unified `rolesApi`:

| Old | New | FR |
|-----|-----|----|
| `fetchRoles(id)` | `rolesApi.getSystemRoles(id)` | FR-008 |
| `assignRole(id, body)` | `rolesApi.assignSystemRole(id, body)` | FR-010 |
| `deleteRole(id, roleId)` | `rolesApi.removeSystemRole(id, role, personId)` | FR-011 |

Side effects:
- GateActionDialog now surfaces `inherited` role badges and disables deletion of inherited rows (must be removed via Org Settings per FR-007).
- AssignRoles now surfaces rolesApi `AssignmentResult.error` envelopes inline.
- VerifyRoles table shows `source` tag instead of `assignedAt`.

### Commit 3 — #368 `fix(signalr): wire MSAL accessTokenFactory to notifications hub`
**File:** `src/Ato.Copilot.Dashboard/src/hooks/useNotifications.ts`

`useNotifications` built a SignalR `HubConnectionBuilder` with `.withUrl(hubUrl)` but no `accessTokenFactory`. The `/hubs/notifications` endpoint has `[Authorize]`, so the negotiate request returned 401 and silently fell to the `.catch()` block. Fix: pass `accessTokenFactory` using `getMsalInstance().acquireTokenSilent()`. The factory fires on every reconnect via `.withAutomaticReconnect()`.

### Commit 4 — #96 `feat(audit): expand AuditLogPage for login event trail UI`
**File:** `src/Ato.Copilot.Dashboard/src/pages/AuditLogPage.tsx`

Feature 051 / US10 (FR-032–FR-038) requires the Audit Log UI to surface all authentication events with `surface` and `correlationId` per the `LoginAuditEvent` backend contract:

- `AuditLogEntry` interface adds `surface` and `correlationId` fields
- `ACTION_COLORS` expanded: `LoginSuccess`, `LoginFailure`, `IdleSignOut`, `SimulationBlocked`, `SimulatedLogin`, `ImpersonationStart`, `TenantSwitch`
- Table adds **Surface** and **Correlation ID** columns (ID truncated to 8 chars; full value in `title` attr)
- `colSpan` updated from 6 to 8

Backend T085-T099 and throttle middleware T142-T144 were previously shipped in `051-cicd-hardening`. This closes the UI-side of US10 (T100).

---

## Testing
- `#365`: Verify `/api/onboarding/*` calls include `Cookie:` header in DevTools Network (cross-origin deploy).
- `#366`: Open GateActionDialog → Roles; confirm assigned roles display with source tag; inherited rows show "(inherited)" badge; remove button disabled for inherited rows.
- `#368`: Open DevTools → Network → WS; verify `/hubs/notifications/negotiate` returns 200 (not 401).
- `#96`: Open `/audit`; verify Login/LoginSuccess/LoginFailure/IdleSignOut badge colors; Surface and Correlation ID columns present.

## Spec Compliance
- Feature 051 § 3.3 (withCredentials, accessTokenFactory)
- FR-005, FR-007, FR-008, FR-010, FR-011, FR-032–FR-038

## Rollback
```
git revert --no-commit 4a71941 20c6cca 06aa1b2 21da894
git commit -m "revert: wave8 security auth fixes"
```
