### PR TITLE
feat(#64): Feature 074 — Policy + Technical Narrative Split & Evidence Classification

### DIFF
--- a/specs/074-policy-technical-narrative/checklists/requirements.md
+++ b/specs/074-policy-technical-narrative/checklists/requirements.md
@@ -1,0 +1,99 @@
+# Requirements Checklist — 074: Policy + Technical Narrative Split & Evidence Classification
+
+---
+
+## 1. SDK Artifact Completeness
+
+| Artifact | File | Status |
+|----------|------|--------|
+| Spec (background, stories, FRs, NFRs, test plan, DoD) | `spec.md` | ✅ Present |
+| Tasks (phased, file paths, issue refs) | `tasks.md` | ✅ Present |
+| Data model (entity extensions, enum, migration, back-fill SQL, rollback) | `data-model.md` | ✅ Present |
+| Research (6 decision records R1–R6) | `research.md` | ✅ Present |
+| Plan (7-phase implementation plan with checkpoints) | `plan.md` | ✅ Present |
+| Quickstart (migration verify, curl examples, role-gate test, pitfalls) | `quickstart.md` | ✅ Present |
+| HTTP API contract (3 endpoints, all req/resp/errors) | `contracts/http-api.md` | ✅ Present |
+| MCP tools contract (3 tools, parameters, responses, registration) | `contracts/mcp-tools.md` | ✅ Present |
+| Requirements checklist | `checklists/requirements.md` | ✅ Present |
+
+**SDK artifact verdict: COMPLETE (9/9)**
+
+---
+
+## 2. Functional Requirements Coverage
+
+| ID | Requirement | Covered In | Verdict |
+|----|-------------|------------|---------|
+| FR-001 | `PolicyNarrative` + `TechnicalNarrative` additive nullable columns | data-model.md §1, tasks.md T002, T004 | ✅ |
+| FR-002 | `EvidenceNarrativeType` enum + `NarrativeType` column on `EvidenceArtifact` | data-model.md §2, tasks.md T001, T003 | ✅ |
+| FR-003 | Legacy `Narrative` back-filled to `TechnicalNarrative`; `MigratedFromLegacy = true` | data-model.md §4 back-fill SQL, tasks.md T005, spec.md US1 AC4 | ✅ |
+| FR-004 | `PATCH /api/systems/{id}/controls/{controlId}/narrative` partial update | contracts/http-api.md §2, tasks.md T009 | ✅ |
+| FR-005 | `GET /api/systems/{id}/controls/{controlId}/narrative` returns both halves + evidence split | contracts/http-api.md §1, tasks.md T008 | ✅ |
+| FR-006 | MCP tools `narrative_set_policy`, `narrative_set_technical`, `evidence_classify` | contracts/mcp-tools.md, tasks.md T011-T013 | ✅ |
+| FR-007 | SSP OSCAL + DOCX exports render both halves with canonical labels | spec.md FR-007, tasks.md T017, T018 | ✅ |
+| FR-008 | Auto-tagging classifier + bulk job for legacy evidence | spec.md FR-008, tasks.md T015, T016, research.md R3 | ✅ |
+| FR-009 | Role gate: PE/SCA → 403 on `policyNarrative` write | contracts/http-api.md §2, tasks.md T009, research.md R5 | ✅ |
+| FR-010 | Staleness rules: Policy stale on `OrgDefaultUpdated`, Technical event-based | spec.md FR-010, contracts/http-api.md §1 response | ✅ |
+
+**Functional requirements verdict: COMPLETE (10/10)**
+
+---
+
+## 3. Non-Functional Requirements Coverage
+
+| ID | Requirement | Covered In | Verdict |
+|----|-------------|------------|---------|
+| NFR-001 | Additive migration — zero data loss; rollback drops only new columns | data-model.md §4 Down(), research.md R1 | ✅ |
+| NFR-002 | PATCH p99 < 200 ms | spec.md NFR-002 | ✅ |
+| NFR-003 | All new columns nullable (no NOT NULL on existing tables) | data-model.md §4 migration, tasks.md T004 | ✅ |
+| NFR-004 | `EvidenceNarrativeType` defaults correct at DB level | data-model.md §4 defaultValue annotations + back-fill | ✅ |
+| NFR-005 | Legacy `Narrative` in API response as `legacyNarrative` | contracts/http-api.md §1, data-model.md §3 DualNarrativeResponse | ✅ |
+| NFR-006 | Classifier < 1 s per 1 000 rows | spec.md NFR-006, tasks.md T015 | ✅ |
+| NFR-007 | MCP tools follow `BaseTool` envelope | contracts/mcp-tools.md, tasks.md T011-T013 | ✅ |
+
+**Non-functional requirements verdict: COMPLETE (7/7)**
+
+---
+
+## 4. User Story Coverage
+
+| Story | Acceptance Scenarios | Test Task | Verdict |
+|-------|---------------------|-----------|---------|
+| US1 — Two first-class editors | AC1–AC4 | T019, T020 | ✅ |
+| US2 — Evidence tagged Policy/Technical | AC1–AC2 | T020, T021 | ✅ |
+| US3 — Role-based write gates | PE → 403 | T020 | ✅ |
+| US4 — SSP export both halves canonical | OSCAL + DOCX | T022 | ✅ |
+| US5 — MCP agent authoring | Tool invocation | contracts/mcp-tools.md | ✅ |
+
+**User story verdict: COMPLETE (5/5)**
+
+---
+
+## 5. Research Decision Records
+
+| ID | Question | Answered? |
+|----|----------|-----------|
+| R1 | Additive columns vs. new `ControlNarrative` table | ✅ |
+| R2 | Legacy `Narrative` rename vs. preserve | ✅ |
+| R3 | `EvidenceNarrativeType` default for new uploads | ✅ |
+| R4 | Back-fill legacy narrative to Technical vs. Legacy kind | ✅ |
+| R5 | Hard 403 vs. draft suggestion for PE on Policy | ✅ |
+| R6 | OSCAL statement IDs — `_smt.a/_smt.b` vs. `_smt.policy/_smt.technical` | ✅ |
+
+**Research verdict: COMPLETE (6/6)**
+
+---
+
+## 6. Open Questions (for `/clarify` before implementation)
+
+| # | Question | Default in Spec |
+|---|----------|-----------------|
+| Q1 | Approval ordering — must Policy be approved before Technical? | No gating (independent approvals) |
+| Q2 | Coherence-check trigger — auto on each Technical save, or only on demand? | On demand / final-approval gate |
+| Q3 | Both-half evidence in appendices — show in both appendices or separate Appendix C? | Show in both with footnote |
+| Q4 | CSP-inherited capabilities — always seed Policy only, or allow marking Technical too? | Policy only |
+| Q5 | Family-level cadence overrides — per deployment or per organization? | Per deployment (appsettings) |
+
+---
+
+**Overall checklist verdict: READY FOR IMPLEMENTATION**

--- a/specs/074-policy-technical-narrative/contracts/http-api.md
+++ b/specs/074-policy-technical-narrative/contracts/http-api.md
@@ -1,0 +1,222 @@
+# HTTP API Contract — 074: Policy + Technical Narrative Split
+
+All endpoints follow the existing ATO Copilot envelope pattern:
+
+```json
+{
+  "status": "success" | "error",
+  "data": <T>,
+  "metadata": { "executionTimeMs": number, "timestamp": "ISO-8601", "tool": null },
+  "error": { "errorCode": string, "message": string, "suggestion": string } | null
+}
+```
+
+Authentication: Bearer JWT (MSAL). All endpoints require an authenticated caller.
+Role constraints are noted per endpoint.
+
+---
+
+## 1. `GET /api/systems/{systemId}/controls/{controlId}/narrative`
+
+Returns both narrative halves plus evidence split by narrative type.
+
+### Authorization
+Any authenticated tenant user. No role restriction.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `systemId` | string | Yes | System GUID, name, or acronym |
+| `controlId` | string | Yes | NIST 800-53 control ID (e.g., `AC-2`, `AC-2(1)`) |
+
+### Response `200 OK`
+
+```json
+{
+  "status": "success",
+  "data": {
+    "systemId": "aaaaaaaa-0000-0000-0000-000000000001",
+    "controlId": "AC-2",
+    "policyNarrative": "The Account Management Policy (AMP-001) governs lifecycle for all users. Reviews occur annually.",
+    "technicalNarrative": "Azure AD Conditional Access policy 'Require MFA' enforces account management controls.",
+    "legacyNarrative": "We have an account management policy and Azure AD enforces lifecycle workflows.",
+    "migratedFromLegacy": true,
+    "policyEvidence": [
+      {
+        "id": "bbbbbbbb-0000-0000-0000-000000000001",
+        "fileName": "Account_Management_Policy_v3.0.pdf",
+        "contentType": "application/pdf",
+        "fileSizeBytes": 204800,
+        "narrativeType": 0,
+        "autoTagRationale": "Filename matches PolicyDocumentRegex",
+        "manuallyTaggedBy": null,
+        "uploadedAt": "2026-03-15T10:00:00Z"
+      }
+    ],
+    "technicalEvidence": [
+      {
+        "id": "cccccccc-0000-0000-0000-000000000001",
+        "fileName": "azure_policy_compliance_ac2.json",
+        "contentType": "application/json",
+        "fileSizeBytes": 8192,
+        "narrativeType": 1,
+        "autoTagRationale": "Source=AzurePolicy",
+        "manuallyTaggedBy": null,
+        "uploadedAt": "2026-05-01T08:00:00Z"
+      }
+    ],
+    "unclassifiedEvidence": [],
+    "isPolicyStale": false,
+    "isTechnicalStale": false,
+    "policyStaleReason": null,
+    "technicalStaleReason": null
+  },
+  "metadata": { "executionTimeMs": 18, "timestamp": "2026-06-11T00:00:00Z", "tool": null }
+}
+```
+
+### Response `404 Not Found`
+
+```json
+{
+  "status": "error",
+  "data": null,
+  "metadata": { "executionTimeMs": 5, "timestamp": "...", "tool": null },
+  "error": {
+    "errorCode": "NOT_FOUND",
+    "message": "No ControlImplementation found for system 'aaaa...' control 'AC-2'.",
+    "suggestion": "Verify the systemId and controlId are correct."
+  }
+}
+```
+
+---
+
+## 2. `PATCH /api/systems/{systemId}/controls/{controlId}/narrative`
+
+Partially updates one or both narrative halves. Omitted fields are left unchanged.
+
+### Authorization
+
+| Caller Role | `policyNarrative` | `technicalNarrative` |
+|-------------|-------------------|----------------------|
+| `Analyst` (ISSO/ISSM) | ✅ allowed | ✅ allowed |
+| `SecurityLead` (ISSM) | ✅ allowed | ✅ allowed |
+| `PlatformEngineer` | ❌ 403 | ✅ allowed |
+| `Sca` | ❌ 403 | ✅ allowed |
+| `AuditReader` | ❌ 403 | ❌ 403 |
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `systemId` | string | Yes | System GUID, name, or acronym |
+| `controlId` | string | Yes | NIST 800-53 control ID |
+
+### Request Body
+
+```json
+{
+  "policyNarrative": "The Account Management Policy (AMP-001) governs...",
+  "technicalNarrative": "Azure AD Conditional Access enforces..."
+}
+```
+
+Both fields are optional. Send only the field(s) you want to update.
+
+### Response `200 OK`
+
+Returns the same `DualNarrativeResponse` shape as GET (section 1 above), reflecting
+the updated values.
+
+### Response `403 Forbidden`
+
+```json
+{
+  "status": "error",
+  "data": null,
+  "metadata": { "executionTimeMs": 3, "timestamp": "...", "tool": null },
+  "error": {
+    "errorCode": "FORBIDDEN",
+    "message": "Role 'PlatformEngineer' is not permitted to write policyNarrative.",
+    "suggestion": "Ask your ISSM (Analyst role) to author the Policy narrative."
+  }
+}
+```
+
+### Response `400 Bad Request`
+
+```json
+{
+  "status": "error",
+  "data": null,
+  "metadata": { "executionTimeMs": 2, "timestamp": "...", "tool": null },
+  "error": {
+    "errorCode": "VALIDATION_ERROR",
+    "message": "policyNarrative exceeds maximum length of 8000 characters.",
+    "suggestion": "Shorten the narrative to 8000 characters or fewer."
+  }
+}
+```
+
+---
+
+## 3. `PATCH /api/evidence/{artifactId}/classify`
+
+Re-classifies an existing evidence artifact's narrative type.
+
+### Authorization
+Any authenticated tenant user with access to the system that owns the artifact.
+Manual re-tag always allowed (overrides auto-tag). Sets `manuallyTaggedBy = caller OID`,
+clears `autoTagRationale`.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `artifactId` | string | Yes | Evidence artifact GUID |
+
+### Request Body
+
+```json
+{
+  "narrativeType": 0,
+  "rationale": "This is the signed Account Management Policy PDF."
+}
+```
+
+| Field | Type | Required | Values |
+|-------|------|----------|--------|
+| `narrativeType` | integer | Yes | `0`=Policy, `1`=Technical, `2`=Combined, `3`=Unclassified |
+| `rationale` | string | No | Optional human-readable note stored in `AutoTagRationale` (cleared on next classifier run) |
+
+### Response `200 OK`
+
+```json
+{
+  "status": "success",
+  "data": {
+    "id": "cccccccc-0000-0000-0000-000000000001",
+    "fileName": "azure_policy_compliance_ac2.json",
+    "narrativeType": 0,
+    "autoTagRationale": "This is the signed Account Management Policy PDF.",
+    "manuallyTaggedBy": "john.doe@contoso.com"
+  },
+  "metadata": { "executionTimeMs": 6, "timestamp": "...", "tool": null }
+}
+```
+
+### Response `404 Not Found`
+Returns `NOT_FOUND` error if the artifact does not exist in the caller's tenant.
+
+---
+
+## 4. Error Codes
+
+| `errorCode` | HTTP Status | Description |
+|-------------|-------------|-------------|
+| `NOT_FOUND` | 404 | `ControlImplementation` or `EvidenceArtifact` does not exist in tenant |
+| `FORBIDDEN` | 403 | Caller role not permitted to write the requested field |
+| `VALIDATION_ERROR` | 400 | Input fails length or enum validation |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/specs/074-policy-technical-narrative/contracts/mcp-tools.md
+++ b/specs/074-policy-technical-narrative/contracts/mcp-tools.md
@@ -1,0 +1,180 @@
+# MCP Tools Contract — 074: Policy + Technical Narrative Split
+
+All tools follow the existing ATO Copilot `BaseTool` response envelope:
+
+```json
+{
+  "status": "success" | "error",
+  "data": <T>,
+  "metadata": { "executionTimeMs": number, "timestamp": "ISO-8601", "tool": "<tool-name>" },
+  "error": { "errorCode": string, "message": string, "suggestion": string } | null
+}
+```
+
+Three new tools are added in this feature. All are registered in
+`Ato.Copilot.Agents.Compliance` alongside existing narrative tools.
+
+---
+
+## Tool 1 — `narrative_set_policy`
+
+**File:** `src/Ato.Copilot.Agents/Compliance/Tools/NarrativePolicyTool.cs`
+**Class:** `NarrativePolicyTool`
+
+### Description
+
+Author or update the **Policy/Procedural** narrative half for a NIST control. Captures
+org-level governance: who owns the control, what the written policy says, review frequency,
+role assignments, and policy document citations. The Technical half is left unchanged.
+
+ISSO/ISSM roles only. PlatformEngineer and SCA callers will receive an error.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `system_id` | string | ✅ | System GUID, name, or acronym |
+| `control_id` | string | ✅ | NIST 800-53 control ID (e.g., `AC-2`, `IA-5(1)`) |
+| `policy_narrative` | string | ✅ | Full text of the Policy narrative (max 8 000 chars) |
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "systemId": "aaaaaaaa-0000-0000-0000-000000000001",
+    "controlId": "AC-2",
+    "policyNarrative": "The Account Management Policy (AMP-001)..."
+  },
+  "metadata": { "executionTimeMs": 45, "timestamp": "2026-06-11T00:00:00Z", "tool": "narrative_set_policy" }
+}
+```
+
+### Error Responses
+
+| `errorCode` | Condition |
+|-------------|-----------|
+| `INVALID_INPUT` | `system_id`, `control_id`, or `policy_narrative` missing or blank |
+| `NOT_FOUND` | System or control not found in caller's tenant |
+| `FORBIDDEN` | Caller role is not permitted to write Policy narratives |
+| `VALIDATION_ERROR` | `policy_narrative` exceeds 8 000 characters |
+
+---
+
+## Tool 2 — `narrative_set_technical`
+
+**File:** `src/Ato.Copilot.Agents/Compliance/Tools/NarrativeTechnicalTool.cs`
+**Class:** `NarrativeTechnicalTool`
+
+### Description
+
+Author or update the **Technical/Implementation** narrative half for a NIST control.
+Captures system-level configuration: cloud config, automated controls, scan output,
+Conditional Access rules, RBAC assignments, CI/CD gates. The Policy half is left unchanged.
+
+Available to ISSO, ISSM, SCA, and PlatformEngineer roles.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `system_id` | string | ✅ | System GUID, name, or acronym |
+| `control_id` | string | ✅ | NIST 800-53 control ID |
+| `technical_narrative` | string | ✅ | Full text of the Technical narrative (max 8 000 chars) |
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "systemId": "aaaaaaaa-0000-0000-0000-000000000001",
+    "controlId": "AC-2",
+    "technicalNarrative": "Azure AD Conditional Access policy 'Require MFA'..."
+  },
+  "metadata": { "executionTimeMs": 38, "timestamp": "2026-06-11T00:00:00Z", "tool": "narrative_set_technical" }
+}
+```
+
+### Error Responses
+
+| `errorCode` | Condition |
+|-------------|-----------|
+| `INVALID_INPUT` | `system_id`, `control_id`, or `technical_narrative` missing or blank |
+| `NOT_FOUND` | System or control not found in caller's tenant |
+| `VALIDATION_ERROR` | `technical_narrative` exceeds 8 000 characters |
+
+---
+
+## Tool 3 — `evidence_classify`
+
+**File:** `src/Ato.Copilot.Agents/Compliance/Tools/EvidenceClassifyTool.cs`
+**Class:** `EvidenceClassifyTool`
+
+### Description
+
+Manually classify an existing `EvidenceArtifact` as supporting the Policy half, Technical
+half, both (Combined), or mark as Unclassified. Overwrites any prior auto-tag. Records the
+caller as `ManuallyTaggedBy` and clears the classifier's `AutoTagRationale`.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evidence_artifact_id` | string | ✅ | Evidence artifact GUID |
+| `narrative_type` | string | ✅ | One of: `"Policy"`, `"Technical"`, `"Combined"`, `"Unclassified"` |
+| `rationale` | string | ❌ | Optional human-readable explanation stored in `AutoTagRationale` |
+
+### Parameter Notes
+
+- `narrative_type` is case-insensitive. `"policy"`, `"POLICY"`, and `"Policy"` all map to `EvidenceNarrativeType.Policy`.
+- Sending `"Unclassified"` effectively un-classifies the artifact and removes the prior
+  manual tag (sets `ManuallyTaggedBy = null`).
+
+### Success Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "evidenceArtifactId": "cccccccc-0000-0000-0000-000000000001",
+    "fileName": "Account_Management_Policy_v3.0.pdf",
+    "narrativeType": "Policy",
+    "autoTagRationale": "Manual: confirmed this is the signed policy document.",
+    "manuallyTaggedBy": "john.doe@contoso.com",
+    "classifiedAt": "2026-06-11T00:00:00Z"
+  },
+  "metadata": { "executionTimeMs": 22, "timestamp": "2026-06-11T00:00:00Z", "tool": "evidence_classify" }
+}
+```
+
+### Error Responses
+
+| `errorCode` | Condition |
+|-------------|-----------|
+| `INVALID_INPUT` | `evidence_artifact_id` or `narrative_type` missing; `narrative_type` not a recognized value |
+| `NOT_FOUND` | Artifact does not exist in caller's tenant |
+
+---
+
+## Tool Registration
+
+Register all three tools in the agent DI setup (find existing narrative tool registrations
+by searching for `NarrativeHistoryTool` in the MCP startup/DI file):
+
+```csharp
+// Add alongside NarrativeHistoryTool, NarrativeGovernanceTool, etc.
+services.AddScoped<NarrativePolicyTool>();
+services.AddScoped<NarrativeTechnicalTool>();
+services.AddScoped<EvidenceClassifyTool>();
+```
+
+And add to the tool list exposed by the agent:
+
+```csharp
+// In the tool manifest builder / agent tool factory
+tools.Add(provider.GetRequiredService<NarrativePolicyTool>());
+tools.Add(provider.GetRequiredService<NarrativeTechnicalTool>());
+tools.Add(provider.GetRequiredService<EvidenceClassifyTool>());
+```

--- a/specs/074-policy-technical-narrative/data-model.md
+++ b/specs/074-policy-technical-narrative/data-model.md
@@ -1,0 +1,320 @@
+# Data Model — 074: Policy + Technical Narrative Split & Evidence Classification
+
+---
+
+## 1. `ControlImplementation` Extensions (Additive — `SspModels.cs`)
+
+### 1.1 New Properties
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Compliance/SspModels.cs
+// Insert after the existing `Narrative` property (line ~44)
+
+/// <summary>
+/// Feature 052 (#64): policy/procedural narrative half (up to 8000 chars).
+/// Captures org-level governance: who owns the control, what the written policy says,
+/// review frequency, role assignments, and policy document citations.
+/// Nullable — null means "not yet authored".
+/// Do NOT rename the existing <see cref="Narrative"/> field above; this is additive.
+/// </summary>
+[MaxLength(8000)]
+public string? PolicyNarrative { get; set; }
+
+/// <summary>
+/// Feature 052 (#64): technical/implementation narrative half (up to 8000 chars).
+/// Captures system-level implementation: cloud config, automated controls, scan output,
+/// Conditional Access rules, RBAC, CI/CD gates.
+/// Back-filled from <see cref="Narrative"/> during the additive migration when
+/// <see cref="MigratedFromLegacy"/> is set to true.
+/// </summary>
+[MaxLength(8000)]
+public string? TechnicalNarrative { get; set; }
+
+/// <summary>
+/// Feature 052 (#64): true when <see cref="TechnicalNarrative"/> was automatically
+/// populated from the legacy <see cref="Narrative"/> field during migration.
+/// Allows audit trail to distinguish migrated vs. freshly-authored content.
+/// </summary>
+public bool MigratedFromLegacy { get; set; }
+```
+
+### 1.2 No Breaking Changes
+- `Narrative` (the original field) is **not renamed, not removed, and not made non-nullable**.
+- It remains the "combined / legacy" field for backward compatibility.
+- The REST response includes it as `legacyNarrative` for clients that have not upgraded.
+
+---
+
+## 2. `EvidenceArtifact` Extensions (Additive — `EvidenceArtifactModels.cs`)
+
+### 2.1 New Enum: `EvidenceNarrativeType`
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs
+// Insert after EvidenceCategory enum (around line 235)
+
+/// <summary>
+/// Feature 052 (#64): which narrative half a given EvidenceArtifact supports.
+/// Applied at upload time by the caller or retroactively by the auto-tagging classifier.
+/// </summary>
+public enum EvidenceNarrativeType
+{
+    /// <summary>
+    /// Artifact supports the Policy/Procedural half.
+    /// Examples: signed policy PDF, meeting minutes, training roster, SOP document.
+    /// </summary>
+    Policy = 0,
+
+    /// <summary>
+    /// Artifact supports the Technical/Implementation half.
+    /// Examples: Azure Policy export, Defender snapshot, SCAP result, screenshot.
+    /// </summary>
+    Technical = 1,
+
+    /// <summary>
+    /// Artifact supports both halves equally.
+    /// Default for existing/legacy artifacts after migration back-fill.
+    /// </summary>
+    Combined = 2,
+
+    /// <summary>
+    /// Not yet classified. Default for new uploads until tagged by caller or classifier.
+    /// </summary>
+    Unclassified = 3
+}
+```
+
+### 2.2 New Properties on `EvidenceArtifact`
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Compliance/EvidenceArtifactModels.cs
+// Insert after the CollectionMethod property, before the Navigation section
+
+// ─── Feature 052 (#64): Narrative-half classification ────────────────────────
+
+/// <summary>
+/// Which narrative half this artifact supports.
+/// Default: Unclassified (3) for new uploads.
+/// Migration back-fill: Combined (2) for all existing rows.
+/// </summary>
+public EvidenceNarrativeType NarrativeType { get; set; } = EvidenceNarrativeType.Unclassified;
+
+/// <summary>
+/// Plain-text rationale written by the auto-tagging classifier.
+/// Null when the artifact was manually tagged or not yet classified.
+/// Examples: "Filename matches PolicyDocumentRegex", "Source=AzurePolicy", "LowConfidence".
+/// </summary>
+[MaxLength(500)]
+public string? AutoTagRationale { get; set; }
+
+/// <summary>
+/// OID of the user who manually re-tagged this artifact.
+/// Set on manual override; clears <see cref="AutoTagRationale"/>.
+/// Null for auto-tagged or never-overridden artifacts.
+/// </summary>
+[MaxLength(200)]
+public string? ManuallyTaggedBy { get; set; }
+```
+
+---
+
+## 3. DTOs — `NarrativeDualDtos.cs`
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Compliance/NarrativeDualDtos.cs
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+/// <summary>
+/// Feature 052 (#64): request body for PATCH dual-narrative endpoint.
+/// Both fields are optional — omit to leave the corresponding half unchanged.
+/// </summary>
+public record PatchDualNarrativeRequest(
+    string? PolicyNarrative,
+    string? TechnicalNarrative);
+
+/// <summary>
+/// Feature 052 (#64): response shape for GET + PATCH dual-narrative endpoints.
+/// </summary>
+public record DualNarrativeResponse(
+    string SystemId,
+    string ControlId,
+
+    /// <summary>Policy/procedural narrative. Null = not yet authored.</summary>
+    string? PolicyNarrative,
+
+    /// <summary>Technical/implementation narrative. Null = not yet authored.</summary>
+    string? TechnicalNarrative,
+
+    /// <summary>
+    /// Original combined narrative preserved for backward compatibility.
+    /// Clients that have not upgraded should fall back to this field.
+    /// </summary>
+    string? LegacyNarrative,
+
+    bool MigratedFromLegacy,
+
+    /// <summary>Evidence artifacts tagged as Policy or Combined.</summary>
+    List<EvidenceArtifactSummary> PolicyEvidence,
+
+    /// <summary>Evidence artifacts tagged as Technical or Combined.</summary>
+    List<EvidenceArtifactSummary> TechnicalEvidence,
+
+    /// <summary>Evidence artifacts tagged as Unclassified (pending classification).</summary>
+    List<EvidenceArtifactSummary> UnclassifiedEvidence,
+
+    /// <summary>True if the PolicyNarrative is stale (e.g., OrgDefault changed).</summary>
+    bool IsPolicyStale,
+
+    /// <summary>True if the TechnicalNarrative is stale.</summary>
+    bool IsTechnicalStale,
+
+    string? PolicyStaleReason,
+    string? TechnicalStaleReason);
+
+/// <summary>
+/// Feature 052 (#64): slim summary of an evidence artifact for narrative responses.
+/// </summary>
+public record EvidenceArtifactSummary(
+    string Id,
+    string FileName,
+    string ContentType,
+    long FileSizeBytes,
+    EvidenceNarrativeType NarrativeType,
+    string? AutoTagRationale,
+    string? ManuallyTaggedBy,
+    DateTime UploadedAt);
+```
+
+---
+
+## 4. EF Core Migration
+
+### 4.1 Migration Name
+```
+Feature052_PolicyTechnicalNarrativeSplit
+```
+
+### 4.2 `Up()` Method
+
+```csharp
+// Additive columns on ControlImplementations
+migrationBuilder.AddColumn<string>(
+    name: "PolicyNarrative",
+    table: "ControlImplementations",
+    type: "nvarchar(8000)",
+    maxLength: 8000,
+    nullable: true);
+
+migrationBuilder.AddColumn<string>(
+    name: "TechnicalNarrative",
+    table: "ControlImplementations",
+    type: "nvarchar(8000)",
+    maxLength: 8000,
+    nullable: true);
+
+migrationBuilder.AddColumn<bool>(
+    name: "MigratedFromLegacy",
+    table: "ControlImplementations",
+    type: "bit",
+    nullable: false,
+    defaultValue: false);
+
+// Additive columns on EvidenceArtifacts
+migrationBuilder.AddColumn<int>(
+    name: "NarrativeType",
+    table: "EvidenceArtifacts",
+    type: "int",
+    nullable: false,
+    defaultValue: 3); // Unclassified — for NEW rows only
+
+migrationBuilder.AddColumn<string>(
+    name: "AutoTagRationale",
+    table: "EvidenceArtifacts",
+    type: "nvarchar(500)",
+    maxLength: 500,
+    nullable: true);
+
+migrationBuilder.AddColumn<string>(
+    name: "ManuallyTaggedBy",
+    table: "EvidenceArtifacts",
+    type: "nvarchar(200)",
+    maxLength: 200,
+    nullable: true);
+
+// ─── Back-fill ────────────────────────────────────────────────────────────────
+
+// Copy legacy Narrative → TechnicalNarrative for existing rows
+migrationBuilder.Sql(
+    "UPDATE ControlImplementations " +
+    "SET TechnicalNarrative = Narrative, MigratedFromLegacy = 1 " +
+    "WHERE Narrative IS NOT NULL");
+
+// Existing evidence rows → Combined (2), not Unclassified (3)
+// The column default of 3 applies only to rows inserted after this migration.
+migrationBuilder.Sql(
+    "UPDATE EvidenceArtifacts SET NarrativeType = 2");
+```
+
+### 4.3 `Down()` Method (Rollback)
+
+```csharp
+migrationBuilder.DropColumn(name: "PolicyNarrative", table: "ControlImplementations");
+migrationBuilder.DropColumn(name: "TechnicalNarrative", table: "ControlImplementations");
+migrationBuilder.DropColumn(name: "MigratedFromLegacy", table: "ControlImplementations");
+migrationBuilder.DropColumn(name: "NarrativeType", table: "EvidenceArtifacts");
+migrationBuilder.DropColumn(name: "AutoTagRationale", table: "EvidenceArtifacts");
+migrationBuilder.DropColumn(name: "ManuallyTaggedBy", table: "EvidenceArtifacts");
+```
+
+### 4.4 SQL Equivalents (Raw — for SQLite dev / MSSQL prod reference)
+
+```sql
+-- ControlImplementations
+ALTER TABLE ControlImplementations ADD PolicyNarrative NVARCHAR(8000) NULL;
+ALTER TABLE ControlImplementations ADD TechnicalNarrative NVARCHAR(8000) NULL;
+ALTER TABLE ControlImplementations ADD MigratedFromLegacy BIT NOT NULL DEFAULT 0;
+
+-- Back-fill
+UPDATE ControlImplementations
+SET TechnicalNarrative = Narrative, MigratedFromLegacy = 1
+WHERE Narrative IS NOT NULL;
+
+-- EvidenceArtifacts
+ALTER TABLE EvidenceArtifacts ADD NarrativeType INT NOT NULL DEFAULT 3;
+ALTER TABLE EvidenceArtifacts ADD AutoTagRationale NVARCHAR(500) NULL;
+ALTER TABLE EvidenceArtifacts ADD ManuallyTaggedBy NVARCHAR(200) NULL;
+
+-- Back-fill existing rows to Combined
+UPDATE EvidenceArtifacts SET NarrativeType = 2;
+```
+
+---
+
+## 5. Indexes
+
+No new indexes required in Phase 1.
+
+**Future consideration (post-MVP):** Index on `EvidenceArtifacts(NarrativeType)` if the
+evidence split query becomes a hot path. Defer until query profiling shows it is needed.
+
+---
+
+## 6. Row-Level Security (RLS)
+
+No new RLS rules. The existing `TenantScoped` attribute on both `ControlImplementation` and
+`EvidenceArtifact` covers tenant isolation for the new columns automatically. The role-based
+write gate for `PolicyNarrative` is enforced in application code (middleware), not at the DB level.
+
+---
+
+## 7. Backward Compatibility Guarantee
+
+| Change | Impact | Safe? |
+|--------|--------|-------|
+| `PolicyNarrative` column added (nullable) | Existing EF queries select `NULL` for new column | ✅ |
+| `TechnicalNarrative` column added (nullable) | Same as above | ✅ |
+| `MigratedFromLegacy` column added (NOT NULL, default false) | EF default prevents insert failures | ✅ |
+| `Narrative` field unchanged | No renaming, no removal | ✅ |
+| `NarrativeType` added to `EvidenceArtifact` (NOT NULL, default 3) | Existing uploads get Unclassified; back-fill sets to Combined | ✅ |
+| `AutoTagRationale` / `ManuallyTaggedBy` nullable columns | Transparent to existing code | ✅ |

--- a/specs/074-policy-technical-narrative/plan.md
+++ b/specs/074-policy-technical-narrative/plan.md
@@ -1,0 +1,136 @@
+# Plan — 074: Policy + Technical Narrative Split & Evidence Classification
+
+---
+
+## Overview
+
+7-phase plan. Each phase has a hard checkpoint: `dotnet build` must pass before the next
+phase begins. All phases target branch `074-policy-technical-narrative`.
+
+---
+
+## Phase 1 — Data Model (Sprint 1, Days 1–2)
+
+**Goal:** New columns and enum defined in C#. No migration yet.
+
+**Tasks:** T001, T002, T003
+
+**Work:**
+1. Add `EvidenceNarrativeType` enum to `ComplianceModels.cs` (after `EvidenceCategory`)
+2. Add `PolicyNarrative`, `TechnicalNarrative`, `MigratedFromLegacy` to `ControlImplementation`
+3. Add `NarrativeType`, `AutoTagRationale`, `ManuallyTaggedBy` to `EvidenceArtifact`
+4. Create `NarrativeDualDtos.cs` with `PatchDualNarrativeRequest`, `DualNarrativeResponse`,
+   `EvidenceArtifactSummary` records (T010)
+
+**Checkpoint 1:** `dotnet build Ato.Copilot.sln` passes with zero errors. No migration
+applied yet.
+
+---
+
+## Phase 2 — EF Core Migration (Sprint 1, Days 2–3)
+
+**Goal:** Schema change applied to dev database. Back-fill verified.
+
+**Tasks:** T004, T005
+
+**Work:**
+1. Run `dotnet ef migrations add Feature052_PolicyTechnicalNarrativeSplit`
+2. Review generated migration file — confirm all six `AddColumn` calls and no unexpected changes
+3. Add back-fill SQL to migration `Up()` (T005)
+4. Apply migration: `dotnet ef database update`
+5. Spot-check with SQLite query: `SELECT Id, Narrative, TechnicalNarrative, MigratedFromLegacy FROM ControlImplementations LIMIT 5`
+
+**Checkpoint 2:** Migration file exists. `dotnet ef database update` succeeds on dev SQLite.
+Existing rows have `TechnicalNarrative = Narrative` and `MigratedFromLegacy = 1` where
+`Narrative IS NOT NULL`. New `EvidenceArtifact` rows get `NarrativeType = 3` (Unclassified);
+existing rows get `NarrativeType = 2` (Combined) from back-fill.
+
+---
+
+## Phase 3 — HTTP Endpoints (Sprint 1, Days 3–5)
+
+**Goal:** GET and PATCH endpoints functional with correct auth and audit logging.
+
+**Tasks:** T006, T007, T008, T009, T010
+
+**Work:**
+1. Create `NarrativeDualEndpoints.cs` with stub route handlers
+2. Register `MapNarrativeDualEndpoints()` in startup
+3. Implement `GetDualNarrativeAsync` — EF query + evidence split projection
+4. Implement `PatchDualNarrativeAsync` — partial update + role gate + audit log
+5. Create `EvidenceClassifyEndpoint.cs` + `MapEvidenceClassifyEndpoint()` (T014)
+
+**Checkpoint 3:** `dotnet build` passes. `GET /api/systems/{id}/controls/AC-2/narrative`
+returns 200 with `policyNarrative`, `technicalNarrative`, and split evidence lists.
+`PATCH` with only `policyNarrative` leaves `technicalNarrative` unchanged. PlatformEngineer
+JWT receives 403 on Policy write.
+
+---
+
+## Phase 4 — MCP Tools (Sprint 2, Days 1–2)
+
+**Goal:** Three new MCP tools registered and callable by agents.
+
+**Tasks:** T011, T012, T013, T014
+
+**Work:**
+1. Create `NarrativePolicyTool.cs` — `narrative_set_policy`
+2. Create `NarrativeTechnicalTool.cs` — `narrative_set_technical`
+3. Create `EvidenceClassifyTool.cs` — `evidence_classify`
+4. Register all three tools in the MCP agent DI registration (search for existing
+   `NarrativeHistoryTool` registration to find the right file)
+
+**Checkpoint 4:** All three tools appear in the agent's tool manifest. `narrative_set_policy`
+can be invoked via the MCP test harness and returns success envelope.
+
+---
+
+## Phase 5 — Auto-Tagger Service (Sprint 2, Days 2–3)
+
+**Goal:** Classifier service implemented; bulk-tag job runnable.
+
+**Tasks:** T015, T016
+
+**Work:**
+1. Create `IEvidenceNarrativeClassifier` interface
+2. Implement `EvidenceNarrativeClassifier` with source-based rules + filename regex
+3. Create `EvidenceNarrativeBulkClassifierJob` for one-time backfill
+4. Register classifier in DI
+
+**Checkpoint 5:** Unit test T021 passes (200 test artifacts tagged correctly). Bulk job
+produces summary log line.
+
+---
+
+## Phase 6 — SSP Export Integration (Sprint 2, Days 3–5)
+
+**Goal:** OSCAL and DOCX exports render both halves with canonical labels.
+
+**Tasks:** T017, T018
+
+**Work:**
+1. Locate OSCAL export service — search `_smt.` or `implemented-requirements` in codebase
+2. Add `_smt.policy` + `_smt.technical` statement entries (Policy first, Technical second)
+3. Locate DOCX/QuestPDF export service — search `Implementation Statement` in codebase
+4. Insert two labeled subsections per control; read placeholder from `appsettings.json`
+
+**Checkpoint 6:** Integration test T022 passes. OSCAL JSON has both `statement-id` values.
+DOCX has two labeled subsections. Missing halves render placeholder string.
+
+---
+
+## Phase 7 — Tests & Cleanup (Sprint 3, Days 1–2)
+
+**Goal:** All acceptance scenarios pass; spec files merged.
+
+**Tasks:** T019, T020, T021, T022
+
+**Work:**
+1. Write and run integration test T019 (migration)
+2. Write and run integration test T020 (endpoint PATCH/GET + role gate)
+3. Confirm unit test T021 (classifier)
+4. Write and run integration test T022 (OSCAL export)
+5. PR review, address feedback, merge to `main`
+
+**Checkpoint 7 (Final):** `dotnet test Ato.Copilot.sln` passes with zero failures.
+All Definition of Done checklist items in `spec.md` checked.

--- a/specs/074-policy-technical-narrative/quickstart.md
+++ b/specs/074-policy-technical-narrative/quickstart.md
@@ -1,0 +1,195 @@
+# Quickstart — 074: Policy + Technical Narrative Split & Evidence Classification
+
+This guide covers local development verification, migration verification, and end-to-end
+testing for Feature 052 (#64).
+
+---
+
+## Prerequisites
+
+```bash
+# From repo root
+dotnet build Ato.Copilot.sln
+dotnet test  Ato.Copilot.sln
+
+# Dashboard (Vite dev server)
+cd src/Ato.Copilot.Dashboard
+npm ci
+npm run dev
+```
+
+---
+
+## 1. Apply the Migration (Dev — SQLite)
+
+```bash
+# From repo root
+dotnet ef migrations add Feature052_PolicyTechnicalNarrativeSplit \
+  --project src/Ato.Copilot.Core \
+  --startup-project src/Ato.Copilot.Mcp
+
+# Review the generated migration file — confirm 6 AddColumn calls
+# and the two Sql() back-fill statements
+
+dotnet ef database update \
+  --project src/Ato.Copilot.Core \
+  --startup-project src/Ato.Copilot.Mcp
+
+# Verify new columns exist
+sqlite3 data/ato-copilot.db ".schema ControlImplementations" | grep -E 'PolicyNarrative|TechnicalNarrative|MigratedFromLegacy'
+sqlite3 data/ato-copilot.db ".schema EvidenceArtifacts" | grep -E 'NarrativeType|AutoTagRationale|ManuallyTaggedBy'
+```
+
+**Expected output (ControlImplementations):**
+```
+"PolicyNarrative" TEXT,
+"TechnicalNarrative" TEXT,
+"MigratedFromLegacy" INTEGER NOT NULL DEFAULT 0,
+```
+
+---
+
+## 2. Verify Back-Fill
+
+```bash
+# Verify TechnicalNarrative was populated from legacy Narrative
+sqlite3 data/ato-copilot.db \
+  "SELECT Id, substr(Narrative,1,40), substr(TechnicalNarrative,1,40), MigratedFromLegacy \
+   FROM ControlImplementations \
+   WHERE Narrative IS NOT NULL LIMIT 5;"
+```
+
+Expected: `TechnicalNarrative` matches the first 40 chars of `Narrative` for each row,
+and `MigratedFromLegacy = 1`.
+
+```bash
+# Verify existing EvidenceArtifacts got Combined (2), not Unclassified (3)
+sqlite3 data/ato-copilot.db \
+  "SELECT NarrativeType, COUNT(*) FROM EvidenceArtifacts GROUP BY NarrativeType;"
+```
+
+Expected: all rows show `NarrativeType = 2` (Combined).
+
+---
+
+## 3. Dual Narrative GET Endpoint
+
+```bash
+# Authenticate and get a JWT first (use your local dev token)
+TOKEN="<your-dev-JWT>"
+SYSTEM_ID="<a-registered-system-id-from-your-dev-db>"
+
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:5000/api/systems/$SYSTEM_ID/controls/AC-2/narrative" | jq .
+```
+
+**Expected response shape:**
+```json
+{
+  "status": "success",
+  "data": {
+    "systemId": "...",
+    "controlId": "AC-2",
+    "policyNarrative": null,
+    "technicalNarrative": "... (back-filled from legacy Narrative) ...",
+    "legacyNarrative": "... (original Narrative, unchanged) ...",
+    "migratedFromLegacy": true,
+    "policyEvidence": [],
+    "technicalEvidence": [],
+    "unclassifiedEvidence": [],
+    "isPolicyStale": false,
+    "isTechnicalStale": false,
+    "policyStaleReason": null,
+    "technicalStaleReason": null
+  },
+  "metadata": { "executionTimeMs": 12, "timestamp": "..." }
+}
+```
+
+---
+
+## 4. Dual Narrative PATCH — Technical Half Only
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"technicalNarrative": "Azure AD Conditional Access enforces MFA for all AC-2 user accounts."}' \
+  "http://localhost:5000/api/systems/$SYSTEM_ID/controls/AC-2/narrative" | jq .data.technicalNarrative
+```
+
+Expected: `"Azure AD Conditional Access enforces MFA for all AC-2 user accounts."`.
+`policyNarrative` must remain `null` (unchanged).
+
+---
+
+## 5. Role Gate — PlatformEngineer → 403 on Policy Write
+
+```bash
+PE_TOKEN="<a-JWT-for-a-PlatformEngineer-role>"
+
+curl -s -X PATCH \
+  -H "Authorization: Bearer $PE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"policyNarrative": "Attempting to write policy as Engineer."}' \
+  "http://localhost:5000/api/systems/$SYSTEM_ID/controls/AC-2/narrative" | jq .status
+
+# Expected: "error" with errorCode "FORBIDDEN"
+```
+
+---
+
+## 6. Evidence Classify Endpoint
+
+```bash
+ARTIFACT_ID="<an-evidence-artifact-id>"
+
+curl -s -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"narrativeType": 0, "rationale": "Manual: this is the AC-2 Policy PDF"}' \
+  "http://localhost:5000/api/evidence/$ARTIFACT_ID/classify" | jq .
+```
+
+Expected: artifact's `narrativeType` updated to `0` (Policy), `autoTagRationale` cleared,
+`manuallyTaggedBy` set to caller OID.
+
+---
+
+## 7. MCP Tool — `narrative_set_policy`
+
+Via MCP test harness or `curl` to the MCP endpoint:
+
+```json
+{
+  "tool": "narrative_set_policy",
+  "arguments": {
+    "system_id": "<system-id>",
+    "control_id": "AC-2",
+    "policy_narrative": "The Account Management Policy (AMP-001) governs account lifecycle for all system users. Reviews occur annually per FISMA requirements. The ISSM is the policy owner."
+  }
+}
+```
+
+Expected response:
+```json
+{
+  "status": "success",
+  "data": {
+    "controlId": "AC-2",
+    "policyNarrative": "The Account Management Policy..."
+  }
+}
+```
+
+---
+
+## 8. Known Pitfalls
+
+| Pitfall | Mitigation |
+|---------|-----------|
+| Running `dotnet ef migrations add` without reviewing the generated file first — the back-fill SQL must be manually added (T005) | Always open the migration file after generation and add the `Sql()` calls before applying |
+| `NarrativeType = 3` (Unclassified) appears on existing evidence after migration | The back-fill `UPDATE EvidenceArtifacts SET NarrativeType = 2` in `Up()` corrects this; verify with the `GROUP BY` query in Step 2 above |
+| PlatformEngineer can still write `technicalNarrative` when `policyNarrative` is also included in the body | The role gate checks whether `policyNarrative` is non-null; strip it from the body to test Technical-only write |
+| OSCAL export inserts `_smt.policy` but old consumers expect `_smt.a` | See research.md R6 — `_smt.policy/_smt.technical` is the chosen convention; consumers need updating if they hard-code `_smt.a` |
+| Bulk classifier job re-runs override manual tags | The job skips rows where `ManuallyTaggedBy IS NOT NULL` — verify this guard is in place before running |

--- a/specs/074-policy-technical-narrative/research.md
+++ b/specs/074-policy-technical-narrative/research.md
@@ -1,0 +1,152 @@
+# Research — 074: Policy + Technical Narrative Split & Evidence Classification
+
+Decision records for architectural choices in Feature 052 (#64).
+
+---
+
+## R1: Additive Columns vs. New `ControlNarrative` Table
+
+**Question:** Should the two new narrative halves be stored as columns on
+`ControlImplementation` (additive) or as rows in a new `ControlNarrative` table
+(using a `NarrativeKind` discriminator row-per-half pattern)?
+
+**Answer: Additive columns on `ControlImplementation`.**
+
+### Evidence
+
+The issue body for #64 states: "Add `PolicyNarrative` + `TechnicalNarrative` as ADDITIONAL
+nullable columns (migration-safe additive change). The existing `Narrative` field becomes the
+'combined/legacy' field."
+
+A separate `ControlNarrative` table would:
+1. Require a JOIN on every SSP render, adding query complexity.
+2. Break the existing unique constraint on `(RegisteredSystemId, ControlId)`.
+3. Force every consumer of `ControlImplementation` to be updated.
+4. Create an unbounded row count if future halves are ever added (though they are out of scope).
+
+Two nullable nullable columns are:
+- **Zero-downtime** — deploy the code, then run the migration; existing rows read `NULL`.
+- **Rollback-safe** — `Down()` drops two columns with no data loss to the original `Narrative`.
+- **Query-transparent** — all existing `SELECT * FROM ControlImplementations` queries continue
+  to work; consumers that don't need the new columns see `NULL` without modification.
+
+**Decision: R1 — Additive nullable columns. No new table.**
+
+---
+
+## R2: Legacy `Narrative` Disposition
+
+**Question:** Should the existing `Narrative` field be renamed to `TechnicalNarrative`
+(breaking change) or kept as-is (additive)?
+
+**Answer: Keep `Narrative` as-is. Do NOT rename.**
+
+### Rationale
+
+Renaming `Narrative` to any other field name is a breaking change for:
+1. All existing EF Core queries that reference `.Narrative` by name.
+2. All REST API clients that consume `narrative` from the JSON response.
+3. All MCP tools that pass `narrative` to existing endpoints.
+4. All SSP export code that references `ci.Narrative`.
+
+The migration strategy instead:
+- Back-fills `TechnicalNarrative = Narrative` for all rows where `Narrative IS NOT NULL`.
+- Sets `MigratedFromLegacy = true` on those rows.
+- Leaves `Narrative` unchanged — consumers that haven't upgraded see the same value.
+- New API response shape exposes `legacyNarrative` (maps from `Narrative`) for backward compat.
+
+**Decision: R2 — `Narrative` field preserved as "combined/legacy". No rename.**
+
+---
+
+## R3: `EvidenceNarrativeType` Default for New Uploads
+
+**Question:** Should new `EvidenceArtifact` uploads default to `Unclassified` (3) or
+`Technical` (1) since most auto-collected evidence is technical in nature?
+
+**Answer: `Unclassified` (3).**
+
+### Rationale
+
+Defaulting to `Technical` would silently mislabel manually-uploaded policy documents until
+the user explicitly re-tags them. `Unclassified` is honest — it signals "needs classification"
+and allows the auto-tagging classifier to assign the correct value on its first run.
+
+The trade-off is that the `UnclassifiedEvidence` list in the GET response may be non-empty
+after initial upload, but that is preferable to silent mislabeling.
+
+**Decision: R3 — New uploads default to `Unclassified`. Back-fill existing rows to `Combined`
+(not `Unclassified`) because the intent of legacy evidence is "supports this control" without
+a specific half, which matches the semantic of `Combined`.**
+
+---
+
+## R4: Back-Fill of Legacy Narrative to Policy or Technical?
+
+**Question:** Issue #64 US5 says legacy `ControlImplementation` rows should be migrated to
+`NarrativeKind=Technical` (the historical default). But should the migration silently back-fill
+`TechnicalNarrative = Narrative`, or create a "Legacy" kind that we sunset?
+
+**Answer: Back-fill to `TechnicalNarrative` with `MigratedFromLegacy = true` flag.**
+
+### Rationale
+
+A third `Legacy` kind:
+- Requires UI to handle a third state that is never authored and only exists to be migrated.
+- Creates dead code paths in export rendering.
+- Confuses auditors who see a `Legacy` section in the SSP.
+
+Back-filling to `TechnicalNarrative` (with the `MigratedFromLegacy` audit flag):
+- Ensures the SSP export immediately reflects content in the Technical slot.
+- Policy slot renders `[Not Authored]` — correct, because no org has authored it yet.
+- The `MigratedFromLegacy` flag lets the UI optionally show a banner: "This technical
+  narrative was migrated from a legacy combined narrative. Review and split as needed."
+
+**Decision: R4 — Back-fill to `TechnicalNarrative`; no `Legacy` kind. Issue #64 US5 AC5
+confirms this approach.**
+
+---
+
+## R5: Role Gate — Hard 403 vs. Draft Suggestion for PlatformEngineer on Policy
+
+**Question:** Should a `PlatformEngineer` receive a hard 403 when writing `PolicyNarrative`,
+or be allowed to submit a "suggested edit" that an ISSM can accept?
+
+**Answer: Hard 403.**
+
+### Rationale
+
+Issue #64 asks: "8. **Engineer write to Policy** — Hard 403 (current proposal), or allow
+Engineers to draft Policy as a 'suggested edit' the ISSM can accept?" The issue lists this
+as a `/clarify` question with the current proposal being hard 403.
+
+For the spec, hard 403 is chosen because:
+1. Simpler to implement and reason about for auditors.
+2. A "suggested edit" workflow requires a `PolicyNarrativeDraft` table, approval flow, and
+   notification system — all out of scope for Feature 052.
+3. Engineers can still author the Technical half directly, which is the common case.
+
+**Decision: R5 — Hard 403 for PlatformEngineer on any request where `policyNarrative` is
+non-null. Engineers who need to propose Policy content should do so out-of-band (e.g., Teams
+message to ISSM).**
+
+---
+
+## R6: OSCAL Statement IDs — `_smt.a/_smt.b` vs. `_smt.policy/_smt.technical`
+
+**Question:** Issue #64 asks: "OSCAL statement IDs — `_smt.a / _smt.b` (NIST OSCAL
+convention) or custom suffixes `_policy / _technical` (clearer but non-standard)?"
+
+**Answer: `_smt.policy` and `_smt.technical`.**
+
+### Rationale
+
+- `_smt.a` and `_smt.b` are generic ordinal suffixes from NIST's OSCAL schema examples;
+  they are not semantically meaningful to downstream tooling.
+- `_smt.policy` and `_smt.technical` are self-documenting — an eMASS import script or
+  FedRAMP reviewer can identify which half is which without a lookup table.
+- OSCAL's schema does not restrict `statement-id` to `_smt.a/b`; any string is valid.
+- Downstream eMASS concatenation (`Policy + "\n\n" + Technical`) relies on being able to
+  identify the two statement entries by their IDs.
+
+**Decision: R6 — Use `{controlId}_smt.policy` and `{controlId}_smt.technical`.**

--- a/specs/074-policy-technical-narrative/spec.md
+++ b/specs/074-policy-technical-narrative/spec.md
@@ -1,0 +1,195 @@
+# Spec 074 — Policy + Technical Narrative Split & Evidence Classification
+
+**Epic:** #64 — Feature 052: Evidence + Narrative Modeling (Policy + Technical)
+**GitHub Issue:** #64
+**Wave:** 9 — Core UX & Integrations
+**Status:** Draft
+**Branch:** `074-policy-technical-narrative`
+**Feature Number:** 074
+
+---
+
+## Background
+
+Every NIST 800-53 control implementation in ATO Copilot today has exactly one `ControlImplementation.Narrative`
+field. In real RMF practice auditors expect **two** canonical halves:
+
+| Half | Covers | Evidence | Reviewer |
+|------|--------|----------|----------|
+| **Policy** | Org-level governance: who owns the control, what the written policy says, review frequency, role assignments, policy document citations | Signed policy PDFs, meeting-minutes, training rosters, SOPs | ISSM |
+| **Technical** | System-level implementation: Azure/cloud configuration, automated controls, scan output, Conditional Access rules, RBAC, CI/CD gates | Azure Policy exports, Defender snapshots, SCAP results, screenshots | ISSM or SCA |
+
+Today ISSMs write one paragraph that blends both (e.g., "We have an account management policy
+**and** Azure AD enforces lifecycle workflows") and evidence (a Word doc vs. an Azure Policy
+JSON) files into one undifferentiated list. Feature 052 models the two halves as **first-class
+duals** so every control has a Policy Narrative and a Technical Narrative with independent
+authorship, review, staleness tracking, AI-generation prompts, and SSP export paths.
+
+### Dependencies
+
+| Feature | How it affects this spec |
+|---------|--------------------------|
+| 024 — narrative-governance | Version history, approval lifecycle, `NarrativeVersion` table extend to both halves |
+| 038 — evidence-repository | `EvidenceArtifact` storage, retention, and versioning extend with `NarrativeType` tag |
+| 022 — ssp-full-oscal | OSCAL export renders both halves as labeled `implemented-requirements.statements[]` entries |
+| 037 — ssp-document-export | DOCX/PDF export renders two labelled subsections per control |
+| 044 — org-control-inheritance | Org-default inheritance applies to Policy half; Technical is always per-system |
+| 041 — emass-package | eMASS concatenates Policy + "\n\n" + Technical as the single implementation statement |
+
+---
+
+## Functional Requirements
+
+### FR-001 — Two Nullable Narrative Columns (Additive Migration)
+`ControlImplementation` gains `PolicyNarrative (string? nullable)` and
+`TechnicalNarrative (string? nullable)` columns. The existing `Narrative` field is **not
+renamed or removed** — it becomes the combined/legacy field. EF Core migration is purely
+additive; no existing rows are altered except by the optional back-fill described in FR-003.
+
+### FR-002 — `EvidenceNarrativeType` Enum on Evidence Artifacts
+`EvidenceArtifact` gains a `NarrativeType` column typed `EvidenceNarrativeType`:
+`Policy (0) | Technical (1) | Combined (2) | Unclassified (3)`. New uploads default to
+`Unclassified`; callers may pass the value on upload. Existing rows default to `Combined`
+(migration back-fill).
+
+### FR-003 — Legacy Narrative Back-fill
+An EF Core `HasData` seed or post-migration script sets `TechnicalNarrative = Narrative`
+for all rows where `Narrative IS NOT NULL` and sets a `MigratedFromLegacy = true` flag so
+the system can distinguish migrated vs. freshly-authored Technical narratives. Policy half
+is initialized `NULL` (not authored) for all existing rows.
+
+### FR-004 — PATCH Endpoint for Dual Narrative Update
+New `PATCH /api/systems/{systemId}/controls/{controlId}/narrative` accepts body with
+`policyNarrative` and/or `technicalNarrative` (both optional). Each provided half is saved
+independently; an omitted half is left unchanged. Returns the full updated dual-narrative
+response (see FR-005).
+
+### FR-005 — GET Endpoint Returns Both Halves + Evidence Split
+`GET /api/systems/{systemId}/controls/{controlId}/narrative` returns the Policy Narrative,
+Technical Narrative, legacy Narrative, and evidence lists split by `NarrativeType`.
+
+### FR-006 — MCP Tools: `narrative_set_policy`, `narrative_set_technical`, `evidence_classify`
+Three new MCP tools for agent-driven authoring and evidence classification (see
+`contracts/mcp-tools.md`).
+
+### FR-007 — SSP Export Renders Both Halves
+OSCAL JSON export adds `statement-id` entries `{controlId}_smt.policy` and
+`{controlId}_smt.technical`. DOCX/PDF export renders `**Implementation Statement (Policy):**`
+followed by `**Implementation Statement (Technical):**`. Missing halves render the configured
+placeholder string (default: `[Not Authored]`).
+
+### FR-008 — Auto-Tagging Classifier for Existing Evidence
+A deterministic classifier tags legacy `EvidenceArtifact` rows by filename/source:
+- Names matching `*Policy*`, `*Procedure*`, `*SOP*`, `*Plan*` → `Policy`
+- Source = `AzurePolicy`, `Defender`, `SCAP`, `ACAS`, `PrismaCloud`, `NessusACASScan`,
+  `AwsSecurityHub`, `GcpScc` → `Technical`
+- Otherwise → `Combined` with `AutoTagRationale = "LowConfidence"`
+Classifier writes a `AutoTagRationale` string field on each row. Manual overrides clear the
+rationale and set `ManuallyTaggedBy`.
+
+### FR-009 — Role-Based Write Gates
+Policy Narrative: writable by `Analyst` role (ISSM/ISSO level). PlatformEngineer role receives
+403 attempting a Policy write.
+Technical Narrative: writable by `PlatformEngineer` and `Analyst` (ISSO/ISSM/SCA).
+
+### FR-010 — Staleness Rules
+Policy Narrative staleness is triggered by `OrgDefaultUpdated` events (Feature 044). Technical
+Narrative staleness is event-based (no cadence). Both halves expose `IsStale` and `StaleReason`
+in the GET response.
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-001 | Migration is purely additive — zero data loss; rollback drops only the two new columns |
+| NFR-002 | PATCH endpoint responds in < 200 ms at p99 under normal load |
+| NFR-003 | All new DB columns are nullable; no NOT NULL constraint added to existing rows |
+| NFR-004 | `EvidenceNarrativeType` defaults are applied at the DB level as well as in EF (`DEFAULT 3` for new artifacts, `DEFAULT 2` for migration back-fill) |
+| NFR-005 | Legacy `Narrative` field remains in the API response under `legacyNarrative` for backward compatibility |
+| NFR-006 | Auto-tagging classifier completes < 1 s per 1000 rows on SQLite (dev) |
+| NFR-007 | MCP tools follow existing `BaseTool` response envelope pattern |
+
+---
+
+## User Stories
+
+### User Story 1 — Two First-Class Narrative Editors Per Control (P1)
+An ISSO authoring AC-2 opens the control and sees two editors: **Policy Narrative** and
+**Technical Narrative**. Each saves independently, each has its own version history, and
+the SSP export renders both as labeled subsections.
+
+**Acceptance Scenarios:**
+1. **Given** an existing system, **When** the user opens AC-2, **Then** both `policyNarrative`
+   and `technicalNarrative` fields are returned in `GET /api/systems/{id}/controls/AC-2/narrative`.
+2. **Given** only `policyNarrative` is PATCHed, **When** the save completes, **Then**
+   `technicalNarrative` is unchanged.
+3. **Given** both halves authored, **When** the SSP exports, **Then** both labeled subsections
+   appear in the export document.
+4. **Given** a legacy system, **When** migration runs, **Then** `technicalNarrative` equals
+   the old `narrative` value; `policyNarrative` is null; `migratedFromLegacy = true`.
+
+### User Story 2 — Evidence Tagged Policy or Technical (P1)
+When evidence is uploaded, the caller declares `NarrativeType`. Each narrative editor returns
+only evidence tagged for its half plus `Combined`. SSP appendices render two evidence indices.
+
+**Acceptance Scenarios:**
+1. **Given** an artifact uploaded with `narrativeType = "Policy"`, **When** the evidence list
+   is fetched, **Then** it appears in the Policy evidence set.
+2. **Given** a legacy artifact, **When** the classifier runs, **Then** it is tagged based on
+   filename/source heuristic with a `autoTagRationale` explanation.
+
+### User Story 3 — Role-Based Write Gates (P1)
+A PlatformEngineer attempting to PATCH `policyNarrative` receives 403. An ISSM can write both.
+
+### User Story 4 — SSP Export Both Halves Canonical (P1)
+OSCAL JSON has `statement-id` suffixes `_smt.policy` and `_smt.technical`. DOCX export has
+labeled subsections in Policy → Technical order. Missing halves get the configured placeholder.
+
+### User Story 5 — MCP Agent Authoring (P2)
+An agent can call `narrative_set_policy` and `narrative_set_technical` to author each half,
+and `evidence_classify` to bulk-tag existing artifacts.
+
+---
+
+## Out of Scope
+
+- More than two halves (no Operational/Managerial/Compensating kinds)
+- Free-form `NarrativeKind` values — enum is closed: `Policy | Technical`
+- Splitting AI narrative cache — old cache entries are invalidated on first use post-migration
+- Per-half POA&Ms — Feature 039 POA&Ms remain at the control level
+- Per-half evidence retention policies — both halves use Feature 038 defaults
+- Renaming "Policy" / "Technical" labels — fixed for cross-deployment auditor consistency
+- Multilingual narratives
+
+---
+
+## Test Plan
+
+| Test | Method | Scope |
+|------|--------|-------|
+| Migration adds two nullable columns | EF Core integration test | `ControlImplementation` table |
+| Migration back-fills `TechnicalNarrative` from `Narrative` | Integration test | Existing rows |
+| PATCH saves each half independently | Integration test | Endpoint |
+| GET returns split evidence lists | Integration test | Endpoint |
+| Role gate: PE → 403 on Policy PATCH | Integration test | Auth middleware |
+| Auto-tagger classifies 200 legacy rows correctly | Unit test | Classifier service |
+| OSCAL export has `_smt.policy` + `_smt.technical` entries | Integration test | Export service |
+| DOCX export has labeled subsections | Integration test | Export service |
+| MCP tools return correct envelope | Unit test | Tool classes |
+
+---
+
+## Definition of Done
+
+- [ ] `PolicyNarrative` and `TechnicalNarrative` columns exist in DB (EF migration applied)
+- [ ] `EvidenceNarrativeType` enum + `NarrativeType` column on `EvidenceArtifact`
+- [ ] `PATCH /api/systems/{id}/controls/{controlId}/narrative` endpoint live
+- [ ] `GET /api/systems/{id}/controls/{controlId}/narrative` returns both halves + evidence split
+- [ ] Role gates enforced: PE → 403 on Policy write
+- [ ] MCP tools `narrative_set_policy`, `narrative_set_technical`, `evidence_classify` registered
+- [ ] SSP OSCAL and DOCX exports render both halves with canonical labels
+- [ ] Auto-tagging classifier service implemented and covered by tests
+- [ ] All acceptance scenarios from US1–US4 pass
+- [ ] Spec files merged to `main` via this PR

--- a/specs/074-policy-technical-narrative/tasks.md
+++ b/specs/074-policy-technical-narrative/tasks.md
@@ -1,0 +1,263 @@
+# Tasks — 074: Policy + Technical Narrative Split & Evidence Classification
+
+_Epic #64 — Feature 052. Each task cites the file path(s) it touches and the relevant issue ref._
+
+---
+
+## Phase 1 — Data Model: Additive Columns & Enum
+
+_Issue #64 | Priority: P1 | Unblocks all backend and export work_
+
+- [ ] **T001**: Add `EvidenceNarrativeType` enum to `ComplianceModels.cs`
+  - File: `src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs`
+  - Insert after the existing `EvidenceCategory` enum (around line 235):
+    ```csharp
+    /// <summary>
+    /// Feature 052 (#64): which narrative half an evidence artifact supports.
+    /// </summary>
+    public enum EvidenceNarrativeType
+    {
+        /// <summary>Supports the Policy/Procedural narrative half.</summary>
+        Policy = 0,
+        /// <summary>Supports the Technical/Implementation narrative half.</summary>
+        Technical = 1,
+        /// <summary>Supports both halves equally (e.g., cross-cutting evidence).</summary>
+        Combined = 2,
+        /// <summary>Not yet classified — default for new uploads.</summary>
+        Unclassified = 3
+    }
+    ```
+
+- [ ] **T002**: Add `PolicyNarrative` and `TechnicalNarrative` to `ControlImplementation`
+  - File: `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs`
+  - After the existing `Narrative` property (around line 44), insert:
+    ```csharp
+    /// <summary>
+    /// Feature 052 (#64): policy/procedural narrative half. Nullable — null = not yet authored.
+    /// Do NOT rename Narrative above; this is an additive companion field.
+    /// </summary>
+    [MaxLength(8000)]
+    public string? PolicyNarrative { get; set; }
+
+    /// <summary>
+    /// Feature 052 (#64): technical/implementation narrative half. Nullable — null = not yet authored.
+    /// On migration this is back-filled from Narrative for existing rows (MigratedFromLegacy=true).
+    /// </summary>
+    [MaxLength(8000)]
+    public string? TechnicalNarrative { get; set; }
+
+    /// <summary>
+    /// Feature 052 (#64): true when TechnicalNarrative was populated from the legacy Narrative
+    /// field during the additive migration. Allows audit trail to distinguish migrated vs.
+    /// freshly-authored content.
+    /// </summary>
+    public bool MigratedFromLegacy { get; set; }
+    ```
+
+- [ ] **T003**: Add `NarrativeType` and `AutoTagRationale` / `ManuallyTaggedBy` to `EvidenceArtifact`
+  - File: `src/Ato.Copilot.Core/Models/Compliance/EvidenceArtifactModels.cs`
+  - After the `CollectionMethod` property, insert:
+    ```csharp
+    // ─── Feature 052 (#64): Narrative-half classification ────────────────────
+
+    /// <summary>
+    /// Which narrative half this artifact supports (Policy | Technical | Combined | Unclassified).
+    /// Defaults to Unclassified for new uploads; migration back-fills existing rows as Combined.
+    /// </summary>
+    public EvidenceNarrativeType NarrativeType { get; set; } = EvidenceNarrativeType.Unclassified;
+
+    /// <summary>
+    /// Rationale written by the auto-tagging classifier (null when manually tagged).
+    /// Example: "Filename matches PolicyDocumentRegex" or "Source=AzurePolicy".
+    /// </summary>
+    [MaxLength(500)]
+    public string? AutoTagRationale { get; set; }
+
+    /// <summary>
+    /// OID of the user who manually re-tagged this artifact (null when auto-tagged or not yet tagged).
+    /// Set on manual override; clears AutoTagRationale.
+    /// </summary>
+    [MaxLength(200)]
+    public string? ManuallyTaggedBy { get; set; }
+    ```
+
+---
+
+## Phase 2 — EF Core Migration
+
+_Issue #64 | Priority: P1 | Depends on Phase 1_
+
+- [ ] **T004**: Generate EF Core migration
+  - Command: `dotnet ef migrations add Feature052_PolicyTechnicalNarrativeSplit --project src/Ato.Copilot.Core --startup-project src/Ato.Copilot.Mcp`
+  - Expected changes in migration `Up()`:
+    - `migrationBuilder.AddColumn<string>("PolicyNarrative", "ControlImplementations", nullable: true, maxLength: 8000)`
+    - `migrationBuilder.AddColumn<string>("TechnicalNarrative", "ControlImplementations", nullable: true, maxLength: 8000)`
+    - `migrationBuilder.AddColumn<bool>("MigratedFromLegacy", "ControlImplementations", nullable: false, defaultValue: false)`
+    - `migrationBuilder.AddColumn<int>("NarrativeType", "EvidenceArtifacts", nullable: false, defaultValue: 3)` _(Unclassified)_
+    - `migrationBuilder.AddColumn<string>("AutoTagRationale", "EvidenceArtifacts", nullable: true, maxLength: 500)`
+    - `migrationBuilder.AddColumn<string>("ManuallyTaggedBy", "EvidenceArtifacts", nullable: true, maxLength: 200)`
+  - Expected changes in migration `Down()`:
+    - `migrationBuilder.DropColumn("PolicyNarrative", "ControlImplementations")`
+    - `migrationBuilder.DropColumn("TechnicalNarrative", "ControlImplementations")`
+    - `migrationBuilder.DropColumn("MigratedFromLegacy", "ControlImplementations")`
+    - `migrationBuilder.DropColumn("NarrativeType", "EvidenceArtifacts")`
+    - `migrationBuilder.DropColumn("AutoTagRationale", "EvidenceArtifacts")`
+    - `migrationBuilder.DropColumn("ManuallyTaggedBy", "EvidenceArtifacts")`
+
+- [ ] **T005**: Add back-fill SQL to migration `Up()` after column additions
+  - In the migration `Up()` method, after adding columns:
+    ```csharp
+    // Back-fill TechnicalNarrative from legacy Narrative for all existing rows
+    migrationBuilder.Sql(
+        "UPDATE ControlImplementations " +
+        "SET TechnicalNarrative = Narrative, MigratedFromLegacy = 1 " +
+        "WHERE Narrative IS NOT NULL");
+
+    // Back-fill EvidenceArtifacts: existing rows default to Combined (2), not Unclassified (3)
+    migrationBuilder.Sql(
+        "UPDATE EvidenceArtifacts SET NarrativeType = 2 WHERE NarrativeType = 3");
+    ```
+  - Note: The column default of `3` (Unclassified) applies only to **new** rows inserted after
+    the migration; the back-fill overrides existing rows to `2` (Combined) so no evidence is lost.
+
+---
+
+## Phase 3 — HTTP Endpoints
+
+_Issue #64 | Priority: P1 | Depends on Phase 2_
+
+- [ ] **T006**: Create `NarrativeDualEndpoints.cs` route declarations
+  - File: `src/Ato.Copilot.Mcp/Endpoints/NarrativeDualEndpoints.cs`
+  - Namespace: `Ato.Copilot.Mcp.Endpoints`
+  - Routes:
+    - `GET /api/systems/{systemId}/controls/{controlId}/narrative` → `GetDualNarrativeAsync`
+    - `PATCH /api/systems/{systemId}/controls/{controlId}/narrative` → `PatchDualNarrativeAsync`
+  - Tag: `.WithTags("Narrative")`
+  - Require auth on both; role-gate `PatchDualNarrativeAsync` by `narrativePart` (see FR-009)
+
+- [ ] **T007**: Register `MapNarrativeDualEndpoints()` in MCP startup
+  - File: `src/Ato.Copilot.Mcp/Extensions/AtoCopilotMcpServiceExtensions.cs`
+    (or wherever other endpoint maps are registered — search for `MapNarrativeGovernanceEndpoints`
+    to find the right file)
+  - Add: `app.MapNarrativeDualEndpoints();`
+
+- [ ] **T008**: Implement `GetDualNarrativeAsync` handler
+  - Query `ControlImplementation` by `(RegisteredSystemId, ControlId)` (tenant-filtered)
+  - Query `EvidenceArtifact` rows for this `ControlImplementationId`, group by `NarrativeType`
+  - Return `DualNarrativeResponse` DTO (see `data-model.md §3`)
+  - 404 if the `ControlImplementation` row does not exist
+
+- [ ] **T009**: Implement `PatchDualNarrativeAsync` handler
+  - Accept `PatchDualNarrativeRequest` body (`policyNarrative?: string`, `technicalNarrative?: string`)
+  - Apply role gate: if `policyNarrative` is provided and caller has only `PlatformEngineer` role → 403
+  - Update only the provided fields; leave the other unchanged
+  - Set `ModifiedAt = DateTime.UtcNow`
+  - Return updated `DualNarrativeResponse`
+  - Write audit log entry (same pattern as existing narrative governance endpoints)
+
+- [ ] **T010**: Create `PatchDualNarrativeRequest` and `DualNarrativeResponse` DTOs
+  - File: `src/Ato.Copilot.Core/Models/Compliance/NarrativeDualDtos.cs`
+  - See `data-model.md §3` for full field list
+
+---
+
+## Phase 4 — MCP Tools
+
+_Issue #64 | Priority: P2 | Depends on Phase 3_
+
+- [ ] **T011**: Create `NarrativePolicyTool` (MCP tool: `narrative_set_policy`)
+  - File: `src/Ato.Copilot.Agents/Compliance/Tools/NarrativePolicyTool.cs`
+  - Namespace: `Ato.Copilot.Agents.Compliance.Tools`
+  - Parameters: `system_id (string, required)`, `control_id (string, required)`,
+    `policy_narrative (string, required)`
+  - Calls `PATCH /api/systems/{id}/controls/{controlId}/narrative` with `policyNarrative` only
+  - Returns success envelope with `policyNarrative` echoed back
+
+- [ ] **T012**: Create `NarrativeTechnicalTool` (MCP tool: `narrative_set_technical`)
+  - File: `src/Ato.Copilot.Agents/Compliance/Tools/NarrativeTechnicalTool.cs`
+  - Parameters: `system_id`, `control_id`, `technical_narrative`
+  - Calls PATCH with `technicalNarrative` only
+
+- [ ] **T013**: Create `EvidenceClassifyTool` (MCP tool: `evidence_classify`)
+  - File: `src/Ato.Copilot.Agents/Compliance/Tools/EvidenceClassifyTool.cs`
+  - Parameters: `evidence_artifact_id (string, required)`,
+    `narrative_type (string, required — "Policy"|"Technical"|"Combined"|"Unclassified")`,
+    `rationale (string, optional)`
+  - Calls `PATCH /api/evidence/{id}/classify` (new endpoint in T014)
+  - Returns updated artifact summary
+
+- [ ] **T014**: Create `EvidenceClassifyEndpoint` for evidence reclassification
+  - File: `src/Ato.Copilot.Mcp/Endpoints/EvidenceClassifyEndpoint.cs`
+  - Route: `PATCH /api/evidence/{artifactId}/classify`
+  - Body: `{ narrativeType: int, rationale?: string }`
+  - Sets `NarrativeType`, clears `AutoTagRationale`, sets `ManuallyTaggedBy = caller OID`
+  - Register in startup alongside T007
+
+---
+
+## Phase 5 — Auto-Tagger Service
+
+_Issue #64 | Priority: P3 | Depends on Phase 2_
+
+- [ ] **T015**: Create `EvidenceNarrativeClassifier` service
+  - File: `src/Ato.Copilot.Core/Services/Compliance/EvidenceNarrativeClassifier.cs`
+  - Interface: `IEvidenceNarrativeClassifier` in `src/Ato.Copilot.Core/Interfaces/Compliance/`
+  - Method: `ClassifyAsync(EvidenceArtifact artifact) : Task<(EvidenceNarrativeType type, string rationale)>`
+  - Logic:
+    1. Source-based rules first (highest priority): `AzurePolicy`, `Defender`, `SCAP`, `ACAS`,
+       `PrismaCloud`, `NessusACASScan`, `AwsSecurityHub`, `GcpScc` → `Technical`
+    2. Filename regex match: `*Policy*|*Procedure*|*SOP*|*Plan*|*Charter*|*Standard*` → `Policy`
+    3. Fallback: `Combined` with `rationale = "LowConfidence"`
+
+- [ ] **T016**: Create one-time migration CLI command or background job to bulk-tag existing artifacts
+  - File: `src/Ato.Copilot.Core/Services/Compliance/EvidenceNarrativeBulkClassifierJob.cs`
+  - Reads all `EvidenceArtifact` rows where `NarrativeType = Combined` (back-filled from migration)
+    and `ManuallyTaggedBy IS NULL`
+  - Calls `IEvidenceNarrativeClassifier.ClassifyAsync` per row and saves result
+  - Writes summary log: "X tagged Policy, Y Technical, Z Combined (low-confidence)"
+  - Should be idempotent — safe to re-run
+
+---
+
+## Phase 6 — SSP Export Integration
+
+_Issue #64 | Priority: P1 | Depends on Phase 2_
+
+- [ ] **T017**: Update OSCAL SSP export to emit both narrative halves
+  - File: search for the OSCAL export service (likely in
+    `src/Ato.Copilot.Core/Services/Compliance/` or `src/Ato.Copilot.Mcp/`)
+  - For each `implemented-requirement`, emit two `statement` entries:
+    - `statement-id: "{controlId}_smt.policy"`, `description: PolicyNarrative ?? "[Not Authored]"`
+    - `statement-id: "{controlId}_smt.technical"`, `description: TechnicalNarrative ?? "[Not Authored]"`
+  - The old `Narrative`/`legacyNarrative` field is NOT emitted in new exports to avoid duplication
+
+- [ ] **T018**: Update DOCX/PDF SSP export to render two labeled subsections
+  - File: search for QuestPDF/DOCX export service (spec 037 — `ssp-document-export`)
+  - Per control, insert:
+    ```
+    **Implementation Statement (Policy):**
+    {PolicyNarrative ?? configuredPlaceholder}
+
+    **Implementation Statement (Technical):**
+    {TechnicalNarrative ?? configuredPlaceholder}
+    ```
+  - Order: Policy always first, Technical second
+  - Read placeholder from `appsettings.json` `Narrative:ExportPlaceholder` (default: `[Not Authored]`)
+
+---
+
+## Phase 7 — Tests
+
+_Issue #64 | Priority: P1_
+
+- [ ] **T019**: Integration test — migration adds nullable columns without breaking existing rows
+  - File: `tests/Ato.Copilot.Tests.Integration/Compliance/Feature052MigrationTests.cs`
+
+- [ ] **T020**: Integration test — PATCH dual narrative, GET reflects changes, role gate 403
+  - File: `tests/Ato.Copilot.Tests.Integration/Compliance/DualNarrativeEndpointTests.cs`
+
+- [ ] **T021**: Unit test — `EvidenceNarrativeClassifier` classifies known filenames and sources
+  - File: `tests/Ato.Copilot.Tests.Unit/Compliance/EvidenceNarrativeClassifierTests.cs`
+
+- [ ] **T022**: Integration test — OSCAL export emits `_smt.policy` + `_smt.technical` statement IDs
+  - File: `tests/Ato.Copilot.Tests.Integration/Compliance/Feature052OscalExportTests.cs`


### PR DESCRIPTION
**Owner**: Cyborg (`agent:cyborg`)

## Problem Statement

Today every NIST control has a single `Narrative` field in `ControlImplementation` (SspModels.cs line ~44) and a single undifferentiated evidence bag (`EvidenceArtifact`). Real RMF practice splits each control into:
- **Policy/Procedural**: org-level documentation, governance roles, procedures, frequency statements
- **Technical/Implementation**: system-level configuration, automated controls, scan outputs, artifacts

Auditors expect BOTH halves documented separately. ISSMs write mixed paragraphs ("we have a policy for AC-2" and "Azure AD enforces AC-2.1" in one field), and evidence files (Word policy doc vs. Azure Policy export) are filed in one undifferentiated list.

## Goal / Desired Outcome

Feature 074 extends `ControlImplementation` with `PolicyNarrative` + `TechnicalNarrative` (additive, migration-safe) and adds `NarrativeType` to `EvidenceArtifact` for classification. The legacy `Narrative` field is preserved as the combined/legacy fallback. All changes are additive — no existing data is broken.

## Scope

**In scope:**
- Add `PolicyNarrative` (string?, nullable) + `TechnicalNarrative` (string?, nullable) to `ControlImplementation`
- Add `NarrativeType` enum (`Policy | Technical | Combined | Unclassified`) to `EvidenceArtifact`
- EF Core migration (additive columns only — no schema rename)
- New endpoints: `PATCH /api/systems/{id}/controls/{controlId}/narrative` (both halves), `GET` same
- New MCP tools: `narrative_set_policy`, `narrative_set_technical`, `evidence_classify`
- Cascade regeneration: when policy or technical narrative changes, re-trigger SSP section update

**Out of scope:**
- Removing or renaming the existing `Narrative` field (breaking change — post-migration task)
- UI redesign of the control detail page (tracked separately in Dashboard issues)
- AI generation of split narratives (future enhancement)

## User Experience Flow

1. SCA or ISSO opens a control detail view for AC-2
2. Two separate text areas appear: "Policy Narrative" (pre-populated from policy docs) and "Technical Narrative" (pre-populated from scan results + capability links)
3. User saves each half independently or together
4. Evidence upload dialog now shows "Evidence Type" selector: Policy Document | Technical Evidence | Assessment Output | Other
5. SSP generation assembles both halves into the control implementation section with clear structural separation

## Functional Requirements

- **FR-001**: `PolicyNarrative` field added to `ControlImplementation` — nullable, max 8000 chars, same as existing `Narrative`
- **FR-002**: `TechnicalNarrative` field added to `ControlImplementation` — nullable, max 8000 chars
- **FR-003**: `NarrativeType` enum added to `EvidenceArtifact` — default `Unclassified` for backwards compatibility
- **FR-004**: EF Core migration MUST be additive — existing `Narrative` column preserved
- **FR-005**: `PATCH /api/systems/{id}/controls/{controlId}/narrative` accepts `{policyNarrative, technicalNarrative}` and updates both fields atomically
- **FR-006**: `GET /api/systems/{id}/controls/{controlId}/narrative` returns all three narrative fields + evidence split by type
- **FR-007**: MCP tools `narrative_set_policy`, `narrative_set_technical`, `evidence_classify` register in tool registry
- **FR-008**: When either `PolicyNarrative` or `TechnicalNarrative` is updated, cascade-regenerate SSP section (existing `ExportRerenderJobHandler` pattern)

## Technical Design Notes

Additive EF Core migration — two nullable columns on `ControlImplementations` table, one nullable enum column on `EvidenceArtifacts` table. No foreign key changes.

`NarrativeGovernanceTools.cs` extended with two new tools. `AssessmentArtifactTools.cs` extended with `evidence_classify` tool.

SSP export assembles: if both halves present → Policy section + Technical section; if only `Narrative` present → legacy section; mixed state handled gracefully.

## Architecture Decisions

| Decision | Chosen | Alternative | Reason |
|---|---|---|---|
| Additive vs rename | Additive (new columns) | Rename `Narrative` | Zero data loss, backwards compatible, all existing tests pass |
| Default for `NarrativeType` | `Unclassified` | `Combined` | Preserves semantic accuracy — existing evidence is not classified yet |
| Cascade trigger | `ExportRerenderJobHandler` pattern | Immediate re-render | Consistent with existing cascade architecture; decoupled |

## Acceptance Criteria

```gherkin
Scenario: Set policy and technical narrative independently
  Given a control AC-2 with existing combined narrative
  When an ISSO sets PolicyNarrative for AC-2 to "We maintain a policy per DoD 5200.28..."
  Then PolicyNarrative is saved without affecting TechnicalNarrative or Narrative
  And the SSP section for AC-2 shows a policy sub-section

Scenario: Evidence classification preserved
  Given an existing EvidenceArtifact with NarrativeType Unclassified
  When SCA calls evidence_classify with type=Technical
  Then NarrativeType is updated to Technical
  And the evidence appears under the Technical section in SSP export

Scenario: Backwards compatibility
  Given a system created before this feature (Narrative field populated, PolicyNarrative null)
  When the SSP is exported
  Then the combined Narrative is rendered as the implementation statement
  And no null-reference errors occur
```

## Non-Functional Requirements

- Migration must run in <30s on a 10,000-record `ControlImplementations` table
- All existing `OscalSspExportServiceTests` must pass (no regression)
- `NarrativeGovernanceTools` unit tests must include new tool coverage

## Test Plan

- Unit: `ControlImplementationNarrativeSplitTests` — set/get both halves, partial update
- Unit: `EvidenceClassificationTests` — type assignment, backwards compatibility
- Unit: `NarrativeGovernanceToolsTests` — new tool execution paths
- Integration: `NarrativeSplitEndpointTests` — full endpoint round-trip
- Migration test: existing seed data survives additive migration

## Definition of Done

- [ ] `PolicyNarrative` + `TechnicalNarrative` added to `ControlImplementation` (nullable)
- [ ] `NarrativeType` enum added to `EvidenceArtifact` (default `Unclassified`)
- [ ] EF Core migration created, additive only
- [ ] `PATCH` + `GET` narrative endpoints live
- [ ] MCP tools `narrative_set_policy`, `narrative_set_technical`, `evidence_classify` registered
- [ ] Cascade regeneration fires on narrative update
- [ ] All existing SSP export tests green
- [ ] New unit + integration tests green

## Explicit Constraints (DO NOT)

- DO NOT rename or remove the existing `Narrative` column in this feature — breaking change
- DO NOT make `NarrativeType` required (would break existing evidence without type)
- DO NOT couple this to the UI redesign work — backend contract first

## Anti-patterns

- Storing narrative type in a separate join table (unnecessary complexity; it's an attribute of the artifact)
- AI-generating the policy/technical split automatically without user review (compliance content must be human-verified)
- Making the `PATCH` endpoint non-atomic (both halves must save together or not at all)

## Existing File References

| File | Line | Relevance |
|---|---|---|
| `src/Ato.Copilot.Core/Models/Compliance/SspModels.cs` | ~15–100 | `ControlImplementation` entity — add `PolicyNarrative`, `TechnicalNarrative` |
| `src/Ato.Copilot.Core/Models/Compliance/EvidenceArtifactModels.cs` | ~1 | `EvidenceArtifact` entity — add `NarrativeType` |
| `src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs` | ~218 | `EvidenceCategory` enum — add `EvidenceNarrativeType` enum nearby |
| `src/Ato.Copilot.Agents/Compliance/Tools/NarrativeGovernanceTools.cs` | ~1 | Add `narrative_set_policy`, `narrative_set_technical` |
| `src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Cascade/ExportRerenderJobHandler.cs` | ~1 | Cascade pattern to follow |
