### PR TITLE
feat(#59): Feature 071 — eMASS Workflow Sync & OSCAL 1.1.2 Upgrade

### DIFF
--- a/specs/071-emass-workflow-sync/checklists/requirements.md
+++ b/specs/071-emass-workflow-sync/checklists/requirements.md
@@ -1,0 +1,192 @@
+# Requirements Checklist: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Issue**: #59
+
+Use this checklist during implementation, review, and acceptance testing. Mark each item `[x]` when verified.
+
+---
+
+## Functional Requirements
+
+### OSCAL 1.1.2 Upgrade (US1 — P0)
+
+- [ ] **FR-001-a** `BuildOscalPoam()` emits `"oscal-version": "1.1.2"` in metadata
+- [ ] **FR-001-b** `BuildOscalPoam()` uses `related-findings` (not `related-observations`) in `poam-items`
+- [ ] **FR-001-c** `BuildOscalPoam()` includes `import-ssp` reference at root level
+- [ ] **FR-002-a** `BuildOscalAssessmentResults()` emits `"oscal-version": "1.1.2"` in metadata
+- [ ] **FR-002-b** `BuildOscalAssessmentResults()` includes `reviewed-controls.control-selections` array
+- [ ] **FR-002-c** `BuildOscalAssessmentResults()` uses `target.status.state` object format (not string)
+- [ ] **FR-002-d** `BuildOscalAssessmentResults()` includes `import-ap` reference at root level
+- [ ] **FR-003** Both upgraded builders pass OSCAL 1.1.2 schema validation via `OscalSchemaValidationService`
+- [ ] All Feature 041 tests pass after upgrade (regression guard)
+
+### System Identifier Completeness (US5)
+
+- [ ] **FR-007-a** eMASS Excel exports include `DitprId` in the correct eMASS Excel column
+- [ ] **FR-007-b** eMASS Excel exports include `EmassId` in the correct eMASS Excel column
+- [ ] **FR-007-c** OSCAL POA&M export includes `metadata.system-id` with DitprId entry
+- [ ] **FR-007-d** OSCAL POA&M export includes `metadata.system-id` with EmassId entry
+- [ ] **FR-007-e** OSCAL Assessment Results export includes `metadata.system-id` with both identifiers
+
+### Export Readiness Check (US2)
+
+- [ ] **FR-004-a** Readiness check validates `DitprId` presence (Blocking)
+- [ ] **FR-004-b** Readiness check validates `EmassId` presence (Blocking)
+- [ ] **FR-004-c** Readiness check validates CIA categorization populated (Blocking)
+- [ ] **FR-004-d** Readiness check validates at least one Approved SSP section (Advisory)
+- [ ] **FR-004-e** Readiness check validates all POA&M items have scheduled completion dates (Advisory)
+- [ ] **FR-005** Response classifies each gap as `Blocking` or `Advisory`
+- [ ] **FR-006** `DitprId` and `EmassId` gaps are always `Blocking` (never Advisory)
+
+### Round-Trip Sync (US3)
+
+- [ ] **FR-008** `EmassRoundTripSyncService` uses `EmassImportParser` for parsing (no parser modifications)
+- [ ] **FR-009-a** Each changed field produces exactly one `EmassConflict` record
+- [ ] **FR-009-b** Conflict records include `FieldName`, `SpinValue`, `EmassValue`, `ConflictStatus = Unresolved`
+- [ ] **FR-009-c** Conflict records include `DetectedAt` timestamp and `SyncBatchId`
+- [ ] **FR-010** SPIN entity tables are NOT modified during a sync run
+- [ ] **FR-011-a** Resolving with `AcceptEmass` updates SPIN data with `EmassValue`
+- [ ] **FR-011-b** Resolving with `KeepSpin` does NOT modify SPIN data
+- [ ] **FR-011-c** Resolving with `Deferred` does NOT modify SPIN data
+- [ ] **FR-012** Second sync with unresolved prior conflicts returns 409 (or warning requiring acknowledgment)
+- [ ] **FR-013** Identical fields (after normalization) produce zero conflict records
+
+### Workflow Status (US4)
+
+- [ ] **FR-014-a** Status response includes `LastExportedAt` (nullable)
+- [ ] **FR-014-b** Status response includes `LastSyncedAt` (nullable)
+- [ ] **FR-014-c** Status response includes `UnresolvedConflictCount`
+- [ ] **FR-014-d** Status response includes `ExportSummary` with per-category counts
+- [ ] **FR-014-e** Status response includes `ReadinessStatus` summary (IsReady + gap counts)
+- [ ] **FR-015** Status endpoint accessible to ISSO, ISSM, AO roles
+- [ ] **FR-016-a** System never exported → `LastExportedAt = null`
+- [ ] **FR-016-b** System never exported → `OverallStatus = NeverExported`
+
+### MCP Tools
+
+- [ ] **FR-017-a** `emass_get_workflow_status` accepts `system_id` parameter
+- [ ] **FR-017-b** `emass_get_workflow_status` returns markdown-formatted status table
+- [ ] **FR-017-c** `emass_get_workflow_status` works from dashboard chat, Teams, and VS Code
+- [ ] **FR-018-a** `emass_check_export_readiness` accepts `system_id` parameter
+- [ ] **FR-018-b** `emass_check_export_readiness` returns formatted readiness card with gaps
+- [ ] **FR-018-c** `emass_check_export_readiness` highlights Blocking gaps in bold
+
+### Access Control
+
+- [ ] **FR-019-a** Status endpoint: ISSO ✓, ISSM ✓, AO ✓, other roles → 403
+- [ ] **FR-019-b** Readiness endpoint: ISSO ✓, ISSM ✓, AO ✓, other roles → 403
+- [ ] **FR-019-c** Sync upload: ISSO ✓, ISSM ✓, AO → 403, other roles → 403
+- [ ] **FR-019-d** Conflict list: ISSO ✓, ISSM ✓, AO ✓, other roles → 403
+- [ ] **FR-020** Conflict resolution (AcceptEmass/KeepSpin): ISSO ✓, ISSM ✓, AO → 403
+
+---
+
+## Non-Functional Requirements
+
+- [ ] **NFR-001** Sync diff for 400 controls + 150 POA&M items completes < 30 seconds
+- [ ] **NFR-002** Status endpoint responds < 500 ms
+- [ ] **NFR-003** All new endpoints use `{ data, meta, errors }` response envelope
+- [ ] **NFR-004** Resolved conflict records retained for 90 days
+- [ ] **NFR-005** Feature 041 test suite passes without regressions
+
+---
+
+## Gherkin Acceptance Scenarios
+
+### Scenario 1: OSCAL version in POA&M export
+
+```gherkin
+Given a system with active POA&M items
+When I export the OSCAL POA&M via the MCP tool or API
+Then the JSON contains "oscal-version": "1.1.2" in metadata
+And the poam-items array uses "related-findings" not "related-observations"
+And the output passes OSCAL 1.1.2 schema validation
+```
+
+### Scenario 2: Blocking readiness gap for missing DitprId
+
+```gherkin
+Given a system with DitprId not set
+When the ISSO calls emass_check_export_readiness
+Then IsReady is false
+And the gaps array contains an entry for DitprId with severity Blocking
+And the entry includes a fixUrl pointing to the system settings page
+```
+
+### Scenario 3: Round-trip sync creates conflicts without modifying SPIN
+
+```gherkin
+Given a system with SystemName "Alpha" in SPIN
+And an eMASS Excel file where SystemName is "Alpha Production"
+When the ISSO uploads the Excel to POST /api/systems/{id}/emass/sync
+Then an EmassConflict record is created with FieldName="SystemInfo.SystemName"
+  SpinValue="Alpha", EmassValue="Alpha Production", ConflictStatus="Unresolved"
+And the RegisteredSystem.SystemName in the database remains "Alpha"
+```
+
+### Scenario 4: Resolving a conflict with AcceptEmass updates SPIN
+
+```gherkin
+Given an unresolved EmassConflict for SystemInfo.SystemName
+  with SpinValue="Alpha" and EmassValue="Alpha Production"
+When the ISSO calls PUT /api/systems/{id}/emass/conflicts/{conflictId}
+  with resolution="AcceptEmass"
+Then ConflictStatus is updated to "AcceptEmass"
+And RegisteredSystem.SystemName is updated to "Alpha Production"
+And ResolvedAt and ResolvedBy are populated
+```
+
+### Scenario 5: KeepSpin resolution leaves SPIN unchanged
+
+```gherkin
+Given the same unresolved conflict as Scenario 4
+When the ISSO calls PUT with resolution="KeepSpin"
+Then ConflictStatus is updated to "KeepSpin"
+And RegisteredSystem.SystemName remains "Alpha"
+```
+
+### Scenario 6: Workflow status for a never-exported system
+
+```gherkin
+Given a system that has never had an eMASS export
+When GET /api/systems/{id}/emass/status is called
+Then OverallStatus is "NeverExported"
+And LastExportedAt is null
+And UnresolvedConflictCount is 0
+```
+
+### Scenario 7: MCP tool returns formatted status table
+
+```gherkin
+Given a system with export history and 2 unresolved conflicts
+When the user asks "What is my eMASS status?" in the dashboard chat
+Then the agent calls emass_get_workflow_status
+And the response includes a markdown table with Controls, PoamItems, Artifacts rows
+And shows "Unresolved Conflicts: 2 ⚠️"
+```
+
+---
+
+## Definition of Done
+
+- [ ] All `tasks.md` tasks completed and marked `[x]`
+- [ ] All Functional Requirements above checked `[x]`
+- [ ] All NFRs verified (performance tests run)
+- [ ] All 7 Gherkin scenarios pass (unit or integration tests)
+- [ ] `dotnet test` passes with no regressions (Feature 041 + Feature 071)
+- [ ] PR reviewed and approved
+- [ ] Issue #59 linked; all acceptance criteria in issue verified
+- [ ] `docs/guides/emass-workflow.md` created and renders in MkDocs
+- [ ] Agent tool catalog updated with 2 new tool entries
+
+---
+
+## DO NOT / Anti-Patterns
+
+- **DO NOT** modify `EmassImportParser.cs` for Feature 071 — create adapters
+- **DO NOT** modify `EmassImportService.cs` (onboarding path) — round-trip sync is a separate service
+- **DO NOT** auto-merge SPIN data during sync — all merges are explicit ISSO choices
+- **DO NOT** break Feature 041 package generation — OSCAL upgrade must be backward-compatible for package pipeline
+- **DO NOT** store binary Excel content in `EmassConflict` records — store field values as strings only
+- **DO NOT** create a `EmassExportLog` table in this feature — derive last-exported timestamps from `AuthorizationPackage` records (future increment if needed)
+- **DO NOT** expose the conflict resolution endpoint to AO role — AO is read-only

--- a/specs/071-emass-workflow-sync/contracts/http-api.md
+++ b/specs/071-emass-workflow-sync/contracts/http-api.md
@@ -1,0 +1,305 @@
+# HTTP API Contracts: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Date**: 2026-06-11  
+**Base path**: `/api/systems/{systemId}/emass`  
+**Auth**: Bearer JWT — roles enforced per endpoint  
+**Envelope**: All responses follow `{ "data": {...}, "meta": {...}, "errors": [...] }`
+
+---
+
+## GET /api/systems/{systemId}/emass/status
+
+Returns the ISSO's complete eMASS workflow status for a system.
+
+**RBAC**: ISSO, ISSM, AO  
+**Performance**: Must respond < 500 ms (NFR-002)
+
+### Request
+
+```http
+GET /api/systems/abc123/emass/status
+Authorization: Bearer <token>
+```
+
+### Response 200
+
+```json
+{
+  "data": {
+    "systemId": "abc123",
+    "overallStatus": "HasConflicts",
+    "lastExportedAt": "2026-05-15T14:30:00Z",
+    "lastSyncedAt": "2026-06-01T09:00:00Z",
+    "unresolvedConflictCount": 3,
+    "exportSummary": [
+      {
+        "category": "Controls",
+        "exportedCount": 325,
+        "pendingCount": 12,
+        "lastExportedAt": "2026-05-15T14:30:00Z"
+      },
+      {
+        "category": "PoamItems",
+        "exportedCount": 48,
+        "pendingCount": 5,
+        "lastExportedAt": "2026-05-15T14:30:00Z"
+      },
+      {
+        "category": "Artifacts",
+        "exportedCount": 6,
+        "pendingCount": 0,
+        "lastExportedAt": "2026-05-15T14:30:00Z"
+      }
+    ],
+    "readinessStatus": {
+      "isReady": false,
+      "blockingGapCount": 1,
+      "advisoryGapCount": 2
+    }
+  },
+  "meta": { "checkedAt": "2026-06-11T10:00:00Z" },
+  "errors": []
+}
+```
+
+### Response 404
+
+```json
+{
+  "data": null,
+  "meta": {},
+  "errors": [{ "code": "SYSTEM_NOT_FOUND", "message": "System abc123 not found." }]
+}
+```
+
+---
+
+## GET /api/systems/{systemId}/emass/readiness
+
+Returns the export readiness check result with all gaps identified.
+
+**RBAC**: ISSO, ISSM, AO
+
+### Response 200 — Not Ready
+
+```json
+{
+  "data": {
+    "systemId": "abc123",
+    "isReady": false,
+    "checkedAt": "2026-06-11T10:00:00Z",
+    "gaps": [
+      {
+        "fieldName": "DitprId",
+        "description": "DITPR System ID is required by eMASS to match the import to the correct system record.",
+        "severity": "Blocking",
+        "fixUrl": "/systems/abc123/settings#identifiers"
+      },
+      {
+        "fieldName": "Ssp.ApprovedSections",
+        "description": "At least one SSP section must be in Approved status before export.",
+        "severity": "Advisory",
+        "fixUrl": "/systems/abc123/ssp"
+      }
+    ]
+  },
+  "meta": {},
+  "errors": []
+}
+```
+
+### Response 200 — Ready
+
+```json
+{
+  "data": {
+    "systemId": "abc123",
+    "isReady": true,
+    "checkedAt": "2026-06-11T10:00:00Z",
+    "gaps": []
+  },
+  "meta": {},
+  "errors": []
+}
+```
+
+---
+
+## POST /api/systems/{systemId}/emass/sync
+
+Uploads an eMASS Excel export file, diffs it against SPIN state, and creates `EmassConflict` records for every changed field. **Does not modify SPIN data.**
+
+**RBAC**: ISSO, ISSM  
+**Content-Type**: `multipart/form-data`  
+**Max file size**: 50 MB
+
+### Request
+
+```http
+POST /api/systems/abc123/emass/sync
+Authorization: Bearer <token>
+Content-Type: multipart/form-data
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="emass-export.xlsx"
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+
+[binary Excel data]
+--boundary--
+```
+
+### Response 200 — Sync completed
+
+```json
+{
+  "data": {
+    "batchId": "b1234567-...",
+    "systemId": "abc123",
+    "conflictsCreated": 7,
+    "identicalFields": 518,
+    "skippedUnresolved": 0,
+    "syncedAt": "2026-06-11T10:05:00Z"
+  },
+  "meta": {},
+  "errors": []
+}
+```
+
+### Response 409 — Unresolved conflicts from prior batch
+
+```json
+{
+  "data": {
+    "priorBatchId": "a9876543-...",
+    "unresolvedConflictCount": 3
+  },
+  "meta": {},
+  "errors": [
+    {
+      "code": "UNRESOLVED_CONFLICTS",
+      "message": "3 conflicts from the prior sync batch are unresolved. Resolve or acknowledge them before running a new sync.",
+      "hint": "Pass 'acknowledgeUnresolved=true' query parameter to proceed anyway."
+    }
+  ]
+}
+```
+
+**Override**: `POST /api/systems/{id}/emass/sync?acknowledgeUnresolved=true` — proceeds despite unresolved conflicts.
+
+### Response 400 — Wrong system in file
+
+```json
+{
+  "data": null,
+  "meta": {},
+  "errors": [
+    {
+      "code": "SYSTEM_ID_MISMATCH",
+      "message": "The eMASS ID in the uploaded file (98765) does not match this system's EmassId (12345)."
+    }
+  ]
+}
+```
+
+---
+
+## GET /api/systems/{systemId}/emass/conflicts
+
+Returns paginated list of sync conflicts, optionally filtered by status.
+
+**RBAC**: ISSO, ISSM, AO
+
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `status` | string | `Unresolved` | Filter: `Unresolved`, `KeepSpin`, `AcceptEmass`, `Deferred`, `All` |
+| `batchId` | string | (all batches) | Filter by sync batch |
+| `limit` | int | 50 | Max records to return |
+| `offset` | int | 0 | Pagination offset |
+
+### Response 200
+
+```json
+{
+  "data": [
+    {
+      "id": "c1111111-...",
+      "entityType": "SystemInfo",
+      "entityId": null,
+      "fieldName": "SystemInfo.SystemName",
+      "spinValue": "My System (SPIN)",
+      "emassValue": "My System - Production",
+      "conflictStatus": "Unresolved",
+      "detectedAt": "2026-06-11T10:05:00Z",
+      "resolvedAt": null,
+      "resolvedBy": null
+    }
+  ],
+  "meta": {
+    "total": 7,
+    "limit": 50,
+    "offset": 0
+  },
+  "errors": []
+}
+```
+
+---
+
+## PUT /api/systems/{systemId}/emass/conflicts/{conflictId}
+
+Resolves a single conflict. If `AcceptEmass` is chosen, SPIN data is updated with the eMASS value.
+
+**RBAC**: ISSO, ISSM (not AO)
+
+### Request Body
+
+```json
+{
+  "resolution": "AcceptEmass",
+  "notes": "Confirmed with system owner — eMASS name is correct."
+}
+```
+
+**resolution values**: `KeepSpin` | `AcceptEmass` | `Deferred`
+
+### Response 200
+
+```json
+{
+  "data": {
+    "id": "c1111111-...",
+    "conflictStatus": "AcceptEmass",
+    "resolvedAt": "2026-06-11T10:15:00Z",
+    "resolvedBy": "isso@example.com",
+    "spinValueAfter": "My System - Production"
+  },
+  "meta": {},
+  "errors": []
+}
+```
+
+### Response 403
+
+```json
+{
+  "data": null,
+  "meta": {},
+  "errors": [{ "code": "FORBIDDEN", "message": "AO role cannot resolve conflicts. ISSO or ISSM role required." }]
+}
+```
+
+---
+
+## Error Codes
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `SYSTEM_NOT_FOUND` | 404 | System ID does not exist or user lacks access |
+| `CONFLICT_NOT_FOUND` | 404 | Conflict ID does not exist for this system |
+| `UNRESOLVED_CONFLICTS` | 409 | Prior sync batch has unresolved conflicts |
+| `SYSTEM_ID_MISMATCH` | 400 | eMASS ID in file does not match system record |
+| `INVALID_EXCEL_FORMAT` | 400 | File is not a valid eMASS Excel export |
+| `FORBIDDEN` | 403 | Caller role insufficient for this operation |
+| `CONFLICT_ALREADY_RESOLVED` | 409 | Conflict is already in a terminal state (KeepSpin/AcceptEmass) |

--- a/specs/071-emass-workflow-sync/contracts/mcp-tools.md
+++ b/specs/071-emass-workflow-sync/contracts/mcp-tools.md
@@ -1,0 +1,181 @@
+# MCP Tool Contracts: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Date**: 2026-06-11  
+**Pattern**: All tools follow the existing `BaseTool` envelope with `{ result, isError }` wrapping  
+**RBAC**: Enforced at tool level; tool returns `isError: true` with code `FORBIDDEN` if role insufficient  
+**File**: `src/Ato.Copilot.Agents/Compliance/Tools/EmassWorkflowTools.cs`
+
+---
+
+## emass_get_workflow_status
+
+Returns the ISSO's eMASS export workflow status for a system as a formatted markdown response.
+
+### Metadata
+
+| Field | Value |
+|-------|-------|
+| Tool name | `emass_get_workflow_status` |
+| Source file | `EmassWorkflowTools.cs` |
+| Roles | ISSO, ISSM, AO |
+| Calls | `IEmassWorkflowStatusService.GetStatusAsync` |
+| Surface | Dashboard Chat, Teams, VS Code |
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `system_id` | `string` | ✓ | The GUID or slug of the registered system |
+
+### Example Invocation (natural language → tool call)
+
+```
+User: "What is my eMASS export status for System X?"
+→ Tool: emass_get_workflow_status({ "system_id": "abc123" })
+```
+
+### Success Response
+
+```json
+{
+  "result": "## eMASS Workflow Status — My System\n\n| Category | Exported | Pending |\n|----------|----------|---------|\n| Controls | 325 | 12 |\n| POA&M Items | 48 | 5 |\n| Artifacts | 6 | 0 |\n\n**Last Exported**: May 15, 2026  \n**Last Synced**: June 1, 2026  \n**Unresolved Conflicts**: 3 ⚠️  \n**Readiness**: ❌ Not Ready (1 blocking gap)\n\n> 3 sync conflicts are awaiting your review. Navigate to the [eMASS Status page](/systems/abc123/emass/status) to resolve them.",
+  "isError": false
+}
+```
+
+### Error Response — System Not Found
+
+```json
+{
+  "result": "System 'abc123' was not found or you do not have access to it.",
+  "isError": true
+}
+```
+
+### Formatting Rules
+
+- Status table: markdown table with Category / Exported / Pending columns
+- `HasConflicts`: show ⚠️ and conflict count with link to status page
+- `NeverExported`: show "Never exported" with a call-to-action to run readiness check
+- `UpToDate`: show ✅ confirmation
+- `PendingExport`: show pending counts and suggest running an export
+
+---
+
+## emass_check_export_readiness
+
+Checks whether a system has all required fields populated for a successful eMASS export/import. Returns a formatted readiness card.
+
+### Metadata
+
+| Field | Value |
+|-------|-------|
+| Tool name | `emass_check_export_readiness` |
+| Source file | `EmassWorkflowTools.cs` |
+| Roles | ISSO, ISSM, AO |
+| Calls | `IEmassExportReadinessService.CheckReadinessAsync` |
+| Surface | Dashboard Chat, Teams, VS Code |
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `system_id` | `string` | ✓ | The GUID or slug of the registered system |
+
+### Example Invocations
+
+```
+User: "Is System X ready for eMASS export?"
+→ Tool: emass_check_export_readiness({ "system_id": "abc123" })
+
+User: "Check eMASS readiness for my system"
+→ Tool: emass_check_export_readiness({ "system_id": "<system from context>" })
+```
+
+### Success Response — Not Ready
+
+```json
+{
+  "result": "## eMASS Export Readiness — My System\n\n❌ **Not Ready** — 1 blocking gap must be resolved before export.\n\n### Blocking Gaps\n\n| Field | Issue | Fix |\n|-------|-------|-----|\n| **DitprId** | DITPR System ID is required for eMASS import matching. | [Set DitprId](/systems/abc123/settings#identifiers) |\n\n### Advisory Gaps (export may proceed with acknowledgment)\n\n| Field | Issue |\n|-------|-------|\n| Ssp.ApprovedSections | At least one SSP section should be Approved before export. |\n| PoamItems.ScheduledDates | 3 POA&M items are missing scheduled completion dates. |",
+  "isError": false
+}
+```
+
+### Success Response — Ready
+
+```json
+{
+  "result": "## eMASS Export Readiness — My System\n\n✅ **Ready for eMASS export.** All required fields are populated.\n\nYou can now generate an authorization package or use the eMASS export tools.",
+  "isError": false
+}
+```
+
+### Formatting Rules
+
+- Blocking gaps: shown in bold in the table, section header is `### Blocking Gaps`
+- Advisory gaps: separate section `### Advisory Gaps (export may proceed with acknowledgment)`
+- If zero gaps of either type, omit that section
+- Include fix URLs as markdown links when available
+- Suggest next step: "Run `emass_get_workflow_status` to check your overall export state."
+
+---
+
+## Existing Tools — No Changes Required
+
+The following existing tools in `EmassExportTools.cs` are **not modified** by Feature 071:
+
+| Tool | Status | Notes |
+|------|--------|-------|
+| `emass_export_controls` | Unchanged | Excel export; Feature 071 adds DitprId/EmassId to output (T009) |
+| `emass_export_poam` | Unchanged | Excel POA&M export |
+| `emass_export_oscal_poam` | **OSCAL version upgraded** (T001) | Now emits 1.1.2 — same tool name, same parameters |
+| `emass_export_oscal_ar` | **OSCAL version upgraded** (T002) | Now emits 1.1.2 — same tool name, same parameters |
+
+The OSCAL version upgrade (Phase 1) is transparent to tool callers — same parameters, same tool names, upgraded output format.
+
+---
+
+## Tool Registration
+
+Add both new tools to the MCP tool registry. Pattern from `EmassExportTools.cs`:
+
+```csharp
+public class EmassWorkflowTools : BaseTool
+{
+    [McpTool("emass_get_workflow_status")]
+    [McpDescription("Returns the ISSO's eMASS export workflow status including export counts, sync conflicts, and readiness summary.")]
+    [McpRole(Roles.Isso, Roles.Issm, Roles.Ao)]
+    public async Task<ToolResult> GetWorkflowStatusAsync(
+        [McpParameter("system_id", "The system GUID or slug.")] string systemId,
+        CancellationToken ct = default)
+    { ... }
+
+    [McpTool("emass_check_export_readiness")]
+    [McpDescription("Checks whether a system has all required fields for a successful eMASS export. Returns blocking gaps and advisory gaps.")]
+    [McpRole(Roles.Isso, Roles.Issm, Roles.Ao)]
+    public async Task<ToolResult> CheckExportReadinessAsync(
+        [McpParameter("system_id", "The system GUID or slug.")] string systemId,
+        CancellationToken ct = default)
+    { ... }
+}
+```
+
+---
+
+## Agent Tool Catalog Update
+
+After implementing, add entries to `docs/architecture/agent-tool-catalog.md`:
+
+```markdown
+### emass_get_workflow_status
+- **Description**: Returns eMASS export workflow status for a system.
+- **Parameters**: `system_id` (string, required)
+- **Roles**: ISSO, ISSM, AO
+- **Example**: "What is my eMASS status for System X?"
+
+### emass_check_export_readiness
+- **Description**: Validates all required eMASS fields before export.
+- **Parameters**: `system_id` (string, required)
+- **Roles**: ISSO, ISSM, AO
+- **Example**: "Is System X ready for eMASS export?"
+```

--- a/specs/071-emass-workflow-sync/data-model.md
+++ b/specs/071-emass-workflow-sync/data-model.md
@@ -1,0 +1,183 @@
+# Data Model: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Date**: 2026-06-11
+
+## Entity Relationship Overview
+
+```
+RegisteredSystem (existing)
+ ├── EmassConflict[] (NEW) ──► linked per sync batch
+ ├── AuthorizationPackage[] (existing, Feature 041)
+ ├── PoamItem[] (existing)
+ ├── ControlImplementation[] (existing)
+ └── SspSection[] (existing)
+```
+
+**No new tables inherit from `AuthorizationPackage`.** `EmassConflict` is a flat, side-table entity — it references the system and optionally an entity type/ID, but does not subtype or extend package records.
+
+---
+
+## New Entities
+
+### EmassConflict
+
+Represents a single field-level difference detected between a SPIN value and a newer eMASS Excel import. Created during a round-trip sync run; updated only when the ISSO explicitly resolves it.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `Id` | `string` (GUID) | PK, MaxLength(36) | Unique conflict ID |
+| `RegisteredSystemId` | `string` | FK, Required, MaxLength(36) | System this conflict belongs to |
+| `SyncBatchId` | `string` (GUID) | Required, MaxLength(36) | Groups all conflicts from one sync run |
+| `EntityType` | `string` | Required, MaxLength(50) | Entity containing the conflicting field (e.g., `SystemInfo`, `PoamItem`, `ControlBaseline`) |
+| `EntityId` | `string?` | MaxLength(36) | ID of the specific entity instance (null for system-level fields) |
+| `FieldName` | `string` | Required, MaxLength(200) | Fully-qualified field name (e.g., `SystemInfo.SystemName`, `PoamItem.ScheduledCompletionDate`) |
+| `SpinValue` | `string?` | MaxLength(4000) | Current value in SPIN (serialized as string) |
+| `EmassValue` | `string?` | MaxLength(4000) | Value from the eMASS Excel import |
+| `ConflictStatus` | `ConflictStatus` enum | Required | Lifecycle: `Unresolved`, `KeepSpin`, `AcceptEmass`, `Deferred` |
+| `DetectedAt` | `DateTimeOffset` | Required | Timestamp of sync run |
+| `ResolvedAt` | `DateTimeOffset?` | | Timestamp when ISSO resolved |
+| `ResolvedBy` | `string?` | MaxLength(200) | User who resolved the conflict |
+| `Notes` | `string?` | MaxLength(1000) | Optional ISSO notes on resolution |
+
+**Indexes**:
+- `IX_EmassConflict_SystemId_Status` on `(RegisteredSystemId, ConflictStatus)` — for status page queries
+- `IX_EmassConflict_BatchId` on `SyncBatchId` — for batch operations
+
+**Relationships**:
+- Many-to-one with `RegisteredSystem` (cascade delete)
+- No FK to `PoamItem`/`ControlImplementation` — `EntityId` is a soft reference to keep the model flexible
+
+---
+
+## New Enumerations
+
+### ConflictStatus
+
+```csharp
+public enum ConflictStatus
+{
+    Unresolved = 0,   // Created by sync run; awaiting ISSO decision
+    KeepSpin   = 1,   // ISSO chose to retain SPIN value (eMASS value discarded)
+    AcceptEmass = 2,  // ISSO chose to accept eMASS value (SPIN updated)
+    Deferred   = 3    // ISSO acknowledged but postponed decision
+}
+```
+
+### EmassWorkflowOverallStatus
+
+```csharp
+public enum EmassWorkflowOverallStatus
+{
+    NeverExported  = 0,  // System has never been exported to eMASS
+    UpToDate       = 1,  // All SPIN data exported; no pending changes
+    PendingExport  = 2,  // SPIN data changed since last export; export needed
+    HasConflicts   = 3   // Unresolved sync conflicts exist (takes priority)
+}
+```
+
+### ReadinessGapSeverity
+
+```csharp
+public enum ReadinessGapSeverity
+{
+    Blocking  = 0,   // Export must not proceed until resolved
+    Advisory  = 1    // Export may proceed with ISSO acknowledgment
+}
+```
+
+---
+
+## New DTOs (no DB persistence)
+
+### EmassWorkflowStatus
+
+Returned by `GET /api/systems/{id}/emass/status` and the `emass_get_workflow_status` MCP tool.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SystemId` | `string` | System identifier |
+| `OverallStatus` | `EmassWorkflowOverallStatus` | Rolled-up status (HasConflicts > PendingExport > UpToDate > NeverExported) |
+| `LastExportedAt` | `DateTimeOffset?` | Timestamp of most recent successful eMASS export (any type) |
+| `LastSyncedAt` | `DateTimeOffset?` | Timestamp of most recent round-trip sync run |
+| `UnresolvedConflictCount` | `int` | Count of `ConflictStatus = Unresolved` records |
+| `ExportSummary` | `EmassExportCategorySummary[]` | Per-category breakdown (see below) |
+| `ReadinessStatus` | `EmassReadinessSummary` | Quick summary: `IsReady`, `BlockingGapCount`, `AdvisoryGapCount` |
+
+### EmassExportCategorySummary
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Category` | `string` | `Controls`, `PoamItems`, `Artifacts`, `SystemInfo` |
+| `ExportedCount` | `int` | Items included in last export |
+| `PendingCount` | `int` | Items created/updated since last export |
+| `LastExportedAt` | `DateTimeOffset?` | Category-level last export timestamp |
+
+### EmassExportReadinessResult
+
+Returned by `GET /api/systems/{id}/emass/readiness` and `emass_check_export_readiness` MCP tool.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SystemId` | `string` | System identifier |
+| `IsReady` | `bool` | `true` only when zero Blocking gaps exist |
+| `Gaps` | `ReadinessGap[]` | All detected gaps; may be empty |
+| `CheckedAt` | `DateTimeOffset` | Timestamp of this check |
+
+### ReadinessGap
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `FieldName` | `string` | Human-readable field name (e.g., `"DitprId"`) |
+| `Description` | `string` | Why this gap prevents eMASS acceptance |
+| `Severity` | `ReadinessGapSeverity` | `Blocking` or `Advisory` |
+| `FixUrl` | `string?` | Relative dashboard URL where the ISSO can fix the gap |
+
+### EmassConflictDto
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Id` | `string` | Conflict GUID |
+| `EntityType` | `string` | Entity containing the field |
+| `EntityId` | `string?` | Instance ID (if applicable) |
+| `FieldName` | `string` | Fully-qualified field name |
+| `SpinValue` | `string?` | Current SPIN value |
+| `EmassValue` | `string?` | Value from eMASS import |
+| `ConflictStatus` | `string` | String representation of `ConflictStatus` |
+| `DetectedAt` | `DateTimeOffset` | When detected |
+| `ResolvedAt` | `DateTimeOffset?` | When resolved |
+| `ResolvedBy` | `string?` | Who resolved |
+
+---
+
+## Modified Entities
+
+### RegisteredSystem (existing)
+
+No schema changes. However, `EmassExportService` MUST read `DitprId` and `EmassId` from the existing `RegisteredSystem` record and:
+1. Include them in eMASS Excel export columns
+2. Include them in OSCAL `metadata.system-id` array under the appropriate schemes
+
+These fields already exist on `RegisteredSystem` from the initial eMASS import; Feature 071 enforces their presence via the readiness check.
+
+---
+
+## OSCAL Schema Changes (non-DB)
+
+### POA&M (1.0.6 → 1.1.2)
+
+| OSCAL 1.0.6 Field | OSCAL 1.1.2 Field | Change |
+|-------------------|-------------------|--------|
+| `poam-items[].related-observations` | `poam-items[].related-findings` | Renamed (breaking) |
+| *(absent)* | `import-ssp` | Added at root level |
+| `metadata.oscal-version: "1.0.6"` | `metadata.oscal-version: "1.1.2"` | Version bump |
+
+### Assessment Results (1.0.6 → 1.1.2)
+
+| OSCAL 1.0.6 Field | OSCAL 1.1.2 Field | Change |
+|-------------------|-------------------|--------|
+| *(absent)* | `results[].reviewed-controls.control-selections` | Added |
+| `results[].findings[].target.status` (string) | `results[].findings[].target.status.state` (object) | Structure change |
+| *(absent)* | `import-ap` | Added at root level |
+| `metadata.oscal-version: "1.0.6"` | `metadata.oscal-version: "1.1.2"` | Version bump |
+
+Both upgraded builders MUST pass validation against the OSCAL 1.1.2 schema bundles added in Feature 041 T002.

--- a/specs/071-emass-workflow-sync/plan.md
+++ b/specs/071-emass-workflow-sync/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Issue**: #59 | **Wave**: 9
+
+## Overview
+
+Feature 071 is a targeted extension of Feature 041 (eMASS Authorization Package Export). It fixes a P0 OSCAL version defect and adds round-trip workflow capabilities so SPIN can serve as the ISSO's primary ATO workspace.
+
+**Delivery strategy**: Phase 1 (OSCAL upgrade) ships as a hotfix immediately. Phases 2–9 ship as the full feature.
+
+---
+
+## Milestones
+
+| Milestone | Phases | Description | Target |
+|-----------|--------|-------------|--------|
+| M0 — Hotfix | Phase 1 | OSCAL 1.1.2 upgrade — unblocks eMASS submissions today | Sprint 1, Day 3 |
+| M1 — Foundation | Phase 2 | Entities, DTOs, interfaces, migration | Sprint 1, Day 5 |
+| M2 — Services | Phases 3–5 | Readiness, sync, status services + tests | Sprint 2 |
+| M3 — API + Tools | Phases 6–7 | REST endpoints + MCP tools | Sprint 2 |
+| M4 — Dashboard | Phase 8 | Status page + conflict list UI | Sprint 3 |
+| M5 — Done | Phase 9 | Polish, docs, full regression | Sprint 3 |
+
+---
+
+## Phase Breakdown
+
+### Phase 1 — OSCAL 1.1.2 Upgrade (T001–T003)
+
+**Owner**: Backend developer  
+**Files touched**:
+- `src/Ato.Copilot.Agents/Compliance/Services/EmassExportService.cs` — upgrade both builders
+- `tests/Ato.Copilot.Tests.Unit/Compliance/EmassExportServiceTests.cs` — new + regression tests
+
+**Risk**: Low. Changes are confined to two methods in one file. Feature 041 regression tests serve as guardrails.
+
+**Definition of Done**: Both builders emit `"oscal-version": "1.1.2"`. All Feature 041 tests pass. PR merged to `main` as hotfix.
+
+---
+
+### Phase 2 — Foundation (T004–T007)
+
+**Owner**: Backend developer  
+**Files touched**:
+- `src/Ato.Copilot.Core/Models/Compliance/EmassConflict.cs` (new)
+- `src/Ato.Copilot.Core/Dtos/Dashboard/EmassWorkflowDtos.cs` (new)
+- `src/Ato.Copilot.Core/Interfaces/Compliance/IEmassExportReadinessService.cs` (new)
+- `src/Ato.Copilot.Core/Interfaces/Compliance/IEmassRoundTripSyncService.cs` (new)
+- `src/Ato.Copilot.Core/Interfaces/Compliance/IEmassWorkflowStatusService.cs` (new)
+- `AtoCopilotContext.cs` — new DbSet + config
+- EF Core migration `AddEmassConflict`
+
+**Risk**: Medium. EF migrations must not conflict with Feature 041 migrations. Coordinate migration ordering with Feature 041 team.
+
+---
+
+### Phases 3–5 — Services (T008–T015)
+
+**Parallelizable after Phase 2.**
+
+| Phase | Service | Key Risk |
+|-------|---------|----------|
+| 3 — Readiness | `EmassExportReadinessService` | Must use correct DB column names for `DitprId`/`EmassId` |
+| 4 — Sync | `EmassRoundTripSyncService` | Parser reuse — do not modify `EmassImportParser` directly |
+| 5 — Status | `EmassWorkflowStatusService` | Depends on export history query design from Feature 041 |
+
+**Implementation note for Phase 4**: `EmassRoundTripSyncService` MUST reuse `EmassImportParser` without modifying it. If the parser needs new output fields, create a wrapper or adapter — do not change the parser that the onboarding flow depends on.
+
+---
+
+### Phases 6–7 — API + MCP Tools (T016–T021)
+
+**Parallelizable after Phase 2 (interfaces defined).**
+
+All new endpoints go in a new `EmassWorkflowEndpoints.cs` file to avoid merge conflicts with Feature 041's `PackageEndpoints.cs`.
+
+MCP tools follow the `BaseTool` envelope pattern already established in `EmassExportTools.cs`.
+
+---
+
+### Phase 8 — Dashboard (T022–T025)
+
+**Parallelizable after Phase 6 (API contracts exist).**
+
+The status page is a new route (`/systems/:id/emass/status`) — no changes to existing pages are required. The conflict list is a new component used only by the status page.
+
+---
+
+### Phase 9 — Polish (T026–T030)
+
+- Serilog structured logging for sync runs (batch ID, duration, conflict count)
+- New guide: `docs/guides/emass-workflow.md`
+- Update `docs/getting-started/isso.md`
+- Full `dotnet test` regression including Feature 041
+- Performance test: sync 400 controls + 150 POA&M items must complete < 30 s
+
+---
+
+## Risks & Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| OSCAL 1.1.2 schema diff introduces unexpected breaking changes | Medium | High | Compare OSCAL 1.0.6 vs 1.1.2 changelogs before coding T001/T002; run against bundled schemas |
+| EF migration conflicts with Feature 041 | Medium | Medium | Coordinate migration baseline; apply Feature 041 migrations first |
+| `EmassImportParser` does not expose enough data for field-level diff | Low | Medium | Add a thin adapter class rather than modifying the parser |
+| Round-trip sync performance > 30 s for large systems | Low | Medium | Use batched DB inserts for conflict records; avoid N+1 queries |
+| Dashboard status page adds latency to ISSO workflow | Low | Low | Status endpoint is read-only, responds < 500 ms per NFR-002 |
+
+---
+
+## Testing Strategy
+
+| Phase | Test Type | Coverage Target |
+|-------|-----------|----------------|
+| Phase 1 | Unit | 100% of upgraded OSCAL builder methods |
+| Phase 2 | None — pure model/interface definitions | N/A |
+| Phases 3–5 | Unit | 80% per Constitution Principle III |
+| Phases 6–7 | Integration | Happy path + RBAC rejection for each endpoint |
+| Phase 8 | Manual / E2E | ISSO workflow walkthrough in staging |
+| Phase 9 | Regression | All Feature 041 tests + new Feature 071 tests must pass |
+
+---
+
+## Definition of Done
+
+- [ ] All `tasks.md` tasks marked `[x]`
+- [ ] `dotnet test` passes with no regressions against Feature 041
+- [ ] OSCAL exports verified 1.1.2 with schema validation
+- [ ] Sync creates conflicts without modifying SPIN data
+- [ ] Status endpoint responds < 500 ms
+- [ ] MCP tools callable from dashboard chat
+- [ ] `docs/guides/emass-workflow.md` complete
+- [ ] PR approved by 1 reviewer
+- [ ] Issue #59 linked and acceptance criteria verified

--- a/specs/071-emass-workflow-sync/quickstart.md
+++ b/specs/071-emass-workflow-sync/quickstart.md
@@ -1,0 +1,201 @@
+# Quickstart: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Issue**: #59
+
+## Prerequisites
+
+- Feature 041 (eMASS Authorization Package Export) deployed and migrations applied
+- `dotnet SDK 8.0+`
+- Local database with seed data (at least one `RegisteredSystem` with eMASS onboarding data)
+- OSCAL 1.1.2 schema bundles present at `src/Ato.Copilot.Core/Resources/oscal-schemas/` (added in Feature 041 T002)
+
+---
+
+## 1. Verify Feature 041 Baseline
+
+Before starting Feature 071 work, confirm Feature 041 is healthy:
+
+```bash
+cd src/Ato.Copilot.Agents
+dotnet test ../../tests/Ato.Copilot.Tests.Unit --filter "Category=Feature041" --no-build
+```
+
+All Feature 041 tests must pass before any Feature 071 changes are made.
+
+---
+
+## 2. Apply Phase 1 — OSCAL Upgrade (Hotfix Path)
+
+Edit `EmassExportService.cs` for T001 and T002, then verify:
+
+```bash
+dotnet build src/Ato.Copilot.Agents/Ato.Copilot.Agents.csproj
+
+# Run OSCAL upgrade regression
+dotnet test tests/Ato.Copilot.Tests.Unit \
+  --filter "FullyQualifiedName~EmassExportServiceTests" \
+  --logger "console;verbosity=detailed"
+```
+
+Expected output includes:
+- `BuildOscalPoam_Returns_Oscal112_Schema` ✓
+- `BuildOscalAssessmentResults_Returns_Oscal112_Schema` ✓
+- All Feature 041 POA&M/AR builder tests ✓
+
+**Ship Phase 1 immediately** — merge to `main` as a hotfix PR before continuing.
+
+---
+
+## 3. Apply Phase 2 — Migration
+
+After creating the `EmassConflict` entity and updating `AtoCopilotContext`:
+
+```bash
+cd src/Ato.Copilot.Agents
+
+dotnet ef migrations add AddEmassConflict \
+  --project ../Ato.Copilot.Core/Ato.Copilot.Core.csproj \
+  --startup-project ../Ato.Copilot.Mcp/Ato.Copilot.Mcp.csproj \
+  --context AtoCopilotContext
+
+dotnet ef database update \
+  --project ../Ato.Copilot.Core/Ato.Copilot.Core.csproj \
+  --startup-project ../Ato.Copilot.Mcp/Ato.Copilot.Mcp.csproj \
+  --context AtoCopilotContext
+```
+
+Verify the `EmassConflicts` table and indexes exist:
+
+```sql
+SELECT name FROM sys.tables WHERE name = 'EmassConflicts';
+SELECT name FROM sys.indexes WHERE object_id = OBJECT_ID('EmassConflicts');
+-- Expected: IX_EmassConflict_SystemId_Status, IX_EmassConflict_BatchId
+```
+
+---
+
+## 4. Run Full Test Suite
+
+After completing each phase, run the full test suite:
+
+```bash
+dotnet test tests/Ato.Copilot.Tests.Unit --no-build
+dotnet test tests/Ato.Copilot.Tests.Integration --no-build
+```
+
+**All Feature 041 tests must continue to pass.** Feature 071 adds new tests; it must not break existing ones.
+
+---
+
+## 5. Manual Smoke Tests
+
+### 5a. Export Readiness Check
+
+```http
+GET /api/systems/{systemId}/emass/readiness
+Authorization: Bearer <ISSO_token>
+```
+
+Expected for a system missing `DitprId`:
+```json
+{
+  "data": {
+    "systemId": "...",
+    "isReady": false,
+    "gaps": [
+      {
+        "fieldName": "DitprId",
+        "description": "DITPR System ID is required for eMASS import matching.",
+        "severity": "Blocking",
+        "fixUrl": "/systems/.../settings#identifiers"
+      }
+    ]
+  }
+}
+```
+
+### 5b. Workflow Status
+
+```http
+GET /api/systems/{systemId}/emass/status
+Authorization: Bearer <ISSO_token>
+```
+
+Expected for a system never exported:
+```json
+{
+  "data": {
+    "overallStatus": "NeverExported",
+    "lastExportedAt": null,
+    "unresolvedConflictCount": 0
+  }
+}
+```
+
+### 5c. Round-Trip Sync Upload
+
+```http
+POST /api/systems/{systemId}/emass/sync
+Authorization: Bearer <ISSO_token>
+Content-Type: multipart/form-data
+
+[Attach: emass-export.xlsx]
+```
+
+Expected: `200 OK` with sync summary including `conflictsCreated` count. Verify SPIN data unchanged by querying the control/POA&M tables directly.
+
+### 5d. MCP Tool via Chat
+
+In the dashboard chat, type:
+```
+What is the eMASS export status for [System Name]?
+```
+
+Expected: Formatted markdown table showing `OverallStatus`, last exported date, per-category counts, and conflict count.
+
+---
+
+## 6. Performance Validation (NFR-001)
+
+Use the seed data script to create a test system with 400 controls and 150 POA&M items. Upload an eMASS Excel with 20 changed fields spread across both entities:
+
+```bash
+# Seed large test system (integration test helper)
+dotnet run --project tests/Ato.Copilot.Tests.Integration \
+  -- seed-emass-system --controls 400 --poam 150
+```
+
+Time the sync endpoint:
+```bash
+time curl -X POST http://localhost:5000/api/systems/{id}/emass/sync \
+  -H "Authorization: Bearer ..." \
+  -F "file=@tests/fixtures/emass-large-export.xlsx"
+```
+
+Target: < 30 seconds wall-clock (NFR-001).
+
+---
+
+## 7. OSCAL Schema Verification
+
+After Phase 1 is complete, verify both upgraded builders pass schema validation:
+
+```csharp
+// In a unit test or scratch console
+var service = serviceProvider.GetService<IEmassExportService>();
+var poamJson = await service.BuildOscalPoamAsync(systemId);
+var result = await oscalValidator.ValidateAsync("poam", poamJson);
+Assert.True(result.IsValid, string.Join(", ", result.Errors));
+```
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| OSCAL schema validation fails after upgrade | `related-findings` field missing | Check T001 — `related-observations` must be renamed |
+| Migration fails with FK conflict | Feature 041 migrations not applied | Apply Feature 041 migrations first |
+| Sync returns 0 conflicts for a changed file | Parser not reading worksheet | Check `EmassImportParser` column mappings against actual Excel file |
+| Status endpoint returns 500 | `AuthorizationPackage` table missing | Feature 041 must be deployed first |
+| MCP tool returns `tool not found` | Tool not registered | Check `EmassWorkflowTools.cs` registration in DI |

--- a/specs/071-emass-workflow-sync/research.md
+++ b/specs/071-emass-workflow-sync/research.md
@@ -1,0 +1,158 @@
+# Research: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Date**: 2026-06-11
+
+## 1. OSCAL 1.0.6 → 1.1.2 Breaking Changes
+
+### Source
+
+NIST OSCAL GitHub changelog: https://github.com/usnistgov/OSCAL/releases  
+OSCAL 1.1.0 release notes identify the following breaking changes relevant to this feature:
+
+### Plan of Action & Milestones (POA&M)
+
+| Change | 1.0.6 | 1.1.2 | Impact |
+|--------|-------|-------|--------|
+| Rename field | `related-observations` | `related-findings` | **Breaking** — eMASS import will reject documents using the old field name |
+| New required field | *(absent)* | `import-ssp` at root level | **Required** for eMASS linkage; omitting causes validation warning |
+| Version string | `"1.0.6"` | `"1.1.2"` | Must match across all artifacts in a package |
+
+### Assessment Results
+
+| Change | 1.0.6 | 1.1.2 | Impact |
+|--------|-------|-------|--------|
+| `target.status` structure | `"status": "pass"` (string) | `"status": { "state": "satisfied" }` (object) | **Breaking** — field restructured; must use new object format |
+| `reviewed-controls` | *(absent at results level)* | `reviewed-controls.control-selections` required | **Required** for eMASS compliance assessment import |
+| New root field | *(absent)* | `import-ap` (Assessment Plan reference) | Required to link AR → SAP |
+| Version string | `"1.0.6"` | `"1.1.2"` | Same as above |
+
+### Relevant NIST URLs (air-gapped: use bundled schemas from Feature 041 T002)
+- OSCAL POA&M schema: `src/Ato.Copilot.Core/Resources/oscal-schemas/oscal_poam_schema.json`
+- OSCAL Assessment Results schema: `src/Ato.Copilot.Core/Resources/oscal-schemas/oscal_assessment-results_schema.json`
+
+---
+
+## 2. eMASS Import Requirements for System Identifiers
+
+### DitprId and EmassId
+
+eMASS uses two identifier fields to match an imported package to an existing system record:
+
+| Field | eMASS Column | Required? | Notes |
+|-------|-------------|-----------|-------|
+| `DitprId` | `DITPR System ID` | **Mandatory** for DoD systems | Links to the DoD IT Portfolio Repository |
+| `EmassId` | `eMASS System ID` | **Mandatory** for systems already registered in eMASS | Auto-assigned by eMASS on system creation |
+
+If either field is missing, eMASS either rejects the import or creates a duplicate system record, both of which require manual eMASS administrator intervention to clean up.
+
+**OSCAL representation**:
+```json
+"system-id": [
+  { "identifier-type": "https://ies.apps.mil/jira/DoD-DITPR", "id": "<DitprId>" },
+  { "identifier-type": "https://dodea.emass.mil", "id": "<EmassId>" }
+]
+```
+This structure appears in the SSP, POA&M, and Assessment Results `metadata` block.
+
+---
+
+## 3. eMASS Excel Import Template Structure
+
+The existing `EmassImportParser` parses eMASS Excel exports. Key worksheets for round-trip sync:
+
+| Worksheet | Key Fields for Diff |
+|-----------|---------------------|
+| `System Information` | SystemName, Description, SystemType, SecurityCategorization (CIA), DitprId, EmassId |
+| `Controls` | ControlId, ImplementationStatus, Narrative, TestMethod |
+| `POA&M` | PoamId, WeaknessName, ScheduledCompletionDate, MitigationDescription, Status |
+
+**Source**: `EmassImportParser.cs` — review existing column mappings before implementing diff logic in `EmassRoundTripSyncService`.
+
+---
+
+## 4. Conflict Detection Strategy
+
+### Field-Level Diff Approach
+
+The sync service will compare each parsed eMASS field against the corresponding SPIN DB field. Comparison rules:
+
+| Field Type | Comparison Method |
+|------------|-------------------|
+| String | Case-insensitive trim comparison |
+| Date | UTC date equality (ignore time component for scheduled dates) |
+| Enum/Status | Normalized string comparison |
+| Nullable | `null` ≠ empty string — both treated as "not set" for comparison |
+
+### What Creates a Conflict
+
+- Field present in eMASS import AND different from current SPIN value → `EmassConflict` record
+- Field present in eMASS import but missing in SPIN → conflict of type addition
+- Field present in SPIN but absent from eMASS export → **no conflict** (SPIN data is authoritative for fields not in eMASS export)
+
+### What Does NOT Create a Conflict
+
+- Field values are identical after normalization
+- Fields that SPIN owns exclusively (not tracked in eMASS Excel)
+
+---
+
+## 5. Round-Trip Sync — Prior Art
+
+### Initial Onboarding (EmassImportService)
+
+`EmassImportService.cs` handles the *initial* onboarding import — it writes SPIN entities directly from eMASS data with no conflict detection. This is appropriate for first-time import when SPIN has no existing data.
+
+Feature 071 adds a *subsequent* sync path that MUST NOT overwrite existing SPIN data.
+
+**Do not modify** `EmassImportService` or `EmassImportParser` for Feature 071. Create `EmassRoundTripSyncService` as a separate service that reuses the parser.
+
+---
+
+## 6. Workflow Status — Export History Source
+
+`EmassWorkflowStatusService` needs to know when each data category was last exported. Potential sources:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Query `AuthorizationPackage.CompletedAt` (Feature 041) | Already exists | Only tracks full packages, not individual category exports |
+| Add `EmassExportLog` table | Granular per-category tracking | Requires new entity |
+| Use `AuthorizationPackage.PackageArtifact` records | Artifact-level timestamps | Still tied to full packages |
+
+**Decision**: For MVP (Feature 071), derive `LastExportedAt` from the most recent `AuthorizationPackage` with `Status = Completed` for the system. Per-category pending counts are derived from comparing entity `UpdatedAt` timestamps against the package's `CompletedAt`. A dedicated `EmassExportLog` table can be added in a future increment if per-category granularity is needed.
+
+---
+
+## 7. Performance Considerations
+
+### Sync Diff Performance
+
+For a Moderate system (400 controls, 150 POA&M items):
+- ~550 entities to compare
+- Each comparison is an in-memory field-level diff (no additional DB queries per entity)
+- Batch insert of conflict records using EF Core `AddRangeAsync` + single `SaveChangesAsync`
+- Expected: well under NFR-001's 30-second target
+
+**Risk**: N+1 query if sync service fetches entities one-by-one. Mitigation: Eager-load all system entities before beginning diff.
+
+### Status Endpoint Performance
+
+Status endpoint aggregates:
+1. Count query on `EmassConflict` table (indexed on `RegisteredSystemId, ConflictStatus`)
+2. Max timestamp query on `AuthorizationPackage` (indexed on `RegisteredSystemId`)
+3. Readiness check (in-memory field presence checks only)
+
+Expected response time: < 100 ms on indexed queries. NFR-002 target is 500 ms.
+
+---
+
+## 8. RBAC Model
+
+| Operation | Allowed Roles | Rationale |
+|-----------|---------------|-----------|
+| View workflow status | ISSO, ISSM, AO | Read-only — all eMASS stakeholders need visibility |
+| Run readiness check | ISSO, ISSM, AO | Read-only |
+| Upload sync file | ISSO, ISSM | Only primary ATO workspace users can initiate sync |
+| Resolve conflict (KeepSpin/AcceptEmass) | ISSO, ISSM | Data changes require the accountable role |
+| Resolve conflict (Deferred) | ISSO, ISSM, AO | Deferral is informational only |
+
+**Source**: Consistent with existing RBAC in `EmassExportTools.cs` and Feature 041 endpoints.

--- a/specs/071-emass-workflow-sync/spec.md
+++ b/specs/071-emass-workflow-sync/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync
+**Branch**: `071-emass-workflow-sync`
+**Created**: 2026-06-11
+**Status**: Draft
+**GitHub Issue**: [#59](https://github.com/azurenoops/spin_agent/issues/59)
+**Extends**: `specs/041-emass-package` (Feature 041 — eMASS Authorization Package Export)
+**Wave**: 9
+
+## Problem Statement
+
+ISSOs who work across both SPIN and eMASS face three compounding pain points:
+
+1. **OSCAL version mismatch** — Feature 041's POA&M and Assessment Results exports emit OSCAL 1.0.6 while the SSP emits 1.1.2. eMASS import validation rejects packages with mixed OSCAL versions, making *every current package submission fail* until this is fixed.
+2. **No round-trip sync** — After onboarding via `EmassImportService`, there is no way to re-import a newer eMASS Excel export without destructively overwriting SPIN data. ISSOs who update data in eMASS cannot safely bring those updates into SPIN.
+3. **Blind export status** — There is no single view showing what SPIN data has already been exported to eMASS, when, and what is still pending. ISSOs must manually track export state outside the tool.
+
+Two additional gaps block eMASS package acceptance:
+- **Missing system identifiers** — `DitprId` and `EmassId` are required fields for eMASS package import but are currently optional/unpopulated in exports.
+- **No pre-export readiness check** — No mechanism validates that all required eMASS fields are present before the ISSO attempts a submission that will be rejected.
+
+## Goal
+
+Extend Feature 041 so that SPIN can serve as the ISSO's **primary ATO workspace** while eMASS remains the system of record. Specifically:
+
+1. Upgrade all OSCAL exports (POA&M, Assessment Results) to 1.1.2 so packages are accepted by eMASS.
+2. Enable safe round-trip sync: import newer eMASS data, diff against SPIN state, surface conflicts for ISSO review — never silently overwrite.
+3. Provide a single `EmassWorkflowStatus` view showing exported vs. pending data.
+4. Gate exports with an `EmassExportReadiness` check validating all eMASS-required fields.
+
+## Scope
+
+### In Scope
+
+- **OSCAL 1.0.6 → 1.1.2 upgrade** in `EmassExportService` (`BuildOscalPoam`, `BuildOscalAssessmentResults`)
+- **`EmassExportReadiness` service** — validates `DitprId`, `EmassId`, SSP completeness, POA&M completeness before export
+- **`EmassRoundTripSync` service** — imports a newer eMASS Excel, diffs against SPIN state, persists conflict records for ISSO review; never auto-merges
+- **`EmassWorkflowStatus` DTO + endpoint** — `GET /api/systems/{id}/emass/status` returning export history, pending items, and last sync timestamp
+- **MCP tools**: `emass_get_workflow_status`, `emass_check_export_readiness`
+- **`EmassConflict` entity** — persists field-level conflicts awaiting ISSO resolution
+- **Dashboard route** — `/systems/{id}/emass/status` for the ISSO workflow status view
+
+### Out of Scope
+
+- Full authorization package ZIP assembly (Feature 041)
+- SAR generation (Feature 041)
+- OSCAL SAP export (Feature 041)
+- Evidence repository integration (Feature 041)
+- Automated conflict resolution / merge (conflicts are surfaced only — ISSO decides)
+- eMASS API live integration (all sync is file-based Excel import/export)
+- Changes to the initial onboarding wizard (`Step3EmassImport.tsx`, `EmassImportWizard.tsx`)
+
+## User Stories
+
+### US1 — OSCAL Version Consistency (Priority: P0 — Blocking)
+
+As an ISSO submitting a package to eMASS, I need all OSCAL artifacts to use OSCAL 1.1.2 so that eMASS does not reject the import with a version conflict error.
+
+**Why P0**: Every eMASS package generated today will be rejected. This is a blocking defect, not a feature addition.
+
+**Acceptance Scenarios**:
+1. **Given** the system generates an OSCAL POA&M export, **When** the JSON is inspected, **Then** `metadata.oscal-version` equals `"1.1.2"` and the `poam-items` array uses the 1.1.2 schema (field `related-findings` not `related-observations`).
+2. **Given** the system generates an OSCAL Assessment Results export, **When** the JSON is inspected, **Then** `metadata.oscal-version` equals `"1.1.2"`, `results[].reviewed-controls` is present, and `target.status.state` uses valid 1.1.2 values.
+3. **Given** a full authorization package (Feature 041), **When** each OSCAL artifact is extracted and validated, **Then** all four artifacts (SSP, POA&M, AR, SAP) carry `"oscal-version": "1.1.2"`.
+
+---
+
+### US2 — Export Readiness Check (Priority: P1)
+
+As an ISSO, before exporting to eMASS I want SPIN to validate that all required eMASS fields are populated so that I can fix gaps before attempting a submission that eMASS will reject.
+
+**Why P1**: eMASS returns cryptic rejection codes. Pre-flight validation saves hours of back-and-forth.
+
+**Acceptance Scenarios**:
+1. **Given** a system missing `DitprId` and `EmassId`, **When** the ISSO runs the readiness check, **Then** the response lists both fields as blocking gaps with links to where they can be populated.
+2. **Given** a system with all required fields complete, **When** the readiness check runs, **Then** it returns `"ready": true` with a summary of what will be exported.
+3. **Given** the ISSO asks the agent "Is System X ready for eMASS export?", **When** the `emass_check_export_readiness` MCP tool is called, **Then** the response is a formatted readiness card listing gaps (if any) with actionable fix steps.
+
+---
+
+### US3 — Round-Trip Sync (Priority: P1)
+
+As an ISSO, I want to import a newer eMASS Excel export into SPIN so that I can see what changed in eMASS since my last import — without SPIN overwriting data I have already entered.
+
+**Why P1**: Without round-trip sync, the ISSO must manually reconcile two systems, defeating the purpose of SPIN as the primary workspace.
+
+**Acceptance Scenarios**:
+1. **Given** an eMASS Excel file newer than the last SPIN import, **When** the ISSO uploads it via the sync endpoint, **Then** SPIN computes a field-level diff and stores `EmassConflict` records for every changed field, with `SpinValue` and `EmassValue` visible to the ISSO.
+2. **Given** existing `EmassConflict` records, **When** the ISSO reviews them, **Then** they can resolve each conflict by choosing "Keep SPIN", "Accept eMASS", or "Defer" — SPIN data is only updated when the ISSO explicitly chooses "Accept eMASS".
+3. **Given** fields that are identical in both SPIN and the new eMASS export, **When** the sync runs, **Then** no conflict is created for those fields — only changed fields surface.
+4. **Given** the sync runs while unresolved conflicts exist from a prior sync, **When** the ISSO attempts a second sync, **Then** SPIN warns the ISSO that unresolved conflicts exist and requires acknowledgment before proceeding.
+
+---
+
+### US4 — Workflow Status View (Priority: P1)
+
+As an ISSO, I want a single dashboard view showing what SPIN data has been exported to eMASS, when it was exported, and what is still pending, so that I can track my eMASS submission progress without checking two systems.
+
+**Why P1**: ISSOs currently have no visibility into SPIN→eMASS export state. This directly addresses the issue's "SPIN as primary workspace" requirement.
+
+**Acceptance Scenarios**:
+1. **Given** a system with prior exports, **When** the ISSO opens the eMASS Status page, **Then** they see: last export timestamp, which data categories were exported (controls, POA&Ms, artifacts), how many items are pending export, and any unresolved sync conflicts.
+2. **Given** the ISSO asks the agent "What's my eMASS export status for System X?", **When** `emass_get_workflow_status` is called, **Then** the response includes a formatted table showing exported vs. pending items per category.
+3. **Given** a system that has never been exported, **When** the status page loads, **Then** it shows `"Never exported"` with a call-to-action to run the readiness check.
+
+---
+
+### US5 — System Identifier Completeness (Priority: P1)
+
+As an ISSO, I need `DitprId` and `EmassId` to be populated and included in all eMASS exports so that eMASS can match the imported data to the correct system record.
+
+**Why P1**: Without these identifiers, eMASS cannot associate the imported artifacts with any system — the import silently fails or creates a duplicate record.
+
+**Acceptance Scenarios**:
+1. **Given** `DitprId` and `EmassId` are set on a system, **When** any eMASS Excel export is generated, **Then** both fields appear in the correct eMASS columns per the eMASS import template.
+2. **Given** an OSCAL POA&M or Assessment Results export, **When** the JSON is inspected, **Then** the `metadata.system-id` array includes entries for both `DitprId` and `EmassId` under their respective schemes.
+3. **Given** a readiness check where `DitprId` is empty, **When** results are returned, **Then** `DitprId` appears as a **blocking** gap (not a warning).
+
+---
+
+## Edge Cases
+
+- What if the ISSO uploads an eMASS Excel from a *different system*? → Validate the system identifier in the file against `EmassId`; reject with a clear error if they do not match.
+- What if a synced field has been deleted in SPIN but exists in eMASS? → Surface as a conflict of type `Deletion` — the ISSO must explicitly decide.
+- What if the ISSO resolves conflicts and then uploads yet another newer eMASS file? → Create a new sync batch; prior resolved conflicts are archived, not overwritten.
+- What if `DitprId` / `EmassId` are present in the onboarding import but were later cleared? → The readiness check catches this; the status page shows a "System identifiers missing" warning.
+- What if OSCAL schema validation fails after the 1.1.2 upgrade? → The upgraded builder must pass the bundled OSCAL 1.1.2 schema validation introduced in Feature 041 T024.
+
+## Requirements
+
+### Functional Requirements
+
+**OSCAL Upgrade (US1)**
+- **FR-001**: `BuildOscalPoam()` in `EmassExportService` MUST emit `"oscal-version": "1.1.2"` and use `related-findings` (not `related-observations`) per the 1.1.2 schema change.
+- **FR-002**: `BuildOscalAssessmentResults()` in `EmassExportService` MUST emit `"oscal-version": "1.1.2"`, include `reviewed-controls` with `control-selections`, and use valid `target.status.state` values per the 1.1.2 schema.
+- **FR-003**: Both upgraded builders MUST pass validation against the OSCAL 1.1.2 schemas bundled in Feature 041 (`OscalSchemaValidationService`).
+
+**Export Readiness (US2 + US5)**
+- **FR-004**: `EmassExportReadinessService` MUST validate: `DitprId` present, `EmassId` present, SSP has at least one Approved section, all POA&M items have scheduled completion dates, system categorization (Confidentiality/Integrity/Availability) is populated.
+- **FR-005**: Readiness response MUST classify each gap as `Blocking` (export must not proceed) or `Advisory` (export may proceed with warning).
+- **FR-006**: `DitprId` and `EmassId` MUST be treated as `Blocking` gaps.
+- **FR-007**: All eMASS Excel exports MUST include `DitprId` and `EmassId` in the appropriate columns; OSCAL exports MUST include them in `metadata.system-id`.
+
+**Round-Trip Sync (US3)**
+- **FR-008**: `EmassRoundTripSyncService` MUST parse an uploaded eMASS Excel file using the existing `EmassImportParser` and diff it against current SPIN state at the field level.
+- **FR-009**: Each differing field MUST produce an `EmassConflict` record with: `FieldName`, `SpinValue`, `EmassValue`, `ConflictStatus` (Unresolved/KeepSpin/AcceptEmass/Deferred), `DetectedAt`, `ResolvedAt`, `ResolvedBy`.
+- **FR-010**: SPIN data MUST NOT be modified during a sync run — only `EmassConflict` records are written.
+- **FR-011**: Conflict resolution endpoint MUST accept a resolution choice and update SPIN data **only** when `AcceptEmass` is chosen.
+- **FR-012**: A second sync MUST warn if unresolved conflicts from the prior batch exist; the ISSO must acknowledge before proceeding.
+- **FR-013**: Unchanged fields MUST NOT produce conflict records.
+
+**Workflow Status (US4)**
+- **FR-014**: `GET /api/systems/{id}/emass/status` MUST return `EmassWorkflowStatus` including: `LastExportedAt`, `LastSyncedAt`, `UnresolvedConflictCount`, per-category export summary (`Controls`, `PoamItems`, `Artifacts`), and `ReadinessStatus` (summary only — not full gaps list).
+- **FR-015**: The endpoint MUST be accessible to users with ISSO, ISSM, or AO roles.
+- **FR-016**: If the system has never been exported, `LastExportedAt` MUST be `null` and `OverallStatus` MUST be `"NeverExported"`.
+
+**MCP Tools**
+- **FR-017**: `emass_get_workflow_status` MCP tool MUST accept `system_id` and return the `EmassWorkflowStatus` DTO formatted as a markdown table.
+- **FR-018**: `emass_check_export_readiness` MCP tool MUST accept `system_id` and return a readiness card listing gaps with fix instructions; both tools require ISSO/ISSM/AO role.
+
+**Access Control**
+- **FR-019**: All new endpoints and tools MUST enforce ISSO, ISSM, or AO role authorization.
+- **FR-020**: Conflict resolution (Accept eMASS value) MUST be restricted to ISSO and ISSM roles (not AO read-only).
+
+### Non-Functional Requirements
+
+- **NFR-001**: Round-trip sync diff for a system with 400 controls and 150 POA&M items MUST complete in under 30 seconds.
+- **NFR-002**: `EmassWorkflowStatus` endpoint MUST respond in under 500 ms (reads only — no generation).
+- **NFR-003**: All new endpoints MUST follow the existing API envelope pattern (`{ data, meta, errors }`).
+- **NFR-004**: Conflict records MUST be retained for 90 days after resolution.
+- **NFR-005**: OSCAL upgrade MUST NOT break existing Feature 041 package generation — all Feature 041 tests must continue to pass.
+
+## Success Criteria
+
+- **SC-001**: 100% of OSCAL exports (SSP, POA&M, AR, SAP) carry `"oscal-version": "1.1.2"` — zero version mismatch in generated packages.
+- **SC-002**: `EmassExportReadiness` correctly identifies all blocking gaps for 5 representative system configurations (no false negatives on `DitprId`/`EmassId`).
+- **SC-003**: Round-trip sync surfaces field-level conflicts without modifying SPIN data until the ISSO explicitly accepts.
+- **SC-004**: `EmassWorkflowStatus` endpoint returns accurate per-category export counts and conflict count in < 500 ms.
+- **SC-005**: All new MCP tools are callable from dashboard chat, Teams, and VS Code with formatted responses.

--- a/specs/071-emass-workflow-sync/tasks.md
+++ b/specs/071-emass-workflow-sync/tasks.md
@@ -1,0 +1,261 @@
+# Tasks: eMASS Workflow Sync & OSCAL 1.1.2 Upgrade
+
+**Feature**: 071-emass-workflow-sync | **Issue**: #59
+**Input**: `specs/071-emass-workflow-sync/spec.md`, `data-model.md`, `contracts/`
+**Prerequisites**: Feature 041 foundation (entities, services, OSCAL schema bundles) MUST be deployed
+
+**Path Conventions**
+- Core models/interfaces: `src/Ato.Copilot.Core/`
+- Service implementations & MCP tools: `src/Ato.Copilot.Agents/Compliance/`
+- Dashboard API endpoints: `src/Ato.Copilot.Mcp/`
+- Dashboard frontend: `src/Ato.Copilot.Dashboard/src/`
+- Unit tests: `tests/Ato.Copilot.Tests.Unit/`
+- Integration tests: `tests/Ato.Copilot.Tests.Integration/`
+
+**Task legend**
+- `[P]` = can run in parallel with other `[P]` tasks in the same phase (different files)
+- `[USn]` = maps to User Story n in spec.md
+- `[x]` = complete | `[ ]` = pending
+
+---
+
+## Phase 1 — OSCAL 1.1.2 Upgrade (US1 — P0 Blocking)
+
+**Goal**: Fix the version mismatch that causes every current eMASS package submission to be rejected. This phase is independent and can ship immediately.
+
+**Independent Test**: Export POA&M and AR via existing MCP tools; confirm `"oscal-version": "1.1.2"` in both outputs and that Feature 041 package generation still passes all tests.
+
+- [ ] T001 [US1] Upgrade `BuildOscalPoam()` in `src/Ato.Copilot.Agents/Compliance/Services/EmassExportService.cs`:
+  - Set `metadata.oscal-version` to `"1.1.2"`
+  - Rename field `related-observations` → `related-findings` (1.1.2 schema breaking change)
+  - Add `import-ssp` reference using system SSP UUID
+  - Validate output against bundled `oscal_poam_schema.json` via `OscalSchemaValidationService` in unit test
+
+- [ ] T002 [US1] Upgrade `BuildOscalAssessmentResults()` in `src/Ato.Copilot.Agents/Compliance/Services/EmassExportService.cs`:
+  - Set `metadata.oscal-version` to `"1.1.2"`
+  - Add `reviewed-controls.control-selections` array
+  - Update `target.type` and `target.status.state` to valid 1.1.2 enum values
+  - Add `import-ap` reference
+  - Validate output against bundled `oscal_assessment-results_schema.json` in unit test
+
+- [ ] T003 [P] [US1] Add/update unit tests in `tests/Ato.Copilot.Tests.Unit/Compliance/EmassExportServiceTests.cs`:
+  - `BuildOscalPoam_Returns_Oscal112_Schema` — assert version, related-findings field
+  - `BuildOscalAssessmentResults_Returns_Oscal112_Schema` — assert version, reviewed-controls
+  - `Feature041PackageGeneration_StillPasses_AfterUpgrade` — regression guard
+
+**Checkpoint**: Both OSCAL builders emit 1.1.2. All Feature 041 tests pass. Ship independently.
+
+---
+
+## Phase 2 — Foundation (New Entities + Interfaces)
+
+**Goal**: Add `EmassConflict`, `EmassWorkflowStatus` DTO, and service interfaces. All downstream phases depend on this.
+
+**⚠️ CRITICAL**: Phase 3+ cannot start until this phase is complete.
+
+- [ ] T004 [P] Create `EmassConflict` entity in `src/Ato.Copilot.Core/Models/Compliance/EmassConflict.cs`:
+  - Fields per `data-model.md`: `Id`, `RegisteredSystemId`, `SyncBatchId`, `EntityType`, `EntityId`, `FieldName`, `SpinValue`, `EmassValue`, `ConflictStatus` (enum), `DetectedAt`, `ResolvedAt`, `ResolvedBy`
+  - Index on `(RegisteredSystemId, ConflictStatus)` for status dashboard queries
+
+- [ ] T005 [P] Create `EmassWorkflowStatus` DTO in `src/Ato.Copilot.Core/Dtos/Dashboard/EmassWorkflowDtos.cs`:
+  - `EmassWorkflowStatus`: `SystemId`, `OverallStatus` (enum: NeverExported/UpToDate/PendingExport/HasConflicts), `LastExportedAt?`, `LastSyncedAt?`, `UnresolvedConflictCount`, `ExportSummary` (per-category counts), `ReadinessStatus`
+  - `EmassExportReadinessResult`: `SystemId`, `IsReady`, `Gaps` (list of `ReadinessGap`)
+  - `ReadinessGap`: `FieldName`, `Description`, `Severity` (Blocking/Advisory), `FixUrl`
+  - `EmassConflictDto`: surface fields for ISSO review UI
+  - `ResolveConflictRequest`: `ConflictId`, `Resolution` (KeepSpin/AcceptEmass/Deferred)
+
+- [ ] T006 [P] Create service interfaces in `src/Ato.Copilot.Core/Interfaces/Compliance/`:
+  - `IEmassExportReadinessService` — `CheckReadinessAsync(systemId, ct)` → `EmassExportReadinessResult`
+  - `IEmassRoundTripSyncService` — `StartSyncAsync(systemId, excelStream, ct)` → `EmassConflict[]`; `ResolveConflictAsync(conflictId, resolution, resolvedBy, ct)`
+  - `IEmassWorkflowStatusService` — `GetStatusAsync(systemId, ct)` → `EmassWorkflowStatus`
+
+- [ ] T007 Register new DbSet `EmassConflicts` in `AtoCopilotContext`, configure relationships and indexes in `OnModelCreating`, create EF Core migration `AddEmassConflict`
+
+**Checkpoint**: Entities, DTOs, interfaces, and migration in place. All subsequent phases can begin.
+
+---
+
+## Phase 3 — Export Readiness Service (US2 + US5)
+
+**Goal**: Gate eMASS exports with a pre-flight check that catches `DitprId`/`EmassId` gaps and other required fields before the ISSO attempts a doomed submission.
+
+**Independent Test**: Call readiness check on a system with `DitprId` empty — confirm it returns `IsReady=false` with a Blocking gap for `DitprId`.
+
+- [ ] T008 [US2] [US5] Implement `EmassExportReadinessService` in `src/Ato.Copilot.Agents/Compliance/Services/EmassExportReadinessService.cs`:
+  - Check `DitprId` present (Blocking)
+  - Check `EmassId` present (Blocking)
+  - Check system categorization CIA values populated (Blocking)
+  - Check at least one Approved SSP section (Advisory)
+  - Check all POA&M items have scheduled completion dates (Advisory)
+  - Return `EmassExportReadinessResult` with gap list
+
+- [ ] T009 [P] [US5] Update `EmassExportService` Excel export methods to include `DitprId` and `EmassId` in the correct eMASS template columns; update OSCAL builders to populate `metadata.system-id` array with both identifier schemes
+
+- [ ] T010 [P] [US2] Add unit tests in `tests/Ato.Copilot.Tests.Unit/Compliance/EmassExportReadinessServiceTests.cs`:
+  - Test each Blocking gap fires correctly
+  - Test Advisory gaps do not block `IsReady=true`
+  - Test fully populated system returns `IsReady=true`
+
+**Checkpoint**: Readiness check correctly gates export attempts. `DitprId`/`EmassId` are in all export outputs.
+
+---
+
+## Phase 4 — Round-Trip Sync Service (US3)
+
+**Goal**: Enable safe import of a newer eMASS Excel — diff against SPIN state, persist conflicts, never auto-merge.
+
+**Independent Test**: Upload an eMASS Excel with 3 changed fields; confirm exactly 3 `EmassConflict` records created, SPIN data unchanged, resolve one with `AcceptEmass` and verify SPIN updates only that field.
+
+- [ ] T011 [US3] Implement `EmassRoundTripSyncService` in `src/Ato.Copilot.Agents/Compliance/Services/EmassRoundTripSyncService.cs`:
+  - Accept `Stream excelStream`; delegate parsing to existing `EmassImportParser`
+  - Diff parsed data against current SPIN state field-by-field (controls, system info, categorization)
+  - Write `EmassConflict` records only for changed fields (skip identical fields per FR-013)
+  - Warn and require acknowledgment if prior-batch unresolved conflicts exist (FR-012)
+  - Return summary: `BatchId`, `ConflictsCreated`, `IdenticalFields`, `SkippedUnresolved`
+
+- [ ] T012 [US3] Implement conflict resolution method in `EmassRoundTripSyncService`:
+  - Accept `ResolveConflictRequest`
+  - When `AcceptEmass`: update SPIN entity with `EmassValue`, set `ConflictStatus = AcceptEmass`, record `ResolvedAt`/`ResolvedBy`
+  - When `KeepSpin` or `Deferred`: update `ConflictStatus` only, no SPIN data change
+  - Emit domain event for audit log
+
+- [ ] T013 [P] [US3] Add unit tests in `tests/Ato.Copilot.Tests.Unit/Compliance/EmassRoundTripSyncServiceTests.cs`:
+  - Identical fields produce no conflicts
+  - Changed fields produce exactly one conflict each
+  - SPIN data unchanged after sync run (before resolution)
+  - AcceptEmass resolution updates SPIN; KeepSpin does not
+  - Second sync with unresolved conflicts triggers warning
+
+**Checkpoint**: Round-trip sync creates conflict records non-destructively. Resolution is explicit-only.
+
+---
+
+## Phase 5 — Workflow Status Service (US4)
+
+**Goal**: Aggregate export history, pending counts, and conflict count into a single DTO that gives the ISSO a clear picture of SPIN→eMASS state.
+
+**Independent Test**: Call `GET /api/systems/{id}/emass/status` on a system with 2 prior exports and 1 unresolved conflict; confirm all fields in response.
+
+- [ ] T014 [US4] Implement `EmassWorkflowStatusService` in `src/Ato.Copilot.Agents/Compliance/Services/EmassWorkflowStatusService.cs`:
+  - Query most recent export timestamps from `EmassExportHistory` or `AuthorizationPackage` records
+  - Count unresolved `EmassConflict` records for the system
+  - Aggregate per-category pending counts (controls not yet in latest export, POA&M items created/updated since last export)
+  - Call `IEmassExportReadinessService.CheckReadinessAsync` for summary `ReadinessStatus`
+  - Determine `OverallStatus` enum: NeverExported / UpToDate / PendingExport / HasConflicts
+
+- [ ] T015 [P] [US4] Add unit tests in `tests/Ato.Copilot.Tests.Unit/Compliance/EmassWorkflowStatusServiceTests.cs`:
+  - NeverExported when no export history
+  - HasConflicts takes priority when conflicts exist
+  - PendingExport when controls updated after last export
+
+**Checkpoint**: Status DTO accurately reflects system's eMASS workflow state.
+
+---
+
+## Phase 6 — API Endpoints (US2 + US3 + US4)
+
+**Goal**: Expose all new services via REST endpoints; enforce RBAC.
+
+- [ ] T016 [P] [US4] Add `GET /api/systems/{id}/emass/status` to `src/Ato.Copilot.Mcp/Endpoints/EmassWorkflowEndpoints.cs`:
+  - Returns `EmassWorkflowStatus` JSON
+  - RBAC: ISSO, ISSM, AO
+
+- [ ] T017 [P] [US2] Add `GET /api/systems/{id}/emass/readiness` to `EmassWorkflowEndpoints.cs`:
+  - Returns `EmassExportReadinessResult`
+  - RBAC: ISSO, ISSM, AO
+
+- [ ] T018 [P] [US3] Add sync endpoints to `EmassWorkflowEndpoints.cs`:
+  - `POST /api/systems/{id}/emass/sync` — accepts multipart Excel upload, returns sync summary + conflicts
+  - `GET /api/systems/{id}/emass/conflicts` — paginated list of `EmassConflictDto` filtered by status
+  - `PUT /api/systems/{id}/emass/conflicts/{conflictId}` — resolve a conflict; RBAC: ISSO, ISSM only
+
+- [ ] T019 [P] Register `EmassWorkflowEndpoints` in `src/Ato.Copilot.Mcp/Program.cs` (or equivalent startup)
+
+**Checkpoint**: All endpoints accessible, RBAC enforced, responses follow API envelope pattern.
+
+---
+
+## Phase 7 — MCP Tools (US2 + US4)
+
+**Goal**: Expose workflow status and readiness check as agent-callable tools so the ISSO can query state via chat.
+
+- [ ] T020 [P] [US4] [US2] Implement `emass_get_workflow_status` and `emass_check_export_readiness` MCP tools in `src/Ato.Copilot.Agents/Compliance/Tools/EmassWorkflowTools.cs`:
+  - Follow existing `BaseTool` envelope pattern
+  - `emass_get_workflow_status(system_id)` — returns markdown table of export status per category + conflict count
+  - `emass_check_export_readiness(system_id)` — returns formatted readiness card; Blocking gaps shown in bold
+  - RBAC: ISSO, ISSM, AO for both tools
+
+- [ ] T021 [P] [US4] [US2] Register new tools in the MCP tool registry; update `docs/architecture/agent-tool-catalog.md` with parameter tables, response schemas, RBAC, and example invocations
+
+**Checkpoint**: Both MCP tools callable from dashboard chat, Teams, and VS Code.
+
+---
+
+## Phase 8 — Dashboard Status Page (US4)
+
+**Goal**: Give the ISSO a visual eMASS workflow status view and conflict resolution UI.
+
+- [ ] T022 [P] [US4] Create `EmassStatusPage` React component at `src/Ato.Copilot.Dashboard/src/pages/EmassStatus.tsx`:
+  - Fetch `GET /api/systems/{id}/emass/status` on mount
+  - Display: overall status badge, last exported / last synced timestamps, per-category counts (exported / pending), unresolved conflict count with link to conflict list
+  - Show readiness warning banner when `IsReady=false`
+
+- [ ] T023 [P] [US3] Create `EmassConflictList` React component at `src/Ato.Copilot.Dashboard/src/components/EmassConflictList.tsx`:
+  - Display field-level conflicts with `SpinValue` vs `EmassValue` side-by-side
+  - Resolve buttons: "Keep SPIN" / "Accept eMASS" / "Defer" per conflict row
+  - Batch resolve with confirmation dialog for "Accept All eMASS" action
+
+- [ ] T024 [P] Add `emass-status.ts` API client in `src/Ato.Copilot.Dashboard/src/api/emass-status.ts`:
+  - `getEmassStatus(systemId)` → `EmassWorkflowStatus`
+  - `getEmassReadiness(systemId)` → `EmassExportReadinessResult`
+  - `uploadEmassSync(systemId, file)` → sync summary
+  - `getEmassConflicts(systemId, params)` → paginated `EmassConflictDto[]`
+  - `resolveConflict(systemId, conflictId, resolution)` → `EmassConflictDto`
+
+- [ ] T025 Register new route `/systems/:id/emass/status` in dashboard router
+
+**Checkpoint**: ISSO can view eMASS workflow status and resolve conflicts from the dashboard.
+
+---
+
+## Phase 9 — Polish & Cross-Cutting
+
+- [ ] T026 [P] Structured Serilog logging for sync runs: log batch ID, conflicts created, elapsed time
+- [ ] T027 [P] Update `docs/guides/emass-workflow.md` (new guide) covering: status page, readiness check, round-trip sync workflow, conflict resolution
+- [ ] T028 [P] Update `docs/getting-started/isso.md` with eMASS workflow sync section
+- [ ] T029 Run `dotnet test` end-to-end; verify all Feature 041 tests still pass; verify NFR-001 sync performance on mock data (400 controls, 150 POA&M items < 30 s)
+- [ ] T030 Code review: CancellationToken propagation, RBAC enforcement, API envelope consistency, 80% test coverage
+
+---
+
+## Dependencies & Execution Order
+
+```
+Phase 1 (OSCAL Upgrade) ──────────────────────────────────► Ship immediately (independent)
+
+Phase 2 (Foundation) ──────────────────────────────────────► BLOCKS Phases 3–7
+                         │
+        ┌────────────────┼────────────────┬────────────────┐
+        ▼                ▼                ▼                ▼
+Phase 3 (Readiness)  Phase 4 (Sync)  Phase 5 (Status)  Phase 6 (API) ◄─ depends on 3+4+5
+                                                            │
+                                                            ▼
+                                                       Phase 7 (MCP Tools)
+                                                            │
+                                                            ▼
+                                                       Phase 8 (Dashboard)
+                                                            │
+                                                            ▼
+                                                       Phase 9 (Polish)
+```
+
+## Parallel Opportunities
+
+After Phase 2 completes, these can run simultaneously:
+- T008–T010 (Readiness service + tests)
+- T011–T013 (Sync service + tests)
+- T014–T015 (Status service + tests)
+
+Within Phase 6 (API), all four endpoint tasks are parallel (same file but additive methods).
+
+Phase 1 (OSCAL Upgrade) is fully independent — merge to `main` as a hotfix before the rest of the feature lands.


### PR DESCRIPTION
**Owner**: Cyborg (`agent:cyborg`)

## Problem Statement

SPIN Agent and eMASS are both required by DoD organizations — SPIN as the primary compliance workspace, eMASS as the system of record. Today the workflow is serial and manual:
- `EmassImportService` handles initial onboarding (File: `src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Emass/EmassImportService.cs`)
- `EmassExportService` exports Controls + POA&M to Excel and OSCAL (File: `src/Ato.Copilot.Agents/Compliance/Services/EmassExportService.cs`)
- **Gap 1**: OSCAL POA&M and AR exports use version 1.0.6; SSP uses 1.1.2 — eMASS rejects mixed-version packages
- **Gap 2**: No round-trip sync after initial import — updated eMASS data cannot flow back in without full re-import
- **Gap 3**: No `EmassId`/`DitprId` validation before export — eMASS rejects submissions missing these fields
- **Gap 4**: No single "workflow status" view — ISSOs don't know what's been submitted, when, or what remains

## Goal / Desired Outcome

Feature 071 extends the existing eMASS integration with:
1. OSCAL 1.0.6 → 1.1.2 upgrade across POA&M and Assessment Results exports
2. `EmassRoundTripSync` service for diff-and-merge of updated eMASS data into SPIN (with conflict surfacing)
3. `EmassExportReadiness` pre-flight checks validating required fields before export
4. `EmassWorkflowStatus` DTO and endpoints: `GET /api/systems/{id}/emass/status`
5. MCP tools: `emass_get_workflow_status`, `emass_check_export_readiness`

## Scope

**In scope:**
- OSCAL version upgrade (POA&M + AR → 1.1.2)
- Round-trip sync with conflict detection (no silent overwrites)
- Pre-flight readiness check service
- Workflow status endpoint + MCP tool
- Unit tests for all new services and tools

**Out of scope:**
- eMASS direct API integration (requires DoD API keys, tracked separately)
- Full eMASS package assembly (Feature 041)
- New Excel column additions

## User Experience Flow

1. ISSO uploads updated eMASS Excel export via existing wizard (`EmassImportWizard.tsx`)
2. System detects this is a *re-import* (system already exists), triggers round-trip sync instead of full import
3. Sync surfaces conflicts: "Field X in SPIN is 'Implemented', eMASS says 'Not Applicable' — which is authoritative?"
4. ISSO resolves conflicts, commits accepted changes
5. ISSO views `/emass/status` — sees last export date, OSCAL version used, fields still missing for eMASS acceptance
6. ISSO clicks "Check Export Readiness" — receives a checklist of gaps before triggering export

## Functional Requirements

- **FR-001**: OSCAL POA&M export MUST use `oscal-version: 1.1.2` (upgrade from 1.0.6)
- **FR-002**: OSCAL Assessment Results export MUST use `oscal-version: 1.1.2`
- **FR-003**: `EmassExportReadiness` service MUST validate: `EmassId` populated, `DitprId` populated, SSP approval status, POA&M items have scheduled completion dates
- **FR-004**: `EmassRoundTripSync` MUST detect field conflicts and surface them — never silently overwrite SPIN data
- **FR-005**: `GET /api/systems/{id}/emass/status` MUST return last export timestamp, OSCAL version, readiness gaps count
- **FR-006**: `emass_get_workflow_status` MCP tool MUST be accessible to ISSO role
- **FR-007**: `emass_check_export_readiness` MCP tool MUST return a structured gaps list with remediation guidance per gap

## Technical Design Notes

Extends `EmassExportService` (existing) — OSCAL version constant updated in-place.
New `IEmassReadinessService` + `IEmassRoundTripSyncService` interfaces under `Ato.Copilot.Core/Interfaces/`.
New `EmassWorkflowStatusEndpoints.cs` under `Ato.Copilot.Mcp/Endpoints/`.
Data model: `EmassExportHistory` table (FK to `RegisteredSystem`) to track export versions.

## Architecture Decisions

| Decision | Chosen | Alternative | Reason |
|---|---|---|---|
| OSCAL upgrade strategy | In-place constant change in `EmassExportService` | New export service | Minimal diff, same code path, backward-compatible |
| Conflict resolution | User-driven (surface conflicts, ISSO decides) | Last-write-wins | eMASS is system of record — SPIN data may contain manual overrides that must not be lost |
| Readiness check location | Dedicated service + endpoint | Inline in export | Separating concerns allows pre-flight check without triggering export |

## Acceptance Criteria

```gherkin
Scenario: OSCAL version consistency
  Given an ISSM exports a POA&M from SPIN
  When the OSCAL JSON is inspected
  Then the metadata.oscal-version value is "1.1.2"

Scenario: Round-trip conflict detection
  Given a system with eMASS ID 12345 already onboarded in SPIN
  And the ISSO uploads a newer eMASS Excel where AC-2 implementation status differs
  When the sync service processes the import
  Then a conflict record is created for AC-2
  And SPIN's existing value is NOT overwritten

Scenario: Export readiness check
  Given a system with no DitprId set
  When the ISSO calls emass_check_export_readiness
  Then the result includes gap: "DitprId is required for eMASS submission"
  And status is "NotReady"
```

## Non-Functional Requirements

- OSCAL upgrade must not break existing SSP package tests (OscalValidationServiceTests)
- Round-trip sync diff must complete in <5s for systems with ≤500 controls
- All new endpoints require ISSO or ISSM role (RBAC enforced)

## Test Plan

- Unit: `EmassReadinessServiceTests` — test each gap condition
- Unit: `EmassRoundTripSyncTests` — conflict detection, no-conflict passthrough
- Unit: `EmassExportServiceTests` — verify OSCAL version 1.1.2 in POA&M and AR output
- Integration: `EmassWorkflowStatusEndpointTests` — full endpoint round-trip

## Definition of Done

- [ ] OSCAL POA&M and AR exports use 1.1.2
- [ ] `EmassExportReadiness` service validates all 4 required fields
- [ ] `EmassRoundTripSync` detects conflicts without overwriting
- [ ] `GET /api/systems/{id}/emass/status` endpoint live and tested
- [ ] MCP tools `emass_get_workflow_status` + `emass_check_export_readiness` registered
- [ ] All new unit tests pass
- [ ] No regressions in existing eMASS tests (EmassExportToolTests, EmassImportServiceTests)

## Explicit Constraints (DO NOT)

- DO NOT silently overwrite SPIN data during round-trip sync
- DO NOT introduce a new Excel library dependency (ClosedXML already in use)
- DO NOT couple this to Feature 041 (authorization package) — these are independent
- DO NOT expose eMASS credentials or system identifiers in logs

## Anti-patterns

- Adding eMASS-specific logic inside `EmassImportService` — use the new `EmassRoundTripSyncService` instead
- Version-branching the entire export service instead of upgrading the constant in-place
- UI-only readiness check — must be backend-enforced

## Existing File References

| File | Line(s) | Relevance |
|---|---|---|
| `src/Ato.Copilot.Agents/Compliance/Services/EmassExportService.cs` | ~1 | OSCAL version constant to upgrade |
| `src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Emass/EmassImportService.cs` | ~1 | Entry point for round-trip sync detection |
| `src/Ato.Copilot.Core/Models/Compliance/EmassModels.cs` | ~1 | Base models; `EmassExportHistory` entity to add |
| `src/Ato.Copilot.Core/Interfaces/Compliance/IEmassExportService.cs` | ~1 | Interface to extend with readiness method |
| `src/Ato.Copilot.Agents/Compliance/Tools/EmassExportTools.cs` | ~1 | Existing tools; new tools to register here |
| `specs/041-emass-package/spec.md` | ~1 | Related Feature 041 — authorization package |
