### PR TITLE
fix(#386): replace hardcoded 60s migration CTS — revision ActivationFailed on cold start with MI auth

### DIFF
--- a/src/Ato.Copilot.Core/Configuration/DatabaseOptions.cs
+++ b/src/Ato.Copilot.Core/Configuration/DatabaseOptions.cs
@@ -49,4 +49,14 @@ public class DatabaseOptions
     /// </summary>
     [Range(1, 300)]
     public int MaxRetryDelay { get; set; } = 30;
+
+    /// <summary>
+    /// Overall timeout in seconds for the startup database migration / schema-ensure
+    /// operation (the <c>CancellationTokenSource</c> wrapping <c>MigrateDatabaseAsync</c>).
+    /// On Azure Container Apps with Managed Identity SQL auth, cold-start token acquisition
+    /// can take 20–30 s before the first connection attempt, so this must be well above
+    /// <c>CommandTimeoutSeconds × MaxRetryCount</c>. Default: 300 s (5 minutes).
+    /// </summary>
+    [Range(30, 1800)]
+    public int MigrationTimeoutSeconds { get; set; } = 300;
 }

--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -755,7 +755,16 @@ async Task MigrateDatabaseAsync(IServiceProvider services)
 
     try
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var dbOptions = scope.ServiceProvider
+            .GetService<Microsoft.Extensions.Options.IOptions<Ato.Copilot.Core.Configuration.DatabaseOptions>>()?.Value
+            ?? new Ato.Copilot.Core.Configuration.DatabaseOptions();
+
+        // Use configurable migration timeout (default 300 s).
+        // The previous hardcoded 60 s was insufficient on Azure Container Apps with
+        // Managed Identity SQL auth: cold-start token acquisition alone takes 20–30 s,
+        // leaving less than 30 s for EnsureCreatedAsync + schema additions.
+        // Root cause of revision ActivationFailed (issue #386).
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(dbOptions.MigrationTimeoutSeconds));
         var provider = scope.ServiceProvider.GetRequiredService<IConfiguration>()
             .GetValue<string>("Database:Provider") ?? "SQLite";
 

--- a/src/Ato.Copilot.Mcp/appsettings.json
+++ b/src/Ato.Copilot.Mcp/appsettings.json
@@ -115,9 +115,10 @@
   "Database": {
     "Provider": "SqlServer",
     "EnableSensitiveDataLogging": false,
-    "CommandTimeoutSeconds": 30,
+    "CommandTimeoutSeconds": 60,
     "MaxRetryCount": 5,
-    "MaxRetryDelay": 30
+    "MaxRetryDelay": 30,
+    "MigrationTimeoutSeconds": 300
   },
   "Agents": {
     "Compliance": {


### PR DESCRIPTION
## Fixes #386 — Revision ActivationFailed: SQL Migration Timeout

### Root Cause

`MigrateDatabaseAsync` (Program.cs line ~758) wrapped the entire DB startup sequence in a **hardcoded `CancellationTokenSource(60s)`**. On Azure Container Apps with `Authentication=Active Directory Managed Identity`, cold-start token acquisition takes 20–30 s before the first SQL connection attempt. This left less than 30 s for `EnsureCreatedAsync` + schema additions, causing the CTS to fire and throw `TaskCanceledException`.

`EnableRetryOnFailure` was already configured correctly — it could not help because the CTS cancelled the entire migration operation before retries could occur.

### Why It Passed Before

Revision `--0000012` was deployed before stricter ACA health validation and warm-started from a cached connection pool. All subsequent revisions fail on cold start.

### Changes

**`DatabaseOptions.cs`** — new property:
```csharp
[Range(30, 1800)]
public int MigrationTimeoutSeconds { get; set; } = 300;  // was hardcoded 60
```

**`Program.cs`** — CTS now reads config instead of hardcoding:
```csharp
// Before:
using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));

// After:
using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(dbOptions.MigrationTimeoutSeconds));
```

**`appsettings.json`** — production defaults:
```json
"Database": {
  "CommandTimeoutSeconds": 60,   // was 30 — doubles per-command budget
  "MigrationTimeoutSeconds": 300 // new — 5 min overall migration window
}
```

### Why This Is Safe

- `MigrationTimeoutSeconds=300` is the default in `DatabaseOptions`. If `IOptions<DatabaseOptions>` is unavailable at DI scope resolution, the code falls back to `new DatabaseOptions()` which also defaults to 300 s.
- `CommandTimeoutSeconds=60` gives 5 retry × 60s = 300s of EF retry budget before the CTS fires.
- `MigrationTimeoutSeconds` is bounded `[30, 1800]` via `[Range]` validation.

### Acceptance Criteria
- [ ] Next CD revision activates at 100% traffic with `Running` state
- [ ] Log shows `"SQL Server database ready"` without `FTL` entries
- [ ] `EnsureCreatedAsync` completes within the 300s window even on cold start

Closes #386