### PR TITLE
fix(#371): add loading/error states to 5 null-rendering components

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/DeviationSummaryCards.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/DeviationSummaryCards.tsx
@@ -6,7 +6,13 @@ interface DeviationSummaryCardsProps {
 }
 
 export default function DeviationSummaryCards({ summary }: DeviationSummaryCardsProps) {
-  if (!summary) return null;
+  if (!summary) {
+    return (
+      <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        Unable to load deviation summary.
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/Ato.Copilot.Dashboard/src/components/capabilities/CoverageCards.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/capabilities/CoverageCards.tsx
@@ -33,7 +33,17 @@ export default function CoverageCards({ coverage, loading }: CoverageCardsProps)
     );
   }
 
-  if (!coverage) return null;
+  if (!coverage) {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="rounded-lg border border-red-100 bg-red-50 p-4 text-xs text-red-500">
+            Failed to load
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   const gapControls = coverage.unmappedControls;
   const coveragePct = coverage.coveragePercent;

--- a/src/Ato.Copilot.Dashboard/src/components/cards/TodoPanel.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/cards/TodoPanel.tsx
@@ -70,7 +70,14 @@ export default function TodoPanel({ systemId }: TodoPanelProps) {
     );
   }
 
-  if (error || !data || data.items.length === 0) return null;
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 px-5 py-4 text-sm text-red-700">
+        Unable to load tasks. Please refresh.
+      </div>
+    );
+  }
+  if (!data || data.items.length === 0) return null;
 
   const arrow = (
     <svg className="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/src/Ato.Copilot.Dashboard/src/components/portfolio/AoPendingDecisionsWidget.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/portfolio/AoPendingDecisionsWidget.tsx
@@ -66,7 +66,12 @@ export default function AoPendingDecisionsWidget() {
   }, []);
 
   // Hidden while loading or when there are no pending decisions
-  if (loading || decisions.length === 0) return null;
+  if (loading) {
+    return (
+      <div className="mb-6 h-24 animate-pulse rounded-lg border border-amber-200 bg-amber-50" />
+    );
+  }
+  if (decisions.length === 0) return null;
 
   return (
     <div className="mb-6 rounded-lg border border-amber-300 bg-amber-50 shadow-sm">

--- a/src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx
@@ -84,8 +84,13 @@ export default function RequireAuth({ children }: { children: ReactNode }) {
     };
   }, [instance]);
 
-  if (state !== 'authenticated') {
-    return null;
+  if (state === 'probing') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
+      </div>
+    );
   }
+  if (state === 'redirecting') return null;
   return <>{children}</>;
 }


### PR DESCRIPTION
## 1. Problem

Five React components across the dashboard silently returned `null` without distinguishing between a transient loading state and a genuine error. This caused blank sections in the UI — users saw nothing during the auth probe, while todos were loading, while coverage data was fetching, while deviation summary was loading, and while pending decisions were being retrieved — with no feedback that something was happening or had gone wrong.

Specifically:
- **RequireAuth**: `if (state !== 'authenticated') return null` — blank-screened the entire app during the MSAL/server auth probe (typically 200–600 ms).
- **TodoPanel**: `if (error || !data || data.items.length === 0) return null` — silently swallowed fetch errors, showing the same blank as an intentionally empty list.
- **AoPendingDecisionsWidget**: `if (loading || decisions.length === 0) return null` — no skeleton during the initial 60-second-poll fetch.
- **CoverageCards**: `if (!coverage) return null` after the loading skeleton — a failed fetch looked the same as a successful empty response.
- **DeviationSummaryCards**: `if (!summary) return null` — no indication that summary data failed to load.

## 2. Goal

Add appropriate loading indicators and error states to all five components so that:
- Loading states show visual feedback (spinner / skeleton) instead of blank space.
- Error states surface an actionable inline message instead of silently hiding content.
- Intentionally empty states (no todos, no pending decisions) remain silent — those are correct by design.

## 3. Scope

**In scope:**
- `RequireAuth.tsx` — auth probe UX
- `TodoPanel.tsx` — todo fetch error handling
- `AoPendingDecisionsWidget.tsx` — loading skeleton
- `CoverageCards.tsx` — coverage fetch error state
- `DeviationSummaryCards.tsx` — deviation summary error banner

**Out of scope:**
- Retry logic / auto-recover
- Toast notifications or global error boundary changes
- Any backend changes

## 4. UX Flow

**Before:**
- User navigates to any protected route → blank white screen for ~300 ms with no spinner
- Todo fetch fails → todo section disappears silently
- Coverage fetch fails → coverage cards section disappears silently
- Deviation summary fails → summary cards section disappears silently
- Pending decisions widget loading → no visual placeholder; widget just appears suddenly

**After:**
- User navigates to any protected route → full-screen centered spinner during auth probe; instant redirect with no flash once auth resolves
- Todo fetch fails → small red inline notice: "Unable to load tasks. Please refresh."
- Coverage fetch fails → four "Failed to load" error tiles matching the card grid layout
- Deviation summary fails → red inline banner: "Unable to load deviation summary."
- Pending decisions loading → amber skeleton placeholder that matches the widget height

## 5. Functional Requirements

1. `RequireAuth` MUST display a centered spinner while `state === 'probing'`.
2. `RequireAuth` MUST return `null` (no UI) when `state === 'redirecting'` (redirect already in flight).
3. `RequireAuth` MUST render `children` only when `state === 'authenticated'`.
4. `TodoPanel` MUST display an inline error message when `error` is truthy.
5. `TodoPanel` MUST return `null` (silent) when data is empty — this is intentional design.
6. `AoPendingDecisionsWidget` MUST display an amber skeleton while `loading === true`.
7. `AoPendingDecisionsWidget` MUST return `null` when decisions list is empty after load.
8. `CoverageCards` MUST display four "Failed to load" error tiles when `coverage` is null post-load.
9. `DeviationSummaryCards` MUST display a red error banner when `summary` is null.

## 6. Technical Design

Each fix is a minimal, surgical replacement of a single `return null` guard:

- **RequireAuth**: The existing `state` discriminated union (`'probing' | 'authenticated' | 'redirecting'`) already encodes the right states. We switch from a single `!== 'authenticated'` guard to separate handling of each state.
- **TodoPanel**: Split the compound `if (error || !data || data.items.length === 0)` into two separate checks — the error branch renders a red pill; the empty-data branch continues to return null.
- **AoPendingDecisionsWidget**: Split `if (loading || decisions.length === 0)` into sequential checks. Loading returns an `animate-pulse` amber skeleton `<div>`.
- **CoverageCards**: Replace `if (!coverage) return null` with a grid of four red error tiles that mirror the normal card grid layout so the page doesn't collapse.
- **DeviationSummaryCards**: Replace `if (!summary) return null` with a red `mb-6` banner consistent with the page's spacing conventions.

All error/loading UI uses existing Tailwind utility classes already present in the project — no new dependencies.

## 7. Architecture Decisions

- **No retry buttons** — keep the components stateless with respect to retry; refresh is a user gesture (page reload or parent re-fetch).
- **No toasts / global error boundary** — these are local, non-critical data widgets. An inline notice is proportionate.
- **Skeleton dimensions match widget** — `AoPendingDecisionsWidget` skeleton uses `h-24` which approximates the widget's collapsed height to prevent layout shift on load.
- **CoverageCards error grid** — mirrors the 4-column card layout so the page structure is stable regardless of fetch outcome.
- **RequireAuth `redirecting` stays null** — MSAL `loginRedirect` and `navigate()` both take the browser away within milliseconds; showing UI here would cause a flash of unwanted content.

## 8. Acceptance Criteria

- [ ] Navigating to a protected route shows a centered indigo spinner, not a blank screen, while the auth probe is in flight.
- [ ] Once auth resolves, the spinner disappears and the protected content renders immediately (no extra re-render flash).
- [ ] When the `/systems/:id/todos` endpoint returns a non-2xx response, the TodoPanel area shows the inline red error notice.
- [ ] When todos load successfully but the list is empty, the TodoPanel area remains blank (intentional).
- [ ] The AoPendingDecisions area shows an amber skeleton while the initial fetch is pending.
- [ ] Once the pending decisions fetch completes with an empty array, the skeleton disappears and nothing is shown.
- [ ] When the coverage fetch fails (null `coverage` post-load), four "Failed to load" error tiles are shown in the card grid.
- [ ] When `DeviationSummaryCards` receives a null `summary`, the red "Unable to load deviation summary." banner is shown.
- [ ] No existing tests are broken by these changes.
- [ ] All five modified files pass TypeScript compilation without new errors.

## 9. NFRs

- **Performance**: No new network requests introduced; changes are render-only.
- **Accessibility**: Error states use semantic color contrast (red-700 on red-50 meets WCAG AA for text); spinner has implicit role from animation.
- **Bundle size**: No new dependencies; Tailwind classes are already in the purge-safe class list.
- **Maintainability**: Each fix is ≤ 10 LOC; no new abstractions or shared components needed at this stage.

## 10. Test Plan

**Manual steps:**

1. **RequireAuth spinner**
   - Open the app in an incognito window (no cached MSAL token).
   - Navigate to any protected route.
   - Observe: indigo spinner appears centered on gray-50 background.
   - After MSAL redirect completes and `/me` returns 200, spinner disappears and the page renders.

2. **TodoPanel error**
   - In browser DevTools → Network, block `/systems/*/todos`.
   - Navigate to a system dashboard.
   - Observe: red "Unable to load tasks. Please refresh." notice in the todo panel area.
   - Unblock the endpoint and reload; observe: normal todo list (or blank if empty).

3. **AoPendingDecisionsWidget skeleton**
   - In DevTools → Network, throttle to Slow 3G.
   - Navigate to the Portfolio Dashboard.
   - Observe: amber pulsing skeleton visible during fetch.
   - After fetch completes with data: widget renders. With empty data: skeleton disappears, nothing shown.

4. **CoverageCards error**
   - Block the coverage endpoint in DevTools.
   - Navigate to the Capabilities page.
   - Observe: four "Failed to load" red tiles in the card grid positions.

5. **DeviationSummaryCards error**
   - Block the deviations summary endpoint.
   - Navigate to the Deviations page.
   - Observe: red "Unable to load deviation summary." banner in place of the metric cards.

## 11. Definition of Done

- [ ] All 5 files modified with the exact fixes described.
- [ ] `git diff --stat` shows exactly 5 files changed.
- [ ] Branch pushed to `origin/fix/371-null-render-loading-error-states`.
- [ ] PR open against `main` with this body.
- [ ] PR linked to milestone `Wave 9 — Core UX & Integrations`.
- [ ] Labels `bug` and `priority:medium` applied.
- [ ] Issue #371 referenced in commit message and PR body.
- [ ] No TypeScript compilation errors introduced.
- [ ] Manual test steps in §10 verified by reviewer.

## 12. Anti-patterns / Constraints

- **Do NOT** convert these components to class components or add Redux state.
- **Do NOT** add retry buttons that trigger new API calls — parent components own the fetch lifecycle.
- **Do NOT** use a toast library or shared notification context — inline error states are the correct scope.
- **Do NOT** change the empty-state behavior for `TodoPanel` (empty list → null) or `AoPendingDecisionsWidget` (empty decisions → null) — those are intentional design decisions.
- **Do NOT** alter the `RequireAuth` authentication logic or the `loginRedirect` / `navigate` calls — only the render branch changes.
- **Do NOT** add `aria-live` regions without a broader accessibility audit — out of scope for this fix.

## 13. Files Changed

| File | Change |
|------|--------|
| `src/Ato.Copilot.Dashboard/src/features/auth/RequireAuth.tsx` | Replace single `!== 'authenticated'` null guard with probing spinner + redirecting null |
| `src/Ato.Copilot.Dashboard/src/components/cards/TodoPanel.tsx` | Split compound null guard into error notice + empty-list null |
| `src/Ato.Copilot.Dashboard/src/components/portfolio/AoPendingDecisionsWidget.tsx` | Split loading+empty null guard into loading skeleton + empty null |
| `src/Ato.Copilot.Dashboard/src/components/capabilities/CoverageCards.tsx` | Replace post-load null guard with 4-tile error grid |
| `src/Ato.Copilot.Dashboard/src/components/DeviationSummaryCards.tsx` | Replace null guard with inline error banner |

## 14. Linked Issues

Closes #371

## 15. Reviewer Notes

- The CRLF line endings in some files (TodoPanel, CoverageCards, RequireAuth) were pre-existing in the repository; this PR does not introduce the inconsistency.
- The `AoPendingDecisionsWidget` error case (fetch throws) still silently swallows the exception per the existing `// best-effort — widget is non-critical` comment — this is intentional and unchanged. Only the loading skeleton is added.
- `CoverageCards` already had correct loading skeleton handling (lines 26-34) — this PR only fixes the post-load null case.
- Reviewers should pay particular attention to the `RequireAuth` change: the `authenticated` state path is now the implicit fallthrough (`return <>{children}</>`), which is semantically cleaner and matches the state machine's intent.
