### PR TITLE
fix(#370): surface silent .catch(() => {}) swallowers with error feedback

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/PackageGenerationDialog.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/PackageGenerationDialog.tsx
@@ -233,7 +233,7 @@ export default function PackageGenerationDialog({
       connection
         .start()
         .then(() => connection.invoke('SubscribeToPackage', pkgId))
-        .catch(() => {});
+        .catch(() => setError('Real-time progress unavailable. Please refresh to check status.'));
 
       connectionRef.current = connection;
     },

--- a/src/Ato.Copilot.Dashboard/src/components/cards/MappingPanel.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/cards/MappingPanel.tsx
@@ -51,7 +51,7 @@ export function MappingPanel({ capabilityId, systemId }: MappingPanelProps) {
   useEffect(() => {
     fetchMappings();
     if (systemId) {
-      fetchBoundaryDefinitions(systemId).then(setBoundaries).catch(() => {});
+      fetchBoundaryDefinitions(systemId).then(setBoundaries).catch(() => setError('Failed to load boundary definitions'));
     }
   }, [capabilityId, systemId]);
 
@@ -297,11 +297,12 @@ function ControlPickerDialog({ existingControlIds, baselineLevel, boundaries, on
   const [boundaryId, setBoundaryId] = useState('');
   const [loading, setLoading] = useState(true);
   const [adding, setAdding] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     apiClient.get('/controls', { params: { pageSize: 2000 } })
       .then(res => setControls(res.data.items))
-      .catch(() => {})
+      .catch(() => setLoadError('Failed to load controls'))
       .finally(() => setLoading(false));
   }, []);
 
@@ -359,6 +360,9 @@ function ControlPickerDialog({ existingControlIds, baselineLevel, boundaries, on
 
         {/* Filters */}
         <div className="flex items-center gap-3 border-b px-6 py-3">
+          {loadError && (
+            <p className="w-full text-sm text-red-600">{loadError}</p>
+          )}
           <div className="relative flex-1">
             <svg className="absolute left-2.5 top-2 h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
@@ -37,14 +37,15 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
   const [assignments, setAssignments] = useState<ResolvedRoleAssignment[]>([]);
   const [persons, setPersons] = useState<PersonOption[]>([]);
   const [saving, setSaving] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     rolesApi.getSystemRoles(systemId)
       .then((res) => setAssignments(res.roles.filter((r) => r.source !== 'not-assigned')))
-      .catch(() => {});
+      .catch(() => setLoadError('Failed to load role assignments'));
     apiClient.get('/components', { params: { type: 'Person', pageSize: 200 } })
       .then((res) => setPersons(res.data.items ?? []))
-      .catch(() => {});
+      .catch(() => setLoadError('Failed to load personnel'));
   }, [systemId]);
 
   const getAssignment = (role: string) => assignments.find((a) => a.role === role);
@@ -72,6 +73,9 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
 
   return (
     <div>
+      {loadError && (
+        <p className="mb-2 text-sm text-red-600">{loadError}</p>
+      )}
       <h2 className="text-xl font-semibold text-gray-900 mb-1">Step 5: Assign RMF Roles</h2>
       <p className="text-sm text-gray-500 mb-6">Assign personnel to standard RMF roles from existing Person components.</p>
 

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AuthorizationBoundaries.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AuthorizationBoundaries.tsx
@@ -14,6 +14,7 @@ export default function AuthorizationBoundaries({ systemId, onNext, onErrors }: 
   const [boundaries, setBoundaries] = useState<BoundaryDefinitionDto[]>([]);
   const [form, setForm] = useState<CreateBoundaryDefinitionRequest>({ name: '', boundaryType: 'Logical', description: '', isPrimary: false });
   const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Component assignment state
   const [selectedBoundary, setSelectedBoundary] = useState<string | null>(null);
@@ -25,8 +26,8 @@ export default function AuthorizationBoundaries({ systemId, onNext, onErrors }: 
   const [assigningId, setAssigningId] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchBoundaryDefinitions(systemId).then(setBoundaries).catch(() => {});
-    getComponents(systemId).then((res) => setSystemComponents(res.items)).catch(() => {});
+    fetchBoundaryDefinitions(systemId).then(setBoundaries).catch(() => setLoadError('Failed to load boundary definitions'));
+    getComponents(systemId).then((res) => setSystemComponents(res.items)).catch(() => setLoadError('Failed to load system components'));
   }, [systemId]);
 
   // Load already-assigned components when a boundary is selected
@@ -51,7 +52,7 @@ export default function AuthorizationBoundaries({ systemId, onNext, onErrors }: 
     if (compTab === 'org') {
       listComponents({ search: compSearch || undefined, pageSize: 50 })
         .then((res) => setOrgComponents(res.items))
-        .catch(() => {});
+        .catch(() => setLoadError('Failed to load organization components'));
     }
   }, [compTab, compSearch]);
 
@@ -91,7 +92,12 @@ export default function AuthorizationBoundaries({ systemId, onNext, onErrors }: 
         resourceId: componentId,
         resourceType: componentType,
         resourceName: componentName,
-      }).catch(() => {}); // Ignore 409 duplicates
+      }).catch((err: unknown) => {
+        const status = err && typeof err === 'object' && 'response' in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+        if (status !== 409) onErrors({ _form: ['Failed to assign component'] });
+      }); // Ignore 409 duplicates
       // Update local tracking immediately
       setAssignedComponentIds((prev) => new Set([...prev, componentId]));
       // Refresh boundaries to update counts
@@ -107,6 +113,9 @@ export default function AuthorizationBoundaries({ systemId, onNext, onErrors }: 
 
   return (
     <div>
+      {loadError && (
+        <p className="mb-2 text-sm text-red-600">{loadError}</p>
+      )}
       <h2 className="text-xl font-semibold text-gray-900 mb-1">Step 4: Authorization Boundaries</h2>
       <p className="text-sm text-gray-500 mb-6">Define authorization boundaries and assign components to them.</p>
 

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx
@@ -28,7 +28,7 @@ export default function SecurityCapabilities({ systemId, onNext, onErrors }: Sec
 
   // Load existing links on mount
   useEffect(() => {
-    getCapabilityLinks(systemId).then((res) => setLinkedItems(res.items)).catch(() => {});
+    getCapabilityLinks(systemId).then((res) => setLinkedItems(res.items)).catch(() => onErrors({ _form: ['Failed to load capability links'] }));
   }, [systemId]);
 
   // Debounced search

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx
@@ -33,7 +33,7 @@ export default function SystemComponents({ systemId, onNext, onErrors }: SystemC
   const [assigning, setAssigning] = useState<string | null>(null);
 
   useEffect(() => {
-    getComponents(systemId).then((res) => setComponents(res.items)).catch(() => {});
+    getComponents(systemId).then((res) => setComponents(res.items)).catch(() => onErrors({ _form: ['Failed to load system components'] }));
   }, [systemId]);
 
   // Load org components on tab switch or search
@@ -42,7 +42,7 @@ export default function SystemComponents({ systemId, onNext, onErrors }: SystemC
     setOrgLoading(true);
     listComponents({ search: orgSearch || undefined, pageSize: 50 })
       .then((res) => setOrgComponents(res.items))
-      .catch(() => {})
+      .catch(() => onErrors({ _form: ['Failed to load organization components'] }))
       .finally(() => setOrgLoading(false));
   }, [activeTab, orgSearch]);
 

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/VerifyRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/VerifyRoles.tsx
@@ -20,11 +20,12 @@ interface VerifyRolesProps {
 export default function VerifyRoles({ systemId, onNext }: VerifyRolesProps) {
   const [assignments, setAssignments] = useState<ResolvedRoleAssignment[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     rolesApi.getSystemRoles(systemId)
       .then((res) => setAssignments(res.roles.filter((r) => r.source !== 'not-assigned')))
-      .catch(() => {})
+      .catch(() => setLoadError('Failed to load role assignments'))
       .finally(() => setLoading(false));
   }, [systemId]);
 
@@ -35,6 +36,10 @@ export default function VerifyRoles({ systemId, onNext }: VerifyRolesProps) {
 
       {loading ? (
         <p className="text-sm text-gray-500">Loading role assignments...</p>
+      ) : loadError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {loadError}
+        </div>
       ) : assignments.length === 0 ? (
         <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
           No roles assigned. You can go back to Step 5 to assign roles, or continue.

--- a/src/Ato.Copilot.Dashboard/src/pages/BoundaryManagement.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/BoundaryManagement.tsx
@@ -448,6 +448,7 @@ function BoundaryComponentsTab({
   const [editingScope, setEditingScope] = useState<string | null>(null);
   const [editRationale, setEditRationale] = useState('');
   const [editProvider, setEditProvider] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Fetch boundary-component assignments (Feature 040)
   const fetchAssignments = useCallback(async () => {
@@ -471,7 +472,7 @@ function BoundaryComponentsTab({
 
   useEffect(() => {
     if (showAdd && allComponents.length === 0) {
-      listComponents({ pageSize: 200 }).then((r) => setAllComponents(r.items)).catch(() => {});
+      listComponents({ pageSize: 200 }).then((r) => setAllComponents(r.items)).catch(() => setLoadError('Failed to load components'));
     }
   }, [showAdd, allComponents.length]);
 
@@ -572,6 +573,11 @@ function BoundaryComponentsTab({
 
   return (
     <div>
+      {/* Load error banner */}
+      {loadError && (
+        <p className="mb-2 text-sm text-red-600">{loadError}</p>
+      )}
+
       {/* Lock status banner */}
       {lockStatus?.locked && !hasLock && (
         <div className="mb-3 p-2 bg-yellow-50 border border-yellow-200 rounded text-sm text-yellow-800">

--- a/src/Ato.Copilot.Dashboard/src/pages/ComponentLibrary.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/ComponentLibrary.tsx
@@ -940,6 +940,7 @@ function ComponentFormInline({
     new Set(initial?.capabilityLinks.map((cl) => cl.capabilityId) ?? []),
   );
   const [capSearch, setCapSearch] = useState('');
+  const [capLoadError, setCapLoadError] = useState<string | null>(null);
 
   // ─── Entra search state (Issue #238) ───────────────────────────────────────
   const [entraQuery, setEntraQuery] = useState('');
@@ -1001,7 +1002,7 @@ function ComponentFormInline({
 
   // ─── Capability loading ─────────────────────────────────────────────────────
   useEffect(() => {
-    getCapabilities({ pageSize: 200 }).then((r) => setCapabilities(r.items)).catch(() => {});
+    getCapabilities({ pageSize: 200 }).then((r) => setCapabilities(r.items)).catch(() => setCapLoadError('Failed to load capabilities'));
   }, []);
 
   const toggleCap = (id: string) => {
@@ -1256,7 +1257,9 @@ function ComponentFormInline({
           className="block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm mb-1 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
         />
         <div className="max-h-36 overflow-y-auto rounded-md border border-gray-200 bg-gray-50 p-2 space-y-1">
-          {filteredCaps.length === 0 ? (
+          {capLoadError ? (
+            <p className="text-xs text-red-500 italic py-1">{capLoadError}</p>
+          ) : filteredCaps.length === 0 ? (
             <p className="text-xs text-gray-400 italic py-1">
               {capabilities.length === 0 ? 'Loading...' : 'No matching capabilities'}
             </p>

--- a/src/Ato.Copilot.Dashboard/src/pages/PortfolioRiskProfile.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/PortfolioRiskProfile.tsx
@@ -50,7 +50,7 @@ export default function PortfolioRiskProfile() {
   usePolling(fetchData);
 
   useEffect(() => {
-    getCoverage(false, false).then(res => setCoveragePct(res.orgWide.coveragePercent)).catch(() => {});
+    getCoverage(false, false).then(res => setCoveragePct(res.orgWide.coveragePercent)).catch(() => setCoveragePct(null));
   }, []);
 
   // ─── Aggregations ───────────────────────────────────────────────────────────

--- a/src/Ato.Copilot.Dashboard/src/pages/Remediation.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/Remediation.tsx
@@ -88,7 +88,7 @@ export default function Remediation() {
         }
         setDeviationsByPoam(map);
       })
-      .catch(() => {});
+      .catch(() => setDeviationsByPoam(new Map()));
   }, [systemId]);
 
   // Main data — always scoped to current system


### PR DESCRIPTION
## 1. Problem

~20 `.catch(() => {})` blocks across wizard steps and pages silently discard API errors. When these calls fail, users see nothing — no spinner change, no error message, no retry option. Users have no way to know something went wrong.

## 2. Goal

Replace every silent swallow with explicit error state updates so users receive feedback when data fails to load. Per Charter §8: "Silent waits are bugs."

## 3. Scope

**In scope:** 11 React files — 5 wizard steps, 4 pages, 2 components. All `catch(() => {})` blocks that result in silent UI failure.

**Out of scope:** Backend error handling, network retry logic, toast infrastructure (future).

## 4. UX Flow

**Before:** Wizard step loads → API fails → user sees empty list with no explanation. They don't know whether to wait, retry, or report an issue.

**After:** Wizard step loads → API fails → user sees an inline error message. They can identify what failed and take action.

## 5. Functional Requirements

- Every data fetch catch block either sets an error state, calls `onErrors`, or explicitly resets to an empty/null state (for best-effort supplemental data).
- 409 conflicts on boundary component assignment remain silent (intentional dedup behavior); all other errors surface.
- SignalR connection failures in `PackageGenerationDialog` surface a degraded-mode message.

## 6. Technical Design

Three patterns used depending on component structure:

1. **Wizard steps with `onErrors` prop** (`SecurityCapabilities`, `SystemComponents`): route load errors through `onErrors({ _form: [...] })`.
2. **Components needing local error state** (`AssignRoles`, `AuthorizationBoundaries`, `VerifyRoles`, `BoundaryManagement.BoundaryComponentsTab`, `ComponentLibrary.ComponentFormInline`): add `const [loadError, setLoadError] = useState<string | null>(null)` and render inline error text.
3. **Best-effort supplemental fetches** (`PortfolioRiskProfile.coveragePct`, `Remediation.deviationsByPoam`): `.catch(() => setX(null/empty))` — makes null state explicit without blocking UI.

## 7. Architecture Decisions

- No toast system introduced — inline error display is lower-risk and doesn't require a global provider.
- `PackageGenerationDialog` line 211 (post-generation package detail refresh) left as best-effort; download link is already captured from the generation response.
- `BoundaryManagement` lock status check (line 469) kept silent — non-critical read, failure doesn't block workflow.

## 8. Acceptance Criteria

- [ ] Wizard steps (AssignRoles, AuthorizationBoundaries, SecurityCapabilities, SystemComponents, VerifyRoles) show error messages when initial data loads fail
- [ ] PackageGenerationDialog shows degraded-mode message when SignalR fails to connect
- [ ] MappingPanel shows error when boundary definitions or controls fail to load
- [ ] ComponentLibrary shows error in capability picker when capabilities fail to load
- [ ] BoundaryManagement shows error when component list fails in the assignment sub-panel
- [ ] No regressions: 409 duplicate-assignment errors remain silent

## 9. NFRs

- No new external dependencies
- Error messages are user-readable (no stack traces, no HTTP status codes)
- All existing TypeScript types preserved — no `any` introduced

## 10. Test Plan

1. Simulate network failure via browser DevTools → offline → navigate to onboarding wizard → verify each step shows an error message
2. Simulate 409 on boundary component assignment → verify no error shown (silent dedup preserved)
3. Navigate to BoundaryManagement with network failure → verify component list shows error
4. Navigate to ComponentLibrary, create component → verify capability picker shows error on load failure
5. Start package generation → kill SignalR hub → verify degraded-mode message appears

## 11. Definition of Done

- [ ] All 11 files modified as described
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] PR approved and merged
- [ ] Issue #370 closed

## 12. Anti-patterns / Constraints

- Do NOT swallow errors that result in user-visible state changes (empty lists, missing data)
- Do NOT use `console.error` as a substitute for user-visible feedback
- Do NOT introduce toast without adding a global NotificationProvider

## 13. Files Changed

- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx`
- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/AuthorizationBoundaries.tsx`
- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx`
- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx`
- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/VerifyRoles.tsx`
- `src/Ato.Copilot.Dashboard/src/components/PackageGenerationDialog.tsx`
- `src/Ato.Copilot.Dashboard/src/components/cards/MappingPanel.tsx`
- `src/Ato.Copilot.Dashboard/src/pages/BoundaryManagement.tsx`
- `src/Ato.Copilot.Dashboard/src/pages/ComponentLibrary.tsx`
- `src/Ato.Copilot.Dashboard/src/pages/PortfolioRiskProfile.tsx`
- `src/Ato.Copilot.Dashboard/src/pages/Remediation.tsx`

## 14. Linked Issues

Closes #370

## 15. Reviewer Notes

The CRLF normalization in the diff inflates insertion/deletion counts on large files (PackageGenerationDialog, MappingPanel, BoundaryManagement, etc.). The actual logical changes are small — see the commit message for the per-file summary. Review the diff with `git diff --ignore-space-change` to see only logical changes.
