### PR TITLE
feat(#57): Feature 069 — SCA Control Validation Link

### DIFF
--- a/specs/069-sca-control-validation/checklists/requirements.md
+++ b/specs/069-sca-control-validation/checklists/requirements.md
@@ -1,0 +1,92 @@
+# Requirements Checklist — Spec 069: SCA Control Implementation Validation Link
+
+**Epic:** #57 | **Wave:** 9 | **Owner:** Cyborg
+
+---
+
+## Functional Requirements
+
+- [ ] **FR-001** `ControlValidationLink` entity exists in `SspModels.cs` with all required fields: `Id`, `TenantId`, `ControlImplementationId`, `LinkType`, `LinkTarget`, `Description`, `AddedBy`, `AddedAt`, `ValidatedAt`, `IsAutomated`
+- [ ] **FR-002** EF Core migration `Add_ControlValidationLinks` applied; unique constraint on `(ControlImplementationId, LinkTarget)` and index on `ControlImplementationId` confirmed in migration SQL
+- [ ] **FR-003** MCP tool `compliance_get_control_validation` exists and returns link list for a given `system_id` + `control_id` (RBAC: Compliance.Auditor)
+- [ ] **FR-004** MCP tool `action: "add"` creates a manual link; `link_type` and `link_target` validated; returns created link in response
+- [ ] **FR-005** MCP tool `action: "delete"` removes a link by `link_id`; returns `deleted: true`
+- [ ] **FR-006** `GET /api/systems/{id}/controls/{controlId}/validation` returns 200 with link list (RBAC: Compliance.Reader)
+- [ ] **FR-007** `POST /api/systems/{id}/controls/{controlId}/validation` adds a manual link; returns 201 with `Location` header (RBAC: Compliance.Auditor)
+- [ ] **FR-008** `DELETE /api/systems/{id}/controls/{controlId}/validation/{linkId}` removes a link; returns 204 (RBAC: Compliance.Auditor)
+- [ ] **FR-009** IaC scan auto-link: after `iac_compliance_scan` maps a finding to a control ID, a `ControlValidationLink` with `IsAutomated = true` is upserted for that control; upsert is idempotent
+- [ ] **FR-010** Dashboard "Validation Evidence" panel renders on control detail page with link list, type badge, Auto/Manual badge, description, clickable target
+- [ ] **FR-011** Automated links (IaC scan) display "Auto" badge; manual links display "Manual" badge
+- [ ] **FR-012** `AzureResource` link type → Dashboard constructs `https://portal.azure.com/#resource/{linkTarget}` and opens in new tab
+- [ ] **FR-013** Empty-state message shown when `total = 0`: "No validation links yet. Run a compliance scan or add a link manually."
+- [ ] **FR-014** When SCA marks a control Satisfied with 0 validation links: non-blocking `warnings` array included in MCP response; inline warning rendered in Dashboard
+- [ ] **FR-015** Tenant isolation enforced: all DB queries filter by `TenantId`; `[TenantScoped]` attribute on entity
+
+---
+
+## Non-Functional Requirements
+
+- [ ] **NFR-001** Validation link list loads within 500 ms for up to 100 links per control
+- [ ] **NFR-002** `403 Forbidden` returned for any endpoint accessed by insufficient role
+- [ ] **NFR-003** `404 Not Found` returned if `systemId` or `controlId` is not found for the requesting tenant
+- [ ] **NFR-004** IaC scan response time is not materially impacted by link upsert (< 200 ms overhead acceptable)
+- [ ] **NFR-005** Azure Portal deep-links constructed client-side only; backend never constructs portal URLs
+
+---
+
+## Security Requirements
+
+- [ ] **SEC-001** No cross-tenant link visibility — all queries scoped to authenticated tenant
+- [ ] **SEC-002** `Compliance.Reader` can only read links; cannot add or delete
+- [ ] **SEC-003** `IsAutomated` flag is server-set; cannot be overridden by client POST payload
+- [ ] **SEC-004** `ExternalUrl` link targets validated as well-formed URLs before persistence
+
+---
+
+## Test Coverage Requirements
+
+- [ ] **TC-001** Unit test: `GetLinksAsync` returns correct records scoped to `(systemId, controlId, tenantId)`
+- [ ] **TC-002** Unit test: `UpsertScanLinkAsync` — second call with same `(ControlImplementationId, linkTarget)` updates instead of inserting duplicate
+- [ ] **TC-003** Unit test: `GetControlValidationTool` — `action: get` with 0 links returns empty list (not error); `action: get` with 2 links returns correct structure
+- [ ] **TC-004** Unit test: `GetControlValidationTool` — `action: add` missing `link_type` returns `INVALID_INPUT`; `action: delete` missing `link_id` returns `INVALID_INPUT`
+- [ ] **TC-005** Unit test: `AssessControlTool` satisfied determination with 0 links includes `warnings` in response
+- [ ] **TC-006** Unit test: IaC scan tool with control-mapped findings calls `UpsertScanLinkAsync`; `validation_links_created` appears in metadata
+- [ ] **TC-007** Frontend unit test: `ValidationEvidencePanel` renders 2 links correctly; Auto/Manual badges correct; empty-state renders for 0 links
+- [ ] **TC-008** Frontend unit test: `buildAzurePortalUrl("/subscriptions/abc/...")` returns `"https://portal.azure.com/#resource/subscriptions/abc/..."`
+- [ ] **TC-009** Frontend unit test: Add/Delete buttons hidden for `Compliance.Reader` role; visible for `Compliance.Auditor`
+- [ ] **TC-010** Integration test: `GET /api/systems/{id}/controls/AC-2/validation` with MSW mock returns panel with 2 links
+
+---
+
+## User Story Acceptance
+
+### US1 — Validation Link from Control Record
+- [ ] Control detail page shows "Validation Evidence" panel
+- [ ] Panel lists all links with type badge, Auto/Manual badge, description, clickable target
+- [ ] Empty state message shown when 0 links
+- [ ] SCA can add manual link via Add modal
+- [ ] SCA can delete a link with confirmation
+- [ ] Reader role: view only; Add/Delete not available
+
+### US2 — MCP Tool for SCA Agents
+- [ ] `compliance_get_control_validation` callable with `system_id` + `control_id`
+- [ ] Returns `{ links, total }` structure
+- [ ] `action: add` creates link; `action: delete` removes link
+- [ ] `NOT_FOUND` returned for unknown system/control
+
+### US3 — Auto-Populate Links from IaC Scan
+- [ ] Running `iac_compliance_scan` on a Bicep file with control-mapped findings creates `IsAutomated: true` links
+- [ ] Re-running scan does not duplicate links (upsert)
+- [ ] Scan response includes `validation_links_created: N`
+
+---
+
+## Definition of Done (Final Gate)
+
+- [ ] All FR, NFR, SEC requirements above checked
+- [ ] All TC test coverage requirements met (tests passing)
+- [ ] All US acceptance criteria met
+- [ ] Migration applied and reviewed
+- [ ] No TypeScript build errors (`npm run build` clean)
+- [ ] No .NET build errors (`dotnet build` clean)
+- [ ] PR reviewed and approved

--- a/specs/069-sca-control-validation/contracts/http-api.md
+++ b/specs/069-sca-control-validation/contracts/http-api.md
@@ -1,0 +1,171 @@
+# HTTP API Contract — Spec 069: SCA Control Implementation Validation Link
+
+**Base path:** `/api/systems/{systemId}/controls/{controlId}/validation`  
+**Auth:** Bearer JWT — all endpoints require authentication  
+**Tenant:** All responses are tenant-scoped; cross-tenant requests return 404
+
+---
+
+## 1. GET `/api/systems/{systemId}/controls/{controlId}/validation`
+
+**Summary:** List all validation links for a control.  
+**RBAC:** `Compliance.Reader` (minimum); `Compliance.Auditor` also allowed  
+**Method:** `GET`
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `systemId` | string (GUID or name) | Registered system identifier |
+| `controlId` | string | NIST 800-53 control ID (e.g., `AC-2`, `SC-7(3)`) |
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `linkType` | string | No | Filter by link type: `AzureResource`, `ScanFinding`, `EvidenceArtifact`, `ExternalUrl` |
+| `automated` | bool | No | If `true`, return only automated links; `false` = manual only; omit = all |
+
+### Response — 200 OK
+
+```json
+{
+  "systemId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "controlId": "AC-2",
+  "total": 2,
+  "links": [
+    {
+      "id": "a1b2c3d4-...",
+      "linkType": "AzureResource",
+      "linkTarget": "/subscriptions/abc/resourceGroups/rg-prod/providers/Microsoft.Authorization/roleAssignments/...",
+      "description": "RBAC role assignment enforcing least-privilege access (AC-2 requirement)",
+      "addedBy": "jane.assessor@agency.gov",
+      "addedAt": "2026-06-11T14:30:00Z",
+      "validatedAt": "2026-06-11T15:00:00Z",
+      "isAutomated": false
+    },
+    {
+      "id": "e5f6a7b8-...",
+      "linkType": "ScanFinding",
+      "linkTarget": "scan-2026061101-finding-3",
+      "description": "IaC scan: AC-2.1 — RBAC enforced on storage account (nist-800-53-r5) — PASS",
+      "addedBy": "iac-scan",
+      "addedAt": "2026-06-11T12:00:00Z",
+      "validatedAt": null,
+      "isAutomated": true
+    }
+  ]
+}
+```
+
+### Error Responses
+
+| Code | Body | When |
+|---|---|---|
+| 401 | `{ "error": "Unauthorized" }` | No/invalid JWT |
+| 403 | `{ "error": "Forbidden" }` | Authenticated but insufficient role |
+| 404 | `{ "error": "System not found" }` | `systemId` does not exist for this tenant |
+| 404 | `{ "error": "Control not found" }` | `controlId` has no `ControlImplementation` record |
+
+> **Note:** 0 links returns 200 with `{ ..., "total": 0, "links": [] }` — not 404.
+
+---
+
+## 2. POST `/api/systems/{systemId}/controls/{controlId}/validation`
+
+**Summary:** Add a manual validation link to a control.  
+**RBAC:** `Compliance.Auditor` (SCA role required)  
+**Method:** `POST`  
+**Content-Type:** `application/json`
+
+### Path Parameters
+
+Same as GET above.
+
+### Request Body
+
+```json
+{
+  "linkType": "AzureResource",
+  "linkTarget": "/subscriptions/abc/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-jump",
+  "description": "Jump server with Conditional Access enforcing MFA (AC-2 requirement)"
+}
+```
+
+| Field | Type | Required | Validation |
+|---|---|---|---|
+| `linkType` | string | Yes | Must be one of: `AzureResource`, `ScanFinding`, `EvidenceArtifact`, `ExternalUrl` |
+| `linkTarget` | string | Yes | 1–2000 characters; `ExternalUrl` type must match URL pattern |
+| `description` | string | No | Max 1000 characters |
+
+### Response — 201 Created
+
+```json
+{
+  "id": "new-link-guid",
+  "linkType": "AzureResource",
+  "linkTarget": "/subscriptions/abc/...",
+  "description": "Jump server with Conditional Access...",
+  "addedBy": "jane.assessor@agency.gov",
+  "addedAt": "2026-06-11T14:30:00Z",
+  "validatedAt": null,
+  "isAutomated": false
+}
+```
+
+`Location` header: `/api/systems/{systemId}/controls/{controlId}/validation/{id}`
+
+### Error Responses
+
+| Code | Body | When |
+|---|---|---|
+| 400 | `{ "error": "Invalid linkType" }` | Unknown `linkType` value |
+| 400 | `{ "error": "linkTarget must be a valid URL" }` | `ExternalUrl` type with non-URL `linkTarget` |
+| 409 | `{ "error": "DuplicateLink", "message": "A link with this target already exists for this control." }` | Duplicate `(ControlImplementationId, linkTarget)` |
+| 401/403/404 | (same as GET) | |
+
+---
+
+## 3. DELETE `/api/systems/{systemId}/controls/{controlId}/validation/{linkId}`
+
+**Summary:** Remove a validation link.  
+**RBAC:** `Compliance.Auditor`  
+**Method:** `DELETE`
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `systemId` | string | Registered system identifier |
+| `controlId` | string | NIST 800-53 control ID |
+| `linkId` | string (GUID) | `ControlValidationLink` ID |
+
+### Response — 204 No Content
+
+Empty body.
+
+### Error Responses
+
+| Code | Body | When |
+|---|---|---|
+| 404 | `{ "error": "Link not found" }` | `linkId` does not exist for this control/tenant |
+| 401/403 | (same as GET) | |
+
+---
+
+## RBAC Summary
+
+| Endpoint | Compliance.Reader | Compliance.Auditor | Notes |
+|---|---|---|---|
+| `GET` | ✅ | ✅ | Read-only access for both |
+| `POST` | ❌ | ✅ | SCA role required to add |
+| `DELETE` | ❌ | ✅ | SCA role required to delete |
+
+---
+
+## Notes
+
+- All timestamps are UTC ISO-8601 (`2026-06-11T14:30:00Z`)
+- `addedBy` is the authenticated user's identity for manual links; `"iac-scan"` for automated links
+- `validatedAt` is always `null` on creation; SCA sets it by separately confirming the link (future feature — V2)
+- `isAutomated` is server-set; clients cannot override it via POST

--- a/specs/069-sca-control-validation/contracts/mcp-tools.md
+++ b/specs/069-sca-control-validation/contracts/mcp-tools.md
@@ -1,0 +1,219 @@
+# MCP Tool Contract — Spec 069: SCA Control Implementation Validation Link
+
+**Tool name:** `compliance_get_control_validation`  
+**Class:** `GetControlValidationTool` (extends `BaseTool`)  
+**File:** `src/Ato.Copilot.Agents/Compliance/Tools/ControlValidationTools.cs`  
+**RBAC:** `Compliance.Auditor` (SCA role)
+
+---
+
+## Description
+
+> *"Get, add, or delete validation links for a NIST 800-53 control. Links connect a control implementation record to the Azure resources, IaC scan findings, evidence artifacts, or external URLs that prove or disprove implementation. RBAC: Compliance.Auditor (SCA)."*
+
+---
+
+## Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `system_id` | string | **Yes** | System GUID, name, or acronym |
+| `control_id` | string | **Yes** | NIST 800-53 control ID (e.g., `"AC-2"`, `"SC-7(3)"`) |
+| `action` | string | No | `"get"` (default) \| `"add"` \| `"delete"` |
+| `link_type` | string | Conditional | Required when `action = "add"`. One of: `"AzureResource"`, `"ScanFinding"`, `"EvidenceArtifact"`, `"ExternalUrl"` |
+| `link_target` | string | Conditional | Required when `action = "add"`. Azure resource ID, finding ref, evidence ID, or full URL |
+| `description` | string | No | Human-readable description of what this link proves |
+| `link_id` | string | Conditional | Required when `action = "delete"`. GUID of the link to remove |
+
+---
+
+## Action: `get` (default)
+
+Returns all validation links for the specified control.
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "system_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "control_id": "AC-2",
+    "total": 2,
+    "links": [
+      {
+        "id": "a1b2c3d4-...",
+        "link_type": "AzureResource",
+        "link_target": "/subscriptions/abc/resourceGroups/rg-prod/providers/Microsoft.Authorization/roleAssignments/...",
+        "description": "RBAC role assignment enforcing least-privilege (AC-2)",
+        "added_by": "jane.assessor@agency.gov",
+        "added_at": "2026-06-11T14:30:00Z",
+        "validated_at": "2026-06-11T15:00:00Z",
+        "is_automated": false
+      },
+      {
+        "id": "e5f6a7b8-...",
+        "link_type": "ScanFinding",
+        "link_target": "scan-2026061101-finding-3",
+        "description": "IaC scan: AC-2.1 — RBAC enforced on storage account — PASS",
+        "added_by": "iac-scan",
+        "added_at": "2026-06-11T12:00:00Z",
+        "validated_at": null,
+        "is_automated": true
+      }
+    ]
+  },
+  "metadata": {
+    "tool": "compliance_get_control_validation",
+    "duration_ms": 18,
+    "timestamp": "2026-06-11T15:05:00.000Z"
+  }
+}
+```
+
+### Empty (no links)
+
+```json
+{
+  "status": "success",
+  "data": {
+    "system_id": "3fa85f64-...",
+    "control_id": "AC-3",
+    "total": 0,
+    "links": []
+  },
+  "metadata": { ... }
+}
+```
+
+---
+
+## Action: `add`
+
+Creates a new manual validation link for the control.
+
+### Example Call
+
+```json
+{
+  "system_id": "my-system",
+  "control_id": "AC-2",
+  "action": "add",
+  "link_type": "AzureResource",
+  "link_target": "/subscriptions/abc/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-jump",
+  "description": "Jump server with Conditional Access enforcing MFA (AC-2 requirement)"
+}
+```
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "created": {
+      "id": "new-guid-...",
+      "link_type": "AzureResource",
+      "link_target": "/subscriptions/abc/.../vm-jump",
+      "description": "Jump server with Conditional Access...",
+      "added_by": "mcp-user",
+      "added_at": "2026-06-11T15:10:00Z",
+      "validated_at": null,
+      "is_automated": false
+    }
+  },
+  "metadata": { ... }
+}
+```
+
+### Error — Missing link_type or link_target
+
+```json
+{
+  "status": "error",
+  "errorCode": "INVALID_INPUT",
+  "message": "The 'link_type' and 'link_target' parameters are required when action is 'add'."
+}
+```
+
+### Error — Duplicate link
+
+```json
+{
+  "status": "error",
+  "errorCode": "DUPLICATE_LINK",
+  "message": "A validation link with this target already exists for control 'AC-2'."
+}
+```
+
+---
+
+## Action: `delete`
+
+Removes a validation link by ID.
+
+### Example Call
+
+```json
+{
+  "system_id": "my-system",
+  "control_id": "AC-2",
+  "action": "delete",
+  "link_id": "a1b2c3d4-5678-..."
+}
+```
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "deleted": true,
+    "link_id": "a1b2c3d4-5678-..."
+  },
+  "metadata": { ... }
+}
+```
+
+### Error — Link not found
+
+```json
+{
+  "status": "error",
+  "errorCode": "NOT_FOUND",
+  "message": "Validation link 'a1b2c3d4-...' not found for control 'AC-2'."
+}
+```
+
+---
+
+## Error Reference
+
+| `errorCode` | Meaning |
+|---|---|
+| `INVALID_INPUT` | Missing required parameter (e.g., `system_id`, `control_id`, or `link_type`/`link_target` for add) |
+| `NOT_FOUND` | System, control, or link does not exist in this tenant |
+| `DUPLICATE_LINK` | `(ControlImplementationId, link_target)` unique constraint violation |
+| `INVALID_ACTION` | `action` value is not `"get"`, `"add"`, or `"delete"` |
+| `ADD_LINK_FAILED` | Unexpected backend error during link creation |
+| `DELETE_LINK_FAILED` | Unexpected backend error during link deletion |
+
+---
+
+## Integration with `AssessControlTool`
+
+When `compliance_assess_control` records a **Satisfied** determination and the control has **0 validation links**, the response includes an advisory warning:
+
+```json
+{
+  "status": "success",
+  "data": { ... },
+  "warnings": [
+    "No validation links are attached to control 'AC-2'. Consider using compliance_get_control_validation (action: add) to link Azure resources or evidence before finalizing this assessment."
+  ],
+  "metadata": { ... }
+}
+```
+
+This warning is **non-blocking** — the determination is still recorded. It is informational only.

--- a/specs/069-sca-control-validation/data-model.md
+++ b/specs/069-sca-control-validation/data-model.md
@@ -1,0 +1,209 @@
+# Data Model — Spec 069: SCA Control Implementation Validation Link
+
+---
+
+## New Entity: `ControlValidationLink`
+
+**Namespace:** `Ato.Copilot.Core.Models.Compliance`  
+**Table:** `ControlValidationLinks`  
+**Attribute:** `[TenantScoped]`
+
+```csharp
+/// <summary>
+/// Links a ControlImplementation record to an external validation source:
+/// an Azure resource, IaC scan finding, evidence artifact, or external URL.
+/// Populated automatically by IaC scans (IsAutomated=true) or manually by SCA.
+/// </summary>
+/// <remarks>
+/// Feature 069 (Issue #57). Unique constraint on (ControlImplementationId, LinkTarget).
+/// </remarks>
+[TenantScoped]
+public class ControlValidationLink
+{
+    /// <summary>FK to Tenant — stamped by TenantStampingSaveChangesInterceptor.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>Unique identifier (GUID string).</summary>
+    [Key]
+    [MaxLength(36)]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>FK to ControlImplementation.</summary>
+    [Required]
+    [MaxLength(36)]
+    public string ControlImplementationId { get; set; } = string.Empty;
+
+    /// <summary>The category of the validation target.</summary>
+    [Required]
+    public ControlValidationLinkType LinkType { get; set; }
+
+    /// <summary>
+    /// The validation target identifier.
+    /// AzureResource: resource ID (e.g., /subscriptions/{sub}/resourceGroups/{rg}/providers/...)
+    /// ScanFinding: IaC scan finding reference (e.g., "scan-{scanId}-finding-{findingId}")
+    /// EvidenceArtifact: ComplianceEvidence record ID
+    /// ExternalUrl: full URL
+    /// </summary>
+    [Required]
+    [MaxLength(2000)]
+    public string LinkTarget { get; set; } = string.Empty;
+
+    /// <summary>Human-readable description of what this link proves about the control.</summary>
+    [MaxLength(1000)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Identity that created this link.
+    /// "iac-scan" for automated links; user ID or email for manual links.
+    /// </summary>
+    [Required]
+    [MaxLength(200)]
+    public string AddedBy { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when this link was created.</summary>
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// UTC timestamp when an SCA explicitly validated this link
+    /// (confirmed the resource/finding is current and correct).
+    /// Null for newly-created or auto-created links until SCA confirms.
+    /// </summary>
+    public DateTime? ValidatedAt { get; set; }
+
+    /// <summary>
+    /// True if this link was created automatically by the IaC scan pipeline.
+    /// False if added manually by an SCA.
+    /// </summary>
+    public bool IsAutomated { get; set; }
+
+    // ─── Navigation ──────────────────────────────────────────────────────────
+
+    /// <summary>Parent control implementation.</summary>
+    public ControlImplementation ControlImplementation { get; set; } = null!;
+}
+```
+
+---
+
+## New Enum: `ControlValidationLinkType`
+
+```csharp
+/// <summary>
+/// Categorizes the type of validation link target for a control.
+/// Used by the Dashboard to apply type-specific rendering
+/// (e.g., construct Azure Portal URL for AzureResource links).
+/// </summary>
+public enum ControlValidationLinkType
+{
+    /// <summary>
+    /// An Azure resource identified by its ARM resource ID.
+    /// Dashboard constructs: https://portal.azure.com/#resource/{LinkTarget}
+    /// </summary>
+    AzureResource,
+
+    /// <summary>
+    /// A finding produced by the IaC compliance scan tool (IacComplianceScanTool).
+    /// LinkTarget = "scan-{scanId}-finding-{index}" or file path reference.
+    /// </summary>
+    ScanFinding,
+
+    /// <summary>
+    /// A ComplianceEvidence record ID stored in the platform.
+    /// Navigates to the evidence artifact detail view.
+    /// </summary>
+    EvidenceArtifact,
+
+    /// <summary>
+    /// A fully-qualified external URL (e.g., Azure Policy compliance report URL,
+    /// Defender for Cloud link, external audit system).
+    /// </summary>
+    ExternalUrl
+}
+```
+
+---
+
+## Modified Entity: `ControlImplementation` (existing)
+
+**File:** `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs`
+
+Add navigation property at end of Navigation section (after `ApprovedVersion`):
+
+```csharp
+/// <summary>Validation links linking this control to Azure resources, scan findings, or evidence artifacts (Feature 069).</summary>
+public ICollection<ControlValidationLink> ValidationLinks { get; set; } = new List<ControlValidationLink>();
+```
+
+---
+
+## DTOs (Response / Request)
+
+### `ControlValidationLinksResponse`
+
+```csharp
+public record ControlValidationLinksResponse(
+    string SystemId,
+    string ControlId,
+    int Total,
+    IReadOnlyList<ControlValidationLinkDto> Links);
+
+public record ControlValidationLinkDto(
+    string Id,
+    string LinkType,        // enum name
+    string LinkTarget,
+    string? Description,
+    string AddedBy,
+    DateTime AddedAt,
+    DateTime? ValidatedAt,
+    bool IsAutomated);
+```
+
+### `AddValidationLinkRequest`
+
+```csharp
+public record AddValidationLinkRequest(
+    string LinkType,        // "AzureResource" | "ScanFinding" | "EvidenceArtifact" | "ExternalUrl"
+    string LinkTarget,
+    string? Description);
+```
+
+---
+
+## EF Core Configuration Notes
+
+- **Unique constraint:** `(ControlImplementationId, LinkTarget)` — enforces idempotent upsert for automated scan links
+- **Index:** `ControlImplementationId` — fast lookup for the Dashboard panel and MCP tool
+- **Tenant filtering:** All queries must include `.Where(l => l.TenantId == currentTenantId)` — enforced by `TenantQueryFilter` or explicit filter in service
+
+---
+
+## Migration
+
+Migration name: `Add_ControlValidationLinks`
+
+Expected DDL (approximate):
+```sql
+CREATE TABLE ControlValidationLinks (
+    Id NVARCHAR(36) NOT NULL PRIMARY KEY,
+    TenantId UNIQUEIDENTIFIER NOT NULL,
+    ControlImplementationId NVARCHAR(36) NOT NULL,
+    LinkType INT NOT NULL,
+    LinkTarget NVARCHAR(2000) NOT NULL,
+    Description NVARCHAR(1000) NULL,
+    AddedBy NVARCHAR(200) NOT NULL,
+    AddedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+    ValidatedAt DATETIME2 NULL,
+    IsAutomated BIT NOT NULL DEFAULT 0,
+    CONSTRAINT FK_ControlValidationLinks_ControlImplementation
+        FOREIGN KEY (ControlImplementationId)
+        REFERENCES ControlImplementations(Id) ON DELETE CASCADE,
+    CONSTRAINT UQ_ControlValidationLinks_ImplId_Target
+        UNIQUE (ControlImplementationId, LinkTarget)
+);
+
+CREATE INDEX IX_ControlValidationLinks_ControlImplementationId
+    ON ControlValidationLinks(ControlImplementationId);
+
+CREATE INDEX IX_ControlValidationLinks_TenantId
+    ON ControlValidationLinks(TenantId);
+```

--- a/specs/069-sca-control-validation/plan.md
+++ b/specs/069-sca-control-validation/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan — Spec 069: SCA Control Implementation Validation Link
+
+**Target:** Wave 9 — SCA Evidence & Validation  
+**Estimated phases:** 9  
+**Priority tasks marked [P]**
+
+---
+
+## Sequencing Rationale
+
+This feature has a clear layered dependency chain:
+1. Data model first (entity + migration)
+2. Service interface + implementation (all other layers depend on this)
+3. MCP tool (depends on service)
+4. API endpoints (depends on service)
+5. IaC scan hook (depends on service)
+6. Dashboard UI (depends on API endpoints)
+7. Assess-control warning (depends on service)
+8. Tests (depend on all implementation)
+9. CI verification (final gate)
+
+---
+
+## Phase 1 — Data Model & Migration
+**Tasks:** T001–T004  
+**Blocked by:** Nothing — start immediately  
+**Blocks:** All other phases
+
+Key actions:
+- Add `ControlValidationLink` entity to `SspModels.cs`
+- Add `ControlValidationLinkType` enum
+- Add navigation property to `ControlImplementation`
+- Configure EF Core (DbSet, indexes, unique constraint, tenant filter)
+- Generate migration `Add_ControlValidationLinks`
+
+**Done signal:** `dotnet ef migrations add` succeeds; migration SQL reviewed and correct.
+
+---
+
+## Phase 2 — Service Layer
+**Tasks:** T005–T006  
+**Blocked by:** Phase 1 (entity must exist)  
+**Blocks:** Phases 3, 4, 5, 7
+
+Key actions:
+- Define `IControlValidationLinkService` with 4 methods
+- Implement `ControlValidationLinkService` — all queries filtered by `TenantId`
+- Implement upsert logic in `UpsertScanLinkAsync` using `(ControlImplementationId, LinkTarget)` unique constraint
+- Register service in DI
+
+**Done signal:** Service compiles; unit tests for `UpsertScanLinkAsync` idempotency pass.
+
+---
+
+## Phase 3 — MCP Tool
+**Tasks:** T007–T009  
+**Blocked by:** Phase 2  
+**Blocks:** Nothing directly (parallel to Phase 4)
+
+Key actions:
+- Create `GetControlValidationTool` in new file `ControlValidationTools.cs`
+- Implement `get`, `add`, `delete` branches via `action` parameter
+- Register in DI with `Compliance.Auditor` RBAC
+- Return `{ status, data: { links, total }, metadata }` shape
+
+**Done signal:** Tool callable from MCP test harness; NOT_FOUND, empty-list, and CRUD cases work.
+
+---
+
+## Phase 4 — Dashboard API Endpoints
+**Tasks:** T010–T013  
+**Blocked by:** Phase 2  
+**Blocks:** Phase 6 (UI depends on these endpoints)
+
+Key actions:
+- Create `ControlValidationEndpoints.cs` in `Endpoints/Compliance/`
+- Implement `GET`, `POST`, `DELETE` at `/api/systems/{id}/controls/{controlId}/validation`
+- Register endpoints in app startup
+- RBAC: Reader for GET, Auditor for POST/DELETE
+
+**Done signal:** Endpoints return 200/201/204/404 correctly; tested with `curl` or Swagger UI.
+
+---
+
+## Phase 5 — IaC Scan Auto-Link Hook
+**Tasks:** T014–T015  
+**Blocked by:** Phase 2  
+**Blocks:** Nothing (independent of UI)
+
+Key actions:
+- Inject `IControlValidationLinkService` into `IacComplianceScanTool` (optional/null-safe)
+- After scan execution, iterate findings → call `UpsertScanLinkAsync` for each control-mapped finding
+- Add `validation_links_created: N` to scan response metadata
+
+**Done signal:** Scan with a control-mapped Bicep file produces `ControlValidationLink` records; scan response shows `validation_links_created > 0`.
+
+---
+
+## Phase 6 — Dashboard UI
+**Tasks:** T016–T020  
+**Blocked by:** Phase 4  
+**Blocks:** Phase 7 (warning depends on panel existing)
+
+Key actions:
+- Add API methods to `complianceApi.ts`
+- Create `ValidationEvidencePanel.tsx` (link list, badges, add/delete)
+- Create `AddValidationLinkModal.tsx`
+- Mount panel on control detail page
+- Implement `buildAzurePortalUrl` utility
+
+**Done signal:** Control detail page shows Validation Evidence panel; Add and Delete actions work end-to-end; Azure Portal URL opens for `AzureResource` links.
+
+---
+
+## Phase 7 — Warning on Assess-Control with 0 Links
+**Tasks:** T021–T022  
+**Blocked by:** Phase 2 (service), Phase 6 (UI panel in place)  
+**Blocks:** Nothing
+
+Key actions:
+- `AssessControlTool`: after recording Satisfied, fetch link count; if 0, include `warnings` array in JSON
+- Dashboard: if panel shows 0 links and user marks control Satisfied, show inline non-blocking warning
+
+**Done signal:** MCP response for Satisfied control with 0 links includes `warnings`; Dashboard shows warning message.
+
+---
+
+## Phase 8 — Testing
+**Tasks:** T023–T027  
+**Blocked by:** All implementation phases  
+
+Key actions:
+- Backend unit tests: service, tool, IaC scan hook
+- Frontend unit tests: panel rendering, role gating, Azure URL utility
+
+**Done signal:** All new tests pass; no regressions in existing test suite.
+
+---
+
+## Phase 9 — CI Verification
+**Tasks:** T028–T030  
+**Blocked by:** Phase 8
+
+Key actions:
+- `dotnet build && dotnet test`
+- `npm run build`
+- Definition of Done checklist complete
+
+**Done signal:** CI green; PR updated and ready for review.

--- a/specs/069-sca-control-validation/quickstart.md
+++ b/specs/069-sca-control-validation/quickstart.md
@@ -1,0 +1,153 @@
+# Quickstart — Spec 069: SCA Control Implementation Validation Link
+
+---
+
+## Prerequisites
+
+- .NET 9 SDK installed (`dotnet --version` → 9.x)
+- Node.js 20+ and npm 10+ (`node -v`, `npm -v`)
+- EF Core tools: `dotnet tool install --global dotnet-ef` (or verify: `dotnet ef --version`)
+- Connection string configured in `appsettings.Development.json` or user secrets
+- Docker (optional — if running SQL Server locally via container)
+
+---
+
+## 1. Apply the Migration
+
+```bash
+# From repo root
+cd src/Ato.Copilot.Core    # or wherever the migrations project lives
+dotnet ef migrations add Add_ControlValidationLinks \
+  --startup-project ../Ato.Copilot.Mcp \
+  --output-dir Migrations
+
+# Review generated migration SQL:
+dotnet ef migrations script --idempotent
+```
+
+If running SQL Server locally via Docker:
+```bash
+docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=YourStrong!Passw0rd" \
+  -p 1433:1433 --name sql-local -d mcr.microsoft.com/mssql/server:2022-latest
+```
+
+Apply migration:
+```bash
+dotnet ef database update --startup-project ../Ato.Copilot.Mcp
+```
+
+---
+
+## 2. Run the Backend
+
+```bash
+cd src/Ato.Copilot.Mcp
+dotnet run
+# API available at https://localhost:5001 (or http://localhost:5000)
+```
+
+Verify new endpoints are registered:
+```bash
+curl -s https://localhost:5001/api/systems/TEST-SYSTEM/controls/AC-2/validation \
+  -H "Authorization: Bearer $TOKEN"
+# Expect: 200 with { systemId, controlId, total: 0, links: [] }
+```
+
+---
+
+## 3. Test the MCP Tool
+
+Via MCP test harness or direct tool invocation:
+```json
+{
+  "tool": "compliance_get_control_validation",
+  "arguments": {
+    "system_id": "<your-system-id>",
+    "control_id": "AC-2",
+    "action": "get"
+  }
+}
+```
+
+Expected response shape:
+```json
+{
+  "status": "success",
+  "data": {
+    "links": [],
+    "total": 0
+  },
+  "metadata": { "tool": "compliance_get_control_validation", "duration_ms": 12 }
+}
+```
+
+Add a manual link:
+```json
+{
+  "tool": "compliance_get_control_validation",
+  "arguments": {
+    "system_id": "<your-system-id>",
+    "control_id": "AC-2",
+    "action": "add",
+    "link_type": "AzureResource",
+    "link_target": "/subscriptions/abc/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-jump",
+    "description": "Jump server with Conditional Access enforcing MFA (AC-2 requirement)"
+  }
+}
+```
+
+---
+
+## 4. Test IaC Scan Auto-Link
+
+```json
+{
+  "tool": "iac_compliance_scan",
+  "arguments": {
+    "filePath": "main.bicep",
+    "fileContent": "<bicep content with storage account or VM>",
+    "fileType": "bicep",
+    "framework": "nist-800-53-r5"
+  }
+}
+```
+
+After scan, re-run `compliance_get_control_validation` for the matched control — expect `IsAutomated: true` links.
+
+---
+
+## 5. Run the Dashboard
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm install
+npm run dev
+# Dashboard at http://localhost:5173
+```
+
+Navigate to a system → Controls → select any control → verify the **Validation Evidence** panel appears below the narrative.
+
+---
+
+## 6. Run Tests
+
+```bash
+# Backend
+dotnet test Ato.Copilot.sln --filter "Category=Feature069"
+
+# Frontend
+cd src/Ato.Copilot.Dashboard
+npm test -- --testPathPattern="ValidationEvidence|azurePortalUrl"
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Migration fails: `Table 'ControlImplementations' not found` | Ensure prior migrations are applied: `dotnet ef database update` from the latest baseline before adding this migration |
+| `IControlValidationLinkService` not registered | Add `services.AddScoped<IControlValidationLinkService, ControlValidationLinkService>()` in DI setup |
+| IaC scan runs but no links created | Check: `IControlValidationLinkService` is registered and scan findings have `MappedControlIds` populated |
+| `ValidationEvidencePanel` not visible | Confirm the panel is mounted on the correct control detail page component; check browser console for 404 on validation endpoint |
+| Azure Portal URL opens wrong resource | Verify `LinkTarget` stored is the ARM resource ID (e.g., `/subscriptions/...`) not a portal URL |

--- a/specs/069-sca-control-validation/research.md
+++ b/specs/069-sca-control-validation/research.md
@@ -1,0 +1,136 @@
+# Research — Spec 069: SCA Control Implementation Validation Link
+
+**Decision date:** 2026-06-11  
+**Researcher:** Cyborg (agent:cyborg)
+
+---
+
+## Problem Restatement
+
+Issue #57 asks: *"As a SCA I want to see a link or some way I can validate that the control is actually implemented in the environment."*
+
+The core need is **navigability**: given a control record, an SCA should be able to follow a link to actual evidence of implementation — without manually correlating control IDs to Azure resources, scan results, or documents.
+
+---
+
+## Existing Capabilities Audited
+
+| Component | What it does | Gap |
+|---|---|---|
+| `AssessControlTool` (`compliance_assess_control`) | Records Satisfied/OtherThanSatisfied determination + `EvidenceIds` | `EvidenceIds` are `ComplianceEvidence` record IDs — no Azure resource pointers; no back-navigation from determination to resource |
+| `IacComplianceScanTool` (`iac_compliance_scan`) | Scans Bicep/Terraform/ARM and maps findings to NIST control IDs | Findings are returned in the scan response but are not persisted as links on the control record; re-running the scan does not update the control |
+| `ControlImplementation` entity | Stores narrative, status, authorship | No `EvidenceLinks`, `ValidationUrl`, or resource reference fields |
+| `ControlEffectiveness` entity | Per-control determination with `EvidenceIds` (JSON array) | `EvidenceIds` are opaque strings — no typed link to Azure resource vs. scan finding vs. external URL |
+
+---
+
+## Options Considered
+
+### Option A — JSON column on `ControlImplementation` (rejected)
+
+Add a `ValidationLinks` JSON column to `ControlImplementation`.
+
+**Pros:** Minimal schema change; no new table or migration.  
+**Cons:**
+- 0..N links per control → variable-length JSON blob; not queryable without JSON_VALUE
+- Cannot apply tenant filter or FK constraints on contents of a JSON column
+- EF Core JSON column support is workable but adds complexity for querying individual links
+- Cannot cascade-delete a single link without deserializing, modifying, and re-serializing the column
+- Hard to index or report across all links for a tenant
+
+**Verdict:** Rejected. Violates queryability and FK integrity requirements.
+
+---
+
+### Option B — Extend `ControlEffectiveness.EvidenceIds` (rejected)
+
+Store typed resource references alongside existing `EvidenceIds` in `ControlEffectiveness`.
+
+**Pros:** No new entity; leverages existing evidence structure.  
+**Cons:**
+- `ControlEffectiveness` is per-assessment-per-determination; `ControlImplementation` is the persistent record
+- A control can have many assessments over time; resource links should persist across assessment cycles on the implementation record, not be tied to a single determination
+- Mixing evidence artifact IDs with Azure resource IDs and scan findings in one `List<string>` is type-unsafe
+
+**Verdict:** Rejected. Wrong entity; loses persistence across assessment cycles.
+
+---
+
+### Option C — Separate `ControlValidationLink` table with FK to `ControlImplementation` ✅ SELECTED
+
+New `[TenantScoped]` table with FK to `ControlImplementation`, `LinkType` enum, `LinkTarget`, and provenance fields.
+
+**Pros:**
+- FK cascade-delete keeps DB clean if a `ControlImplementation` is removed
+- Unique constraint `(ControlImplementationId, LinkTarget)` enables idempotent upsert from IaC scan
+- Fully queryable; tenant filter applies normally via `TenantStampingSaveChangesInterceptor`
+- `LinkType` enum enables type-specific UI rendering (Azure Portal URL construction)
+- Decouples link lifecycle from assessment lifecycle — links persist across assessments
+- Standard EF Core navigation property on `ControlImplementation`
+
+**Cons:**
+- New migration required
+- Small join overhead when loading control detail (acceptable — panel is loaded on demand)
+
+**Verdict:** Selected. Best separation of concerns; enables all required use cases.
+
+---
+
+### Option D — External evidence URL field on `ControlImplementation` only (rejected)
+
+Add a single `ValidationUrl` string field to `ControlImplementation`.
+
+**Pros:** Simplest possible change; no new table.  
+**Cons:**
+- One URL per control — a single control may be implemented by multiple Azure resources (e.g., AC-2 by Azure AD + RBAC + JIT access)
+- Cannot distinguish automated scan findings from manual SCA additions
+- Cannot store Azure resource IDs (not URLs) without constructing portal URL at write time (bad: URL format can change)
+- Does not address auto-population from IaC scan
+
+**Verdict:** Rejected. Insufficient for real-world multi-resource controls.
+
+---
+
+## Auto-Link Population: Options
+
+### Inline in `IacComplianceScanTool.ExecuteCoreAsync` ✅ SELECTED
+
+Inject `IControlValidationLinkService` into the tool; call `UpsertScanLinkAsync` after findings are computed, within the same request. Return `validation_links_created: N` in metadata.
+
+**Pros:** Simple; immediate consistency; no queue or background job needed.  
+**Cons:** Adds DB write to scan response path; if service unavailable, scan still succeeds (null-safe injection).
+
+**Mitigations:** Service injection is null-safe (no throw if not registered); DB write is fast for ≤100 links.
+
+### Background job / event (rejected for MVP)
+
+Emit an event from the scan tool; a background handler creates links asynchronously.
+
+**Pros:** Decoupled; scan response is unaffected by DB latency.  
+**Cons:** More moving parts; event infrastructure not needed at this scale; links might not exist when SCA immediately views the control after scan.
+
+**Verdict:** Deferred to future iteration if scan performance becomes a concern.
+
+---
+
+## Dashboard URL Construction: Client-Side vs. Server-Side
+
+**Decision:** Azure Portal deep-links constructed **client-side** in `buildAzurePortalUrl` utility.
+
+**Rationale:**
+- Portal URL format (`https://portal.azure.com/#resource/{resourceId}`) is stable and public
+- Server-side construction would require the backend to know the portal URL format — no benefit over client doing it
+- Avoids any risk of leaking resource IDs through server-side URL-building logs
+- URL format is simple enough to unit-test directly
+
+---
+
+## MCP Tool Action Parameter Pattern
+
+**Decision:** Single tool `compliance_get_control_validation` with `action: get | add | delete` parameter.
+
+**Rationale:**
+- Consistent with existing tool patterns in the repo (reviewed `AssessControlTool`, `IacComplianceScanTool`)
+- Agent workflows benefit from a single tool name per entity rather than separate `compliance_add_validation_link` + `compliance_delete_validation_link` tools
+- Reduces MCP tool registry clutter
+- Precedent: compound tools with `action` parameter are idiomatic in this codebase

--- a/specs/069-sca-control-validation/spec.md
+++ b/specs/069-sca-control-validation/spec.md
@@ -1,0 +1,221 @@
+# Spec 069 — SCA Control Implementation Validation Link
+
+**Epic:** #57 — SCA: Validate Control Implementation in the Environment  
+**Milestone:** Wave 9 — SCA Evidence & Validation  
+**Owner:** Cyborg (agent:cyborg)  
+**Status:** Spec-complete (pending implementation)  
+**Last updated:** 2026-06-11  
+**Feature number:** 069
+
+---
+
+## Background
+
+Today an SCA can record per-control effectiveness determinations (Satisfied / OtherThanSatisfied) via the `compliance_assess_control` MCP tool backed by `AssessControlTool` in `AssessmentArtifactTools.cs`. An IaC scanner (`IacComplianceScanTool`) can also run automated policy checks against Bicep/Terraform/ARM files and map findings to NIST 800-53 control IDs.
+
+**The gap:** Neither workflow creates a navigable link from a control record back to the actual Azure resources, IaC scan findings, or evidence artifacts that confirm (or disprove) the control's implementation. When an SCA opens a control detail, there is nothing to click to see *why* the control is Satisfied or what Azure resource enforces it.
+
+`ControlImplementation` (`SspModels.cs`) tracks narrative, status, and authorship — but has no `EvidenceLinks`, `ValidationUrl`, or resource reference fields.  
+`ControlEffectiveness` (`AssessmentModels.cs`) carries `EvidenceIds` (a JSON array of `ComplianceEvidence` record IDs) but no structured resource-level links.
+
+This feature introduces:
+1. A `ControlValidationLink` entity — FK to `ControlImplementation`, typed pointer to an Azure resource, scan finding, evidence artifact, or external URL
+2. Auto-population — when the IaC scan maps findings to controls, links are created automatically
+3. Manual addition — SCA can add/delete links via MCP tool or Dashboard UI
+4. A new MCP tool `compliance_get_control_validation` — returns all validation links for a control
+5. A Dashboard REST endpoint `GET /api/systems/{id}/controls/{controlId}/validation`
+6. A "View Evidence" panel on the control detail page
+
+---
+
+## Tech Stack
+
+- **Backend:** ASP.NET Core 9 Minimal APIs; `MapGroup("/api/systems")`
+- **Data:** EF Core 8 + `[TenantScoped]`; new migration `Add_ControlValidationLinks`
+- **MCP:** `BaseTool` pattern in `Ato.Copilot.Agents`
+- **Frontend:** React 19 + Vite + Tailwind + React Router 7
+- **Auth:** `Compliance.Auditor` policy (SCA role) for read/write; `Compliance.Reader` for read-only
+- **Existing tools:** `AssessControlTool` (T098), `IacComplianceScanTool` — both extended to emit links
+
+---
+
+## User Stories
+
+### US1 — Validation Link from Control Record
+
+**As a** Security Control Assessor (SCA)  
+**I want** to see clickable links on a control record that lead directly to the Azure resource, scan result, or evidence artifact that proves or disproves the control's implementation  
+**So that** I can validate implementation without leaving the compliance context or hunting through separate portals
+
+**Why this priority:** P1. Absence of evidence linkage is the verbatim gap in Issue #57. Without it, SCAs cannot efficiently validate, leading to slower ATOs and potential mis-assessments.
+
+**Independent Test:** Open any system's control detail in the Dashboard → "Validation Evidence" panel is visible, at least one link is present for a recently-scanned control, and clicking it opens the correct Azure resource or artifact.
+
+**Acceptance Criteria**
+- Control detail page (Dashboard) shows a "Validation Evidence" panel
+- Panel lists all `ControlValidationLink` records for the control: type badge, description, link target, added by, added at, whether automated
+- Automated links (from IaC scan) show an "Auto" badge; manual links show "Manual"
+- Clicking a link opens the target (Azure Portal URL, artifact download, external URL) in a new tab
+- Empty state: "No validation links yet. Run a compliance scan or add a link manually."
+- SCA can add a manual link (type + target + description) via a modal form
+- SCA can delete any link with a confirmation dialog
+- Non-SCA roles (Reader) can view links but cannot add or delete
+
+**Edge Cases**
+- Link target is an Azure resource ID (not a URL) — Dashboard constructs the Azure Portal URL: `https://portal.azure.com/#resource/{resourceId}`
+- IaC scan finds no relevant control mapping → no auto-link created; manual addition still available
+- Stale link (resource deleted or moved) — link remains; SCA can delete it; future feature can add health-check
+- Control has 0 links and SCA tries to mark Satisfied → allowed; warning surfaced: "No validation links attached. Consider adding evidence before marking Satisfied."
+
+---
+
+### US2 — MCP Tool for SCA Agents
+
+**As an** AI agent acting for an SCA  
+**I want** a `compliance_get_control_validation` tool that returns all validation links for a control  
+**So that** I can surface evidence during an automated assessment or narrative-generation session
+
+**Why this priority:** P1. All SCA capability must be accessible via MCP for agent-driven workflows (Constitution principle).
+
+**Independent Test:** Call `compliance_get_control_validation` with a valid `system_id` and `control_id` → tool returns structured list of links with type, target, description, and provenance.
+
+**Acceptance Criteria**
+- Tool name: `compliance_get_control_validation`
+- RBAC: `Compliance.Auditor` required
+- Returns `{ links: [...], total: N }` with each link typed and described
+- Tool can also add a link via `action: "add"` parameter or delete via `action: "delete"`
+- Returns `NOT_FOUND` if system or control does not exist
+- Returns empty `links: []` (not an error) if no links exist yet
+
+---
+
+### US3 — Auto-Populate Links from IaC Scan
+
+**As a** compliance engineer  
+**I want** IaC scan results to automatically create `ControlValidationLink` records when findings map to a control  
+**So that** validation links exist without manual SCA effort for any scanned system
+
+**Why this priority:** P2. Auto-population closes the loop between existing scan capability and the new link table, providing immediate value on first use.
+
+**Independent Test:** Run `iac_compliance_scan` against a Bicep file that maps to AC-2 → after the scan, `GET /api/systems/{id}/controls/AC-2/validation` returns at least one link with `IsAutomated: true` and `LinkType: ScanFinding`.
+
+**Acceptance Criteria**
+- After `iac_compliance_scan` executes and maps a finding to a control ID, a `ControlValidationLink` is upserted
+- `IsAutomated = true`, `AddedBy = "iac-scan"`, `LinkType = ScanFinding`
+- `LinkTarget` = the scan finding reference ID or file path
+- `Description` = finding title + severity
+- If a link for the same `(ControlImplementationId, LinkTarget)` already exists, it is updated (upsert on unique constraint)
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-001 | `ControlValidationLink` entity with FK to `ControlImplementation`, `LinkType`, `LinkTarget`, `Description`, `AddedBy`, `AddedAt`, `ValidatedAt`, `IsAutomated` |
+| FR-002 | EF Core migration `Add_ControlValidationLinks` with index on `(ControlImplementationId)` and unique constraint on `(ControlImplementationId, LinkTarget)` |
+| FR-003 | MCP tool `compliance_get_control_validation` — reads links for a control (RBAC: Compliance.Auditor) |
+| FR-004 | MCP tool supports `action: "add"` to create a manual link (RBAC: Compliance.Auditor) |
+| FR-005 | MCP tool supports `action: "delete"` to remove a link by ID (RBAC: Compliance.Auditor) |
+| FR-006 | Dashboard endpoint `GET /api/systems/{id}/controls/{controlId}/validation` returns all links (RBAC: Compliance.Reader) |
+| FR-007 | Dashboard endpoint `POST /api/systems/{id}/controls/{controlId}/validation` adds a manual link (RBAC: Compliance.Auditor) |
+| FR-008 | Dashboard endpoint `DELETE /api/systems/{id}/controls/{controlId}/validation/{linkId}` removes a link (RBAC: Compliance.Auditor) |
+| FR-009 | IaC scan hook: after scan, auto-create `ScanFinding` links for each matched control (upsert) |
+| FR-010 | Dashboard control detail page shows "Validation Evidence" panel with link list, add modal, delete action |
+| FR-011 | Auto-links show "Auto" badge; manual links show "Manual" badge |
+| FR-012 | `AzureResource` link type → Dashboard constructs Azure Portal deep-link URL |
+| FR-013 | Empty-state message when no links exist |
+| FR-014 | Warning surfaced if SCA marks control Satisfied with 0 validation links (non-blocking) |
+| FR-015 | Tenant isolation enforced — `[TenantScoped]` on entity, stamped by `TenantStampingSaveChangesInterceptor` |
+
+---
+
+## Architecture Decisions
+
+| Decision | Rationale |
+|---|---|
+| Separate `ControlValidationLink` table (not extending `ControlImplementation`) | `ControlImplementation` is already a large entity; links are 0..N per control — a separate table with FK is cleaner and avoids EF Core serialization of arbitrary JSON blobs in the parent entity |
+| Upsert on `(ControlImplementationId, LinkTarget)` for auto-links | IaC scans run repeatedly; idempotent upsert prevents duplicate links per scan run |
+| `LinkType` enum rather than free-text | Typed enum enables Dashboard to render type-specific UI (e.g., construct Azure Portal URL for `AzureResource` type without extra logic) |
+| `compliance_get_control_validation` supports add/delete via `action` parameter | Consistent with existing agent tool patterns in the repo; avoids proliferating separate tools for CRUD on a single entity |
+| Warning (not block) when marking Satisfied with 0 links | SCA must retain authority to override; blocking would be paternalistic and could delay ATOs for controls where evidence is external to the system |
+| `ValidatedAt` nullable on the link | Manual links are added by the SCA who has personally verified; auto-links are unverified until SCA explicitly sets `ValidatedAt` via the UI or tool |
+
+---
+
+## Non-Functional Requirements
+
+- Validation link list must load within 500 ms for up to 100 links per control
+- Tenant isolation enforced at DB and API layer (all queries filtered by `TenantId`)
+- IaC scan link auto-creation must not block the scan response — upsert runs as a fire-and-update within the same transaction or a background step
+- Azure Portal deep-link construction is client-side only — no external network call from the backend
+- All endpoints return 403 for insufficient role, 404 for missing system/control
+- Links are soft-reference: deleting a link does not affect the linked resource or artifact
+
+---
+
+## Test Plan
+
+### Manual
+- Run IaC scan on a compliant Bicep file → verify auto-link appears for matched controls
+- Open Dashboard control detail → verify Validation Evidence panel renders
+- Add manual link (AzureResource type) → verify link appears with Manual badge and Azure Portal URL is correct
+- Delete link → confirmation dialog → link removed
+- Open control with 0 links → verify empty-state message
+- Mark control Satisfied with 0 links → verify non-blocking warning appears
+- Non-SCA role (Reader) → verify can view but Add/Delete buttons hidden
+
+### Automated
+- Unit tests: `ControlValidationLinkService.GetLinksAsync` returns correct records by `(systemId, controlId)`
+- Unit tests: `GetControlValidationTool.ExecuteCoreAsync` — valid input returns links; missing control returns NOT_FOUND; empty control returns empty list
+- Unit tests: IaC scan hook — mock scan result with control mapping → verify `ControlValidationLink` upserted
+- Integration: `GET /api/systems/{id}/controls/{controlId}/validation` MSW-mocked → panel renders links
+- Integration: `POST` / `DELETE` endpoints wired to service (MSW)
+- Unit: `AzureResource` link type → Dashboard correctly constructs `https://portal.azure.com/#resource/{id}` URL
+- Role guard: Reader role → Add/Delete buttons not rendered; 403 on API calls
+
+---
+
+## Definition of Done
+
+- [ ] `ControlValidationLink` entity created in `SspModels.cs`
+- [ ] EF Core migration `Add_ControlValidationLinks` applied
+- [ ] `IControlValidationLinkService` interface and `ControlValidationLinkService` implementation
+- [ ] `GetControlValidationTool` (MCP) implemented and registered in DI
+- [ ] `GET`, `POST`, `DELETE` Dashboard endpoints implemented
+- [ ] IaC scan auto-create hook implemented (upsert)
+- [ ] Dashboard "Validation Evidence" panel implemented on control detail page
+- [ ] Azure Portal deep-link construction for `AzureResource` links
+- [ ] Role gates verified (UI + API)
+- [ ] Unit and integration tests passing
+- [ ] Empty-state and 0-links warning rendered correctly
+
+---
+
+## Constraints
+
+- Only `Compliance.Auditor` (SCA) role may add or delete links; `Compliance.Reader` is view-only
+- IaC scan auto-links may not be deleted by non-SCA roles
+- Azure Portal URLs must be constructed client-side; never stored as raw URLs with embedded credentials
+- Tenant isolation is mandatory — no cross-tenant link visibility
+
+---
+
+## Anti-Patterns to Avoid
+
+- Embedding validation links as a JSON column in `ControlImplementation` — breaks queryability and tenant filtering
+- Blocking SCA from marking a control as Satisfied when no links exist — SCA authority must be preserved
+- Constructing Azure Portal URLs server-side with resource IDs from untrusted input — do this client-side only
+- Creating a separate MCP tool for each CRUD action — use the `action` parameter pattern
+- Storing full Azure Portal URLs in `LinkTarget` — store the resource ID/path, construct the URL in the UI
+
+---
+
+## Existing File References
+
+| File | Role |
+|---|---|
+| `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` | `ControlImplementation` entity (lines 15–103) — FK source for `ControlValidationLink` |
+| `src/Ato.Copilot.Core/Models/Compliance/AssessmentModels.cs` | `ControlEffectiveness` entity (lines 16–74) — carries `EvidenceIds`; validation links are complementary |
+| `src/Ato.Copilot.Agents/Compliance/Tools/AssessmentArtifactTools.cs` | `AssessControlTool` (T098, lines 23–131) — RBAC: Compliance.Auditor; extend to warn on 0 links |
+| `src/Ato.Copilot.Agents/Compliance/Tools/IacComplianceScanTool.cs` | `IacComplianceScanTool` (lines 14–80+) — scan result hook for auto-link creation |

--- a/specs/069-sca-control-validation/tasks.md
+++ b/specs/069-sca-control-validation/tasks.md
@@ -1,0 +1,79 @@
+# Tasks — Spec 069: SCA Control Implementation Validation Link
+
+**Epic:** #57 | **Branch:** `069-sca-control-validation`  
+**Wave:** 9 | **Owner:** Cyborg (agent:cyborg)
+
+---
+
+## Phase 1 — Data Model & Migration
+
+- [ ] **T001** [P] `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` — Add `ControlValidationLink` entity with `Id`, `TenantId`, `ControlImplementationId`, `LinkType` (enum), `LinkTarget`, `Description`, `AddedBy`, `AddedAt`, `ValidatedAt`, `IsAutomated`; add `ICollection<ControlValidationLink> ValidationLinks` navigation to `ControlImplementation` (#57)
+- [ ] **T002** [P] `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` — Add `ControlValidationLinkType` enum: `AzureResource`, `ScanFinding`, `EvidenceArtifact`, `ExternalUrl` (#57) — depends on T001
+- [ ] **T003** [P] EF Core `DbContext` — Register `DbSet<ControlValidationLink>`, configure `[TenantScoped]` stamping, add composite unique index on `(ControlImplementationId, LinkTarget)`, add index on `ControlImplementationId` (#57) — depends on T001
+- [ ] **T004** [P] Run `dotnet ef migrations add Add_ControlValidationLinks` in `Ato.Copilot.Core` or appropriate migrations project; verify migration SQL (#57) — depends on T003
+
+---
+
+## Phase 2 — Service Layer
+
+- [ ] **T005** [P] `src/Ato.Copilot.Core/Interfaces/Compliance/IControlValidationLinkService.cs` — Define interface: `GetLinksAsync(systemId, controlId)`, `AddLinkAsync(systemId, controlId, type, target, description, addedBy)`, `DeleteLinkAsync(linkId, deletedBy)`, `UpsertScanLinkAsync(systemId, controlId, scanFindingRef, description)` (#57)
+- [ ] **T006** [P] `src/Ato.Copilot.Agents/Compliance/Services/ControlValidationLinkService.cs` — Implement `IControlValidationLinkService`; all queries filter by `TenantId`; `UpsertScanLinkAsync` performs upsert on `(ControlImplementationId, LinkTarget)` (#57) — depends on T005
+
+---
+
+## Phase 3 — MCP Tool
+
+- [ ] **T007** [P] `src/Ato.Copilot.Agents/Compliance/Tools/ControlValidationTools.cs` — Implement `GetControlValidationTool` extending `BaseTool`; tool name: `compliance_get_control_validation`; RBAC: `Compliance.Auditor`; parameters: `system_id` (required), `control_id` (required), `action` (optional: `"get"` default / `"add"` / `"delete"`), `link_type` (for add), `link_target` (for add), `description` (for add), `link_id` (for delete) (#57) — depends on T006
+- [ ] **T008** `src/Ato.Copilot.Agents/Compliance/Tools/ControlValidationTools.cs` — Wire `action: "add"` and `action: "delete"` branches in `ExecuteCoreAsync`; return structured JSON `{ status, data: { links, total }, metadata }` (#57) — depends on T007
+- [ ] **T009** `src/Ato.Copilot.Agents/DependencyInjection/AgentToolRegistrations.cs` (or equivalent DI file) — Register `GetControlValidationTool` in DI; verify no duplicate tool names (#57) — depends on T007
+
+---
+
+## Phase 4 — Dashboard API Endpoints
+
+- [ ] **T010** [P] `src/Ato.Copilot.Mcp/Endpoints/Compliance/ControlValidationEndpoints.cs` — Implement `GET /api/systems/{id}/controls/{controlId}/validation` → returns `ControlValidationLinksResponse` DTO; RBAC: `Compliance.Reader`; 404 if system not found (#57) — depends on T006
+- [ ] **T011** [P] `src/Ato.Copilot.Mcp/Endpoints/Compliance/ControlValidationEndpoints.cs` — Implement `POST /api/systems/{id}/controls/{controlId}/validation` → accepts `AddValidationLinkRequest` DTO; RBAC: `Compliance.Auditor`; returns 201 with created link (#57) — depends on T006
+- [ ] **T012** `src/Ato.Copilot.Mcp/Endpoints/Compliance/ControlValidationEndpoints.cs` — Implement `DELETE /api/systems/{id}/controls/{controlId}/validation/{linkId}` → RBAC: `Compliance.Auditor`; returns 204 or 404 (#57) — depends on T006
+- [ ] **T013** `src/Ato.Copilot.Mcp/Program.cs` (or route registration file) — Register `ControlValidationEndpoints` in the app route map (#57) — depends on T010
+
+---
+
+## Phase 5 — IaC Scan Auto-Link Hook
+
+- [ ] **T014** [P] `src/Ato.Copilot.Agents/Compliance/Tools/IacComplianceScanTool.cs` — After scan execution, for each finding that maps to a NIST control ID, call `IControlValidationLinkService.UpsertScanLinkAsync`; inject `IControlValidationLinkService` as optional dependency (null-safe for standalone scan scenarios) (#57) — depends on T006
+- [ ] **T015** `src/Ato.Copilot.Agents/Compliance/Tools/IacComplianceScanTool.cs` — Ensure IaC scan response includes `validation_links_created: N` count in `metadata` section so callers know links were upserted (#57) — depends on T014
+
+---
+
+## Phase 6 — Dashboard UI
+
+- [ ] **T016** [P] `src/Ato.Copilot.Dashboard/src/features/compliance/api/complianceApi.ts` — Add `getControlValidationLinks(systemId, controlId)`, `addValidationLink(systemId, controlId, payload)`, `deleteValidationLink(systemId, controlId, linkId)` API methods (#57) — depends on T010
+- [ ] **T017** [P] `src/Ato.Copilot.Dashboard/src/features/compliance/components/ValidationEvidencePanel.tsx` — Create component: renders link list with type badge (AzureResource/ScanFinding/EvidenceArtifact/ExternalUrl), Auto/Manual badge, description, linked target (clickable), added by, added at; empty-state message; Add/Delete buttons (SCA role only) (#57) — depends on T016
+- [ ] **T018** `src/Ato.Copilot.Dashboard/src/features/compliance/components/AddValidationLinkModal.tsx` — Create modal: type selector, link target input, description textarea; submits to `addValidationLink`; `AzureResource` type shows helper text "Enter Azure resource ID (e.g., /subscriptions/.../resourceGroups/...)"; on success, panel refreshes (#57) — depends on T017
+- [ ] **T019** [P] Dashboard control detail page (identified during implementation) — Mount `<ValidationEvidencePanel>` in the control detail view; place below the narrative/status section (#57) — depends on T017
+- [ ] **T020** `src/Ato.Copilot.Dashboard/src/features/compliance/utils/azurePortalUrl.ts` — Implement `buildAzurePortalUrl(resourceId: string): string` helper: `https://portal.azure.com/#resource/${resourceId}`; export and use in `ValidationEvidencePanel` for `AzureResource` links (#57) — depends on T017
+
+---
+
+## Phase 7 — Warning on Assess-Control with 0 Links
+
+- [ ] **T021** `src/Ato.Copilot.Agents/Compliance/Tools/AssessmentArtifactTools.cs` — In `AssessControlTool.ExecuteCoreAsync` (T098), after recording Satisfied determination, call `IControlValidationLinkService.GetLinksAsync`; if count == 0, include `warnings: ["No validation links attached to this control. Consider adding evidence."]` in the response JSON (#57) — depends on T006
+- [ ] **T022** Dashboard — When SCA marks a control as Satisfied from the Dashboard and the `ValidationEvidencePanel` shows 0 links, surface a non-blocking inline warning: "⚠️ No validation evidence linked. Adding evidence strengthens your ATO package." (#57) — depends on T019
+
+---
+
+## Phase 8 — Testing
+
+- [ ] **T023** [P] `tests/Ato.Copilot.Agents.Tests/Compliance/Tools/GetControlValidationToolTests.cs` — Unit tests: valid get returns links; action=add creates link; action=delete removes link; missing control returns NOT_FOUND; 0 links returns empty list not error (#57)
+- [ ] **T024** [P] `tests/Ato.Copilot.Agents.Tests/Compliance/Services/ControlValidationLinkServiceTests.cs` — Unit tests: `UpsertScanLinkAsync` idempotent on duplicate `(ControlImplementationId, LinkTarget)`; tenant isolation enforced (#57)
+- [ ] **T025** `tests/Ato.Copilot.Agents.Tests/Compliance/Tools/IacComplianceScanToolTests.cs` — Unit test: scan with control-mapped findings calls `UpsertScanLinkAsync`; `validation_links_created` in metadata (#57)
+- [ ] **T026** [P] `src/Ato.Copilot.Dashboard/src/features/compliance/components/__tests__/ValidationEvidencePanel.test.tsx` — Tests: links render correctly; Auto/Manual badges; empty-state; Add/Delete buttons hidden for Reader role; `AzureResource` link opens correct portal URL (#57)
+- [ ] **T027** `src/Ato.Copilot.Dashboard/src/features/compliance/utils/__tests__/azurePortalUrl.test.ts` — Unit tests: `buildAzurePortalUrl` constructs correct URL for various resource ID formats (#57)
+
+---
+
+## Phase 9 — CI Verification
+
+- [ ] **T028** Run `dotnet build Ato.Copilot.sln && dotnet test Ato.Copilot.sln` — verify no backend regressions
+- [ ] **T029** Run `cd src/Ato.Copilot.Dashboard && npm run build` — verify TypeScript compiles cleanly
+- [ ] **T030** Verify all Definition of Done items in spec.md checked; update PR description


### PR DESCRIPTION
**Owner:** Cyborg (agent:cyborg)
**Closes:** #57
**Branch:** `069-sca-control-validation` → `main`
**Wave:** 9 — SCA Evidence & Validation

---

## Problem Statement

Today an SCA can record a per-control effectiveness determination (Satisfied / OtherThanSatisfied) via `compliance_assess_control` and the `AssessControlTool` (T098). However, there is **no mechanism to navigate from a control record back to the actual Azure resources, IaC scan findings, or evidence artifacts** that confirm or disprove the control's implementation.

`ControlImplementation` (`SspModels.cs`, lines 15–103) stores narrative, status, and authorship — but has no `EvidenceLinks`, `ValidationUrl`, or resource reference fields. `ControlEffectiveness` (`AssessmentModels.cs`, lines 16–74) carries opaque `EvidenceIds` (a JSON array of `ComplianceEvidence` record IDs) but no typed pointer to a live Azure resource.

When an SCA opens a control detail today, there is nothing to click to see *why* the control is Satisfied or *what* Azure resource enforces it. Issue #57 verbatim: *"As a SCA I want to see a link or some way I can validate that the control is actually implemented in the environment."*

---

## Goal / Desired Outcome

After this feature:
1. A `ControlValidationLink` table persists typed, navigable links from each `ControlImplementation` to the Azure resources, IaC scan findings, evidence artifacts, or external URLs that prove implementation.
2. IaC scan results automatically create `ScanFinding` links (upserted, idempotent) when findings map to NIST control IDs.
3. SCA can manually add or remove links via the `compliance_get_control_validation` MCP tool or the Dashboard "Validation Evidence" panel.
4. The Dashboard control detail page shows all links as clickable evidence; `AzureResource` links open directly in the Azure Portal.
5. `compliance_assess_control` includes an advisory warning if a control is marked Satisfied with 0 validation links.

---

## Scope

**In scope:**
- `ControlValidationLink` entity + EF Core migration
- `IControlValidationLinkService` interface + implementation
- `GetControlValidationTool` MCP tool (`compliance_get_control_validation`) — get / add / delete actions
- Dashboard REST endpoints: `GET`, `POST`, `DELETE /api/systems/{id}/controls/{controlId}/validation`
- IaC scan hook: auto-create `ScanFinding` links after scan execution
- Dashboard `ValidationEvidencePanel` component + `AddValidationLinkModal`
- `AssessControlTool` warning when 0 links on Satisfied determination
- Unit + integration tests for all above

**Out of scope:**
- Link health-check (detecting stale/deleted Azure resources) — deferred to future feature
- `ValidatedAt` workflow (SCA explicitly confirming a link is current) — field exists but UI for setting it is V2
- Defender for Cloud or Azure Policy automatic ingestion — deferred; `ExternalUrl` type covers manual linking in the meantime

---

## User Experience Flow

1. SCA runs `iac_compliance_scan` on a Bicep file → scan completes → `ScanFinding` links auto-created for each matched control
2. SCA opens the Dashboard → navigates to a registered system → opens the Controls list → clicks a control (e.g., AC-2)
3. Control detail page loads → "Validation Evidence" panel is visible below the narrative section
4. Panel shows 2 links: one "Auto" (from IaC scan), one "Manual" (previously added by SCA)
5. SCA clicks the Azure resource link → Azure Portal opens to that resource in a new tab
6. SCA clicks "Add Evidence" → modal opens → selects `AzureResource`, pastes resource ID, adds description → submits
7. New link appears in the panel with "Manual" badge
8. SCA marks control as Satisfied via `compliance_assess_control` with 0 links → receives advisory warning in the tool response
9. SCA marks control as Satisfied with links present → no warning; clean success response

---

## Functional Requirements

| ID | Requirement |
|---|---|
| FR-001 | `ControlValidationLink` entity with FK to `ControlImplementation`, `LinkType`, `LinkTarget`, `Description`, `AddedBy`, `AddedAt`, `ValidatedAt`, `IsAutomated` |
| FR-002 | EF Core migration `Add_ControlValidationLinks`; unique constraint on `(ControlImplementationId, LinkTarget)`; index on `ControlImplementationId` |
| FR-003 | MCP tool `compliance_get_control_validation` — reads links (RBAC: Compliance.Auditor) |
| FR-004 | MCP `action: "add"` — creates manual link; validates `link_type` and `link_target` |
| FR-005 | MCP `action: "delete"` — removes link by `link_id` |
| FR-006 | `GET /api/systems/{id}/controls/{controlId}/validation` — returns links (RBAC: Compliance.Reader) |
| FR-007 | `POST /api/systems/{id}/controls/{controlId}/validation` — adds manual link; returns 201 (RBAC: Compliance.Auditor) |
| FR-008 | `DELETE /api/systems/{id}/controls/{controlId}/validation/{linkId}` — removes link; returns 204 (RBAC: Compliance.Auditor) |
| FR-009 | IaC scan hook: after scan, auto-upsert `ScanFinding` links for each matched control; idempotent |
| FR-010 | Dashboard "Validation Evidence" panel with link list, type badge, Auto/Manual badge, add modal, delete action |
| FR-011 | Empty-state message when 0 links |
| FR-012 | `AzureResource` type → Dashboard constructs `https://portal.azure.com/#resource/{linkTarget}` |
| FR-013 | Non-blocking warning when Satisfied determination recorded with 0 links |
| FR-014 | Tenant isolation: `[TenantScoped]` entity; all queries filtered by `TenantId` |
| FR-015 | `Compliance.Reader` role: view only; `Compliance.Auditor` role: add and delete |

---

## Technical Design Notes

- **Entity placement:** `ControlValidationLink` added to `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` alongside `ControlImplementation`. Navigation property `ICollection<ControlValidationLink> ValidationLinks` added to `ControlImplementation`.
- **Upsert strategy:** `UpsertScanLinkAsync` uses EF Core's `ExecuteUpdateAsync` or `AddOrUpdate` pattern on the unique constraint `(ControlImplementationId, LinkTarget)`. No duplicate links per scan run.
- **IaC scan injection:** `IControlValidationLinkService` injected as optional (null-safe) into `IacComplianceScanTool` to avoid breaking standalone scan scenarios where the service is not registered.
- **Azure Portal URL:** Constructed entirely client-side in `buildAzurePortalUrl(resourceId)` utility (`azurePortalUrl.ts`). Format: `https://portal.azure.com/#resource/${resourceId}`. Backend never stores or constructs portal URLs.
- **MCP tool pattern:** Single tool with `action: get | add | delete` parameter — consistent with existing compound tool patterns in this codebase. Avoids tool registry clutter.
- **Warning on 0 links:** Advisory only — determination is always recorded. The `warnings` array follows the existing pattern used in other tools.

---

## Architecture Decisions

| Decision | Rationale |
|---|---|
| Separate `ControlValidationLink` table (not JSON column on `ControlImplementation`) | Queryable; FK constraints; tenant filter applies normally; individual link deletion without deserializing blobs |
| Upsert on `(ControlImplementationId, LinkTarget)` | IaC scans run repeatedly; idempotent upsert prevents duplicate rows per scan cycle |
| `LinkType` enum over free-text | Enables type-specific UI rendering (Azure Portal URL construction for `AzureResource`) without additional logic in the frontend |
| Optional service injection in `IacComplianceScanTool` | Keeps scan tool usable in standalone contexts; link creation is an enhancement, not a hard dependency |
| Advisory warning (not block) on 0 links | SCA retains authority to override; blocking would be paternalistic and could delay ATOs for controls with external evidence |
| Client-side Azure Portal URL construction | Stable public format; avoids server-side logging of resource IDs in URL-building code |

---

## Acceptance Criteria (Gherkin)

```gherkin
Feature: SCA Control Validation Link

  Scenario: SCA views validation links on control detail
    Given a registered system with control "AC-2" having 2 validation links
    When the SCA opens the control detail page
    Then the "Validation Evidence" panel is visible
    And 2 links are listed with type badges and Auto/Manual badges

  Scenario: IaC scan auto-creates links
    Given a Bicep file with a storage account mapped to "SC-28"
    When the SCA runs compliance_get_control_validation with system_id and control_id "SC-28"
    And iac_compliance_scan is executed against that file
    Then compliance_get_control_validation for "SC-28" returns at least 1 link with is_automated: true

  Scenario: SCA adds a manual AzureResource link
    Given a control "AC-2" with 0 validation links
    When the SCA submits action: "add" with link_type "AzureResource" and a valid resource ID
    Then the tool returns status "success" with the created link
    And the Dashboard panel shows the new link with "Manual" badge
    And clicking the link opens https://portal.azure.com/#resource/<resourceId>

  Scenario: Advisory warning when marking Satisfied with 0 links
    Given control "AU-9" has 0 validation links
    When the SCA calls compliance_assess_control with determination "Satisfied"
    Then the response status is "success" (determination recorded)
    And the response includes a non-empty "warnings" array mentioning validation links

  Scenario: Reader role cannot add or delete links
    Given an authenticated user with Compliance.Reader role
    When they call POST /api/systems/{id}/controls/{controlId}/validation
    Then the response is 403 Forbidden
    And the Dashboard Add/Delete buttons are not rendered
```

---

## Non-Functional Requirements

- Validation link list loads within 500 ms for up to 100 links per control
- IaC scan response time not materially impacted by link upsert (< 200 ms overhead acceptable)
- Azure Portal deep-links constructed client-side only; backend never constructs portal URLs
- Tenant isolation mandatory — no cross-tenant link visibility
- `403 Forbidden` for insufficient role; `404 Not Found` for missing system/control

---

## Test Plan

**Backend unit tests:**
- `ControlValidationLinkService.GetLinksAsync` — correct records by `(systemId, controlId, tenantId)`
- `UpsertScanLinkAsync` — idempotent on duplicate `(ControlImplementationId, LinkTarget)`
- `GetControlValidationTool` — all three `action` branches; NOT_FOUND, empty-list, DUPLICATE_LINK cases
- `AssessControlTool` — Satisfied with 0 links produces `warnings` array
- IaC scan hook — findings with control mapping call `UpsertScanLinkAsync`

**Frontend unit tests:**
- `ValidationEvidencePanel` renders links correctly; Auto/Manual badges; empty-state
- `AddValidationLinkModal` submits correct payload; `AzureResource` helper text visible
- `buildAzurePortalUrl` constructs correct URL for various ARM resource ID formats
- Role gating: Add/Delete hidden for Reader role

**Integration tests:**
- `GET /api/systems/{id}/controls/AC-2/validation` MSW-mocked → panel renders 2 links
- `POST` / `DELETE` endpoints wired to service

---

## Definition of Done

- [ ] `ControlValidationLink` entity + `ControlValidationLinkType` enum in `SspModels.cs`
- [ ] Navigation property `ValidationLinks` added to `ControlImplementation`
- [ ] EF Core migration `Add_ControlValidationLinks` applied and reviewed
- [ ] `IControlValidationLinkService` interface and `ControlValidationLinkService` implementation
- [ ] `GetControlValidationTool` (MCP) implemented and registered in DI
- [ ] `GET`, `POST`, `DELETE` Dashboard endpoints implemented and registered
- [ ] IaC scan hook: auto-upsert links for control-mapped findings
- [ ] Dashboard `ValidationEvidencePanel` + `AddValidationLinkModal` components
- [ ] `buildAzurePortalUrl` utility implemented and unit-tested
- [ ] `AssessControlTool` 0-links advisory warning
- [ ] Role gates verified (UI + API)
- [ ] All unit and integration tests passing
- [ ] `dotnet build Ato.Copilot.sln` clean
- [ ] `npm run build` clean
- [ ] All checklist items in `specs/069-sca-control-validation/checklists/requirements.md` checked

---

## Explicit Constraints

**DO NOT:**
- Embed validation links as a JSON column in `ControlImplementation` — breaks queryability and tenant filtering
- Block the SCA from recording a determination when 0 links exist — warning only, never a hard block
- Construct Azure Portal URLs server-side — do this client-side in `buildAzurePortalUrl` only
- Create separate MCP tools for add and delete — use the `action` parameter pattern
- Store full Azure Portal URLs in `LinkTarget` — store the ARM resource ID/path; URL construction is at render time

---

## Anti-Patterns

- **JSON blob for links:** Tempting for simplicity, but breaks FK integrity, tenant filtering, and per-link delete
- **Blocking determination on 0 links:** Paternalistic; SCA may have evidence that is external to the system
- **IaC scan as hard dependency on link service:** If link service is unavailable, scan must still succeed — use optional injection
- **Claiming IaC auto-links are "verified":** `ValidatedAt` is null until SCA explicitly confirms; `isAutomated` badge communicates provenance, not verification status

---

## Existing File References

| File | Lines | Role |
|---|---|---|
| `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` | 15–103 | `ControlImplementation` entity — FK source for new `ControlValidationLink` |
| `src/Ato.Copilot.Core/Models/Compliance/AssessmentModels.cs` | 16–74 | `ControlEffectiveness` entity — carries `EvidenceIds`; complementary to new links |
| `src/Ato.Copilot.Agents/Compliance/Tools/AssessmentArtifactTools.cs` | 23–131 | `AssessControlTool` (T098) — extend to warn on 0 links when Satisfied |
| `src/Ato.Copilot.Agents/Compliance/Tools/IacComplianceScanTool.cs` | 14–80 | `IacComplianceScanTool` — inject link service; upsert links on scan completion |
