### PR TITLE
feat(#202): wire knowledge base CRUD backend and add full management UI

### DIFF
--- a/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
+++ b/src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Ato.Copilot.Core.Data.Seed;
 using Ato.Copilot.Core.Interfaces.Tenancy;
 using Ato.Copilot.Core.Models;
 using Ato.Copilot.Core.Models.Auth;
@@ -3913,6 +3914,23 @@ public class AtoCopilotContext : DbContext
             entity.HasIndex(e => new { e.TenantId, e.Timestamp })
                 .HasDatabaseName("IX_WizardAudit_Tenant_TimestampDesc")
                 .IsDescending(false, true);
+        });
+
+        // OverlayDocument — Issue #202 / Feature #134: NIST KB overlay CRUD
+        modelBuilder.Entity<OverlayDocument>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Type).HasMaxLength(64).IsRequired();
+            entity.Property(e => e.Title).HasMaxLength(256).IsRequired();
+            entity.Property(e => e.ControlId).HasMaxLength(32).IsRequired();
+            entity.Property(e => e.SourceReference).HasMaxLength(512);
+            entity.Property(e => e.CreatedBy).HasMaxLength(256).IsRequired();
+            entity.Property(e => e.ModifiedBy).HasMaxLength(256);
+            entity.HasIndex(e => new { e.ControlId, e.Type })
+                .HasDatabaseName("IX_OverlayDocument_ControlId_Type");
+            entity.HasIndex(e => e.IsActive)
+                .HasDatabaseName("IX_OverlayDocument_IsActive");
+            entity.HasData(OverlayDocumentSeed.GetSeedData());
         });
     }
 

--- a/src/Ato.Copilot.Dashboard/src/api/overlayDocuments.ts
+++ b/src/Ato.Copilot.Dashboard/src/api/overlayDocuments.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #202 — typed API client module for NIST KB overlay documents.
+ *
+ * NOTE on API URL: apiClient's baseURL is `/api/dashboard`, but the overlay
+ * endpoints are served at the absolute path `/api/v1/admin/overlay-documents`.
+ * The leading `/api/v1/...` bypasses the baseURL, hitting the correct server
+ * route directly.  Do not prepend a relative segment — keep the leading slash.
+ */
+import apiClient from './client';
+
+export interface OverlayDocumentDto {
+  id: string;
+  type: string;
+  title: string;
+  controlId: string;
+  content: string;
+  sourceReference?: string;
+  tenantId?: string;
+  isActive: boolean;
+  createdBy: string;
+  createdAt: string;
+  modifiedBy?: string;
+  modifiedAt?: string;
+}
+
+export interface CreateOverlayDocumentRequest {
+  type: string;
+  title: string;
+  controlId: string;
+  content: string;
+  sourceReference?: string;
+  tenantId?: string;
+}
+
+export interface UpdateOverlayDocumentRequest {
+  title?: string;
+  content?: string;
+  sourceReference?: string;
+  isActive?: boolean;
+}
+
+export async function listOverlayDocuments(params?: {
+  controlId?: string;
+  type?: string;
+  includeInactive?: boolean;
+}): Promise<OverlayDocumentDto[]> {
+  const res = await apiClient.get<OverlayDocumentDto[]>(
+    '/api/v1/admin/overlay-documents',
+    { params },
+  );
+  return res.data;
+}
+
+export async function getOverlayDocument(id: string): Promise<OverlayDocumentDto> {
+  const res = await apiClient.get<OverlayDocumentDto>(
+    `/api/v1/admin/overlay-documents/${id}`,
+  );
+  return res.data;
+}
+
+export async function createOverlayDocument(
+  req: CreateOverlayDocumentRequest,
+): Promise<OverlayDocumentDto> {
+  const res = await apiClient.post<OverlayDocumentDto>(
+    '/api/v1/admin/overlay-documents',
+    req,
+  );
+  return res.data;
+}
+
+export async function updateOverlayDocument(
+  id: string,
+  req: UpdateOverlayDocumentRequest,
+): Promise<OverlayDocumentDto> {
+  const res = await apiClient.put<OverlayDocumentDto>(
+    `/api/v1/admin/overlay-documents/${id}`,
+    req,
+  );
+  return res.data;
+}
+
+export async function deleteOverlayDocument(id: string): Promise<void> {
+  await apiClient.delete(`/api/v1/admin/overlay-documents/${id}`);
+}

--- a/src/Ato.Copilot.Dashboard/src/pages/KnowledgeBaseManagementPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/KnowledgeBaseManagementPage.tsx
@@ -1,68 +1,226 @@
+/**
+ * Issue #202 — Knowledge Base Management Page (full CRUD).
+ *
+ * Wraps the read-only table (from Feature #134) with:
+ *   - Add Document drawer/modal
+ *   - Edit mode in the detail drawer
+ *   - Delete (soft) with confirmation
+ *   - Restore button for inactive documents
+ *   - "Show inactive" toggle
+ *   - PageLayout + PageHero consistent with other admin pages
+ */
 import { useState, useEffect, useCallback } from 'react';
-import apiClient from '../api/client';
+import PageLayout from '../components/layout/PageLayout';
+import PageHero from '../components/layout/PageHero';
+import {
+  listOverlayDocuments,
+  createOverlayDocument,
+  updateOverlayDocument,
+  deleteOverlayDocument,
+  type OverlayDocumentDto,
+  type CreateOverlayDocumentRequest,
+  type UpdateOverlayDocumentRequest,
+} from '../api/overlayDocuments';
 
-interface OverlayDoc {
-  id: string;
+const OVERLAY_TYPES = ['CNSSI-1253', 'SECNAVINST', 'OPNAVINST', 'DoD-8140', 'DoD-8570'] as const;
+
+// ─── Add Document form state ───────────────────────────────────────────────
+interface AddFormState {
   type: string;
   title: string;
   controlId: string;
   content: string;
-  sourceReference?: string;
-  isActive: boolean;
-  createdBy: string;
-  createdAt: string;
+  sourceReference: string;
+  tenantId: string;
+}
+
+const blankAddForm = (): AddFormState => ({
+  type: OVERLAY_TYPES[0],
+  title: '',
+  controlId: '',
+  content: '',
+  sourceReference: '',
+  tenantId: '',
+});
+
+// ─── Edit form state ──────────────────────────────────────────────────────
+interface EditFormState {
+  title: string;
+  content: string;
+  sourceReference: string;
 }
 
 export default function KnowledgeBaseManagementPage() {
-  const [docs, setDocs] = useState<OverlayDoc[]>([]);
+  const [docs, setDocs] = useState<OverlayDocumentDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Filters
   const [filterType, setFilterType] = useState('');
   const [filterControl, setFilterControl] = useState('');
-  const [selected, setSelected] = useState<OverlayDoc | null>(null);
+  const [showInactive, setShowInactive] = useState(false);
 
+  // Detail drawer
+  const [selected, setSelected] = useState<OverlayDocumentDto | null>(null);
+
+  // Edit mode inside drawer
+  const [editMode, setEditMode] = useState(false);
+  const [editForm, setEditForm] = useState<EditFormState>({ title: '', content: '', sourceReference: '' });
+  const [editSaving, setEditSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  // Delete confirmation
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  // Add drawer
+  const [addOpen, setAddOpen] = useState(false);
+  const [addForm, setAddForm] = useState<AddFormState>(blankAddForm());
+  const [addSaving, setAddSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // ── Fetch ────────────────────────────────────────────────────────────────
   const fetchDocs = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      if (filterType) params.set('type', filterType);
-      if (filterControl) params.set('controlId', filterControl);
-      const res = await apiClient.get<OverlayDoc[]>(
-        `/api/v1/admin/overlay-documents${params.size ? '?' + params.toString() : ''}`
-      );
-      setDocs(res.data);
+      const data = await listOverlayDocuments({
+        type: filterType || undefined,
+        controlId: filterControl || undefined,
+        includeInactive: showInactive || undefined,
+      });
+      setDocs(data);
     } catch (e: unknown) {
       setError((e as Error).message ?? 'Failed to load overlay documents');
     } finally {
       setLoading(false);
     }
-  }, [filterType, filterControl]);
+  }, [filterType, filterControl, showInactive]);
 
   useEffect(() => { void fetchDocs(); }, [fetchDocs]);
 
-  const overlayTypes = ['CNSSI-1253', 'SECNAVINST', 'OPNAVINST', 'DoD-8140', 'DoD-8570'];
+  // ── Open detail drawer ───────────────────────────────────────────────────
+  const openDoc = (doc: OverlayDocumentDto) => {
+    setSelected(doc);
+    setEditMode(false);
+    setEditForm({ title: doc.title, content: doc.content, sourceReference: doc.sourceReference ?? '' });
+    setEditError(null);
+    setDeleteConfirm(false);
+  };
 
+  const closeDrawer = () => {
+    setSelected(null);
+    setEditMode(false);
+    setDeleteConfirm(false);
+    setEditError(null);
+  };
+
+  // ── Edit ─────────────────────────────────────────────────────────────────
+  const handleEditSave = async () => {
+    if (!selected) return;
+    setEditSaving(true);
+    setEditError(null);
+    try {
+      const req: UpdateOverlayDocumentRequest = {
+        title: editForm.title,
+        content: editForm.content,
+        sourceReference: editForm.sourceReference || undefined,
+      };
+      const updated = await updateOverlayDocument(selected.id, req);
+      setSelected(updated);
+      setEditMode(false);
+      await fetchDocs();
+    } catch (e: unknown) {
+      setEditError((e as Error).message ?? 'Save failed');
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  // ── Delete (soft) ─────────────────────────────────────────────────────────
+  const handleDelete = async () => {
+    if (!selected) return;
+    setDeleting(true);
+    try {
+      await deleteOverlayDocument(selected.id);
+      closeDrawer();
+      await fetchDocs();
+    } catch (e: unknown) {
+      setEditError((e as Error).message ?? 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // ── Restore ───────────────────────────────────────────────────────────────
+  const handleRestore = async () => {
+    if (!selected) return;
+    setEditSaving(true);
+    setEditError(null);
+    try {
+      const updated = await updateOverlayDocument(selected.id, { isActive: true });
+      setSelected(updated);
+      await fetchDocs();
+    } catch (e: unknown) {
+      setEditError((e as Error).message ?? 'Restore failed');
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  // ── Create ────────────────────────────────────────────────────────────────
+  const handleAddSave = async () => {
+    setAddSaving(true);
+    setAddError(null);
+    try {
+      const req: CreateOverlayDocumentRequest = {
+        type: addForm.type,
+        title: addForm.title,
+        controlId: addForm.controlId,
+        content: addForm.content,
+        sourceReference: addForm.sourceReference || undefined,
+        tenantId: addForm.tenantId || undefined,
+      };
+      await createOverlayDocument(req);
+      setAddOpen(false);
+      setAddForm(blankAddForm());
+      await fetchDocs();
+    } catch (e: unknown) {
+      setAddError((e as Error).message ?? 'Create failed');
+    } finally {
+      setAddSaving(false);
+    }
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold text-gray-900">Knowledge Base Management</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Manage NIST 800-53 overlay documents: Navy Instructions, DoD Directives, CNSSI-1253 NSS overlays.
-          </p>
-        </div>
-      </div>
+    <PageLayout title="Knowledge Base Management">
+      <PageHero
+        eyebrow="Administration"
+        title="Knowledge Base Management"
+        description="Manage NIST 800-53 overlay documents: Navy Instructions, DoD Directives, CNSSI-1253 NSS overlays."
+        actions={
+          <button
+            onClick={() => { setAddOpen(true); setAddError(null); setAddForm(blankAddForm()); }}
+            className="inline-flex items-center gap-2 rounded-lg bg-white/20 hover:bg-white/30 px-4 py-2 text-sm font-medium text-white ring-1 ring-white/40 transition-colors"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            Add Document
+          </button>
+        }
+      />
 
       {/* Filters */}
-      <div className="flex flex-wrap gap-3">
+      <div className="flex flex-wrap items-center gap-3 mb-4">
         <select
           value={filterType}
           onChange={e => setFilterType(e.target.value)}
           className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
         >
           <option value="">All Types</option>
-          {overlayTypes.map(t => <option key={t} value={t}>{t}</option>)}
+          {OVERLAY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
         </select>
         <input
           type="text"
@@ -77,19 +235,45 @@ export default function KnowledgeBaseManagementPage() {
         >
           Apply
         </button>
+        {/* Show inactive toggle */}
+        <label className="ml-auto flex items-center gap-2 cursor-pointer select-none text-sm text-gray-600">
+          <span
+            role="switch"
+            aria-checked={showInactive}
+            tabIndex={0}
+            onClick={() => setShowInactive(v => !v)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') setShowInactive(v => !v); }}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 ${showInactive ? 'bg-indigo-600' : 'bg-gray-300'}`}
+          >
+            <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${showInactive ? 'translate-x-4' : 'translate-x-0.5'}`} />
+          </span>
+          Show inactive
+        </label>
       </div>
 
-      {/* Error */}
+      {/* Error banner */}
       {error && (
-        <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-700">{error}</div>
+        <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-700 mb-4">{error}</div>
       )}
 
       {/* Table */}
       {loading ? (
-        <div className="text-sm text-gray-500">Loading overlay documents…</div>
+        <div className="flex items-center gap-2 text-sm text-gray-500 py-8">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent" />
+          Loading overlay documents…
+        </div>
       ) : docs.length === 0 ? (
         <div className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
-          <p className="text-sm text-gray-400">No overlay documents found. Add command-specific guidance above.</p>
+          <p className="text-sm text-gray-400">
+            No overlay documents found.{' '}
+            <button
+              className="text-indigo-600 hover:underline"
+              onClick={() => { setAddOpen(true); setAddError(null); setAddForm(blankAddForm()); }}
+            >
+              Add the first one
+            </button>
+            .
+          </p>
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
@@ -107,8 +291,8 @@ export default function KnowledgeBaseManagementPage() {
               {docs.map(doc => (
                 <tr
                   key={doc.id}
-                  onClick={() => setSelected(doc)}
-                  className="cursor-pointer hover:bg-indigo-50 transition-colors"
+                  onClick={() => openDoc(doc)}
+                  className={`cursor-pointer hover:bg-indigo-50 transition-colors ${!doc.isActive ? 'opacity-60' : ''}`}
                 >
                   <td className="px-4 py-3 font-mono text-indigo-700">{doc.controlId}</td>
                   <td className="px-4 py-3">
@@ -132,35 +316,288 @@ export default function KnowledgeBaseManagementPage() {
         </div>
       )}
 
-      {/* Detail drawer */}
+      {/* ── Detail / Edit Drawer ─────────────────────────────────────────── */}
       {selected && (
-        <div className="fixed inset-0 z-40 bg-black/30" onClick={() => setSelected(null)}>
+        <div className="fixed inset-0 z-40 bg-black/30" onClick={closeDrawer}>
           <aside
             className="absolute right-0 top-0 h-full w-full max-w-lg bg-white shadow-2xl overflow-y-auto"
             onClick={e => e.stopPropagation()}
           >
+            {/* Drawer header */}
             <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
-              <h2 className="text-base font-semibold text-gray-900">{selected.title}</h2>
-              <button onClick={() => setSelected(null)} className="text-gray-400 hover:text-gray-600">
-                ×
-              </button>
+              <h2 className="text-base font-semibold text-gray-900 truncate">
+                {editMode ? 'Edit Document' : selected.title}
+              </h2>
+              <button onClick={closeDrawer} className="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
             </div>
+
             <div className="p-5 space-y-4">
-              <div className="flex gap-3 text-sm">
-                <span className="font-mono text-indigo-700 bg-indigo-50 px-2 py-1 rounded">{selected.controlId}</span>
-                <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-xs font-medium">{selected.type}</span>
-              </div>
-              {selected.sourceReference && (
-                <p className="text-xs text-gray-500"><strong>Source:</strong> {selected.sourceReference}</p>
+              {/* Status + meta chips */}
+              {!editMode && (
+                <div className="flex flex-wrap gap-2 text-sm">
+                  <span className="font-mono text-indigo-700 bg-indigo-50 px-2 py-1 rounded">{selected.controlId}</span>
+                  <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-xs font-medium">{selected.type}</span>
+                  <span className={`px-2 py-1 rounded text-xs font-medium ${selected.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                    {selected.isActive ? 'Active' : 'Inactive'}
+                  </span>
+                </div>
               )}
-              <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-                <p className="text-sm text-gray-700 whitespace-pre-wrap">{selected.content}</p>
+
+              {/* View mode */}
+              {!editMode && (
+                <>
+                  {selected.sourceReference && (
+                    <p className="text-xs text-gray-500"><strong>Source:</strong> {selected.sourceReference}</p>
+                  )}
+                  <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
+                    <p className="text-sm text-gray-700 whitespace-pre-wrap">{selected.content}</p>
+                  </div>
+                  <p className="text-xs text-gray-400">
+                    Added by {selected.createdBy} · {new Date(selected.createdAt).toLocaleDateString()}
+                    {selected.modifiedAt && ` · Edited ${new Date(selected.modifiedAt).toLocaleDateString()}`}
+                  </p>
+                </>
+              )}
+
+              {/* Edit mode form */}
+              {editMode && (
+                <div className="space-y-3">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">Title</label>
+                    <input
+                      type="text"
+                      value={editForm.title}
+                      onChange={e => setEditForm(f => ({ ...f, title: e.target.value }))}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">Source Reference</label>
+                    <input
+                      type="text"
+                      value={editForm.sourceReference}
+                      onChange={e => setEditForm(f => ({ ...f, sourceReference: e.target.value }))}
+                      placeholder="e.g. SECNAVINST 5239.3C Para 5.a"
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">Content</label>
+                    <textarea
+                      value={editForm.content}
+                      onChange={e => setEditForm(f => ({ ...f, content: e.target.value }))}
+                      rows={8}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 font-mono"
+                    />
+                  </div>
+                  {editError && (
+                    <div className="rounded-lg bg-red-50 border border-red-200 p-2 text-xs text-red-700">{editError}</div>
+                  )}
+                </div>
+              )}
+
+              {/* Action buttons */}
+              <div className="flex flex-wrap gap-2 pt-2">
+                {!editMode ? (
+                  <>
+                    <button
+                      onClick={() => { setEditMode(true); setEditError(null); }}
+                      className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                    >
+                      Edit
+                    </button>
+                    {selected.isActive ? (
+                      <button
+                        onClick={() => setDeleteConfirm(true)}
+                        className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+                      >
+                        Delete
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => void handleRestore()}
+                        disabled={editSaving}
+                        className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                      >
+                        {editSaving ? 'Restoring…' : 'Restore'}
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => void handleEditSave()}
+                      disabled={editSaving}
+                      className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                    >
+                      {editSaving && <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+                      {editSaving ? 'Saving…' : 'Save Changes'}
+                    </button>
+                    <button
+                      onClick={() => { setEditMode(false); setEditError(null); }}
+                      className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                )}
               </div>
-              <p className="text-xs text-gray-400">Added by {selected.createdBy} · {new Date(selected.createdAt).toLocaleDateString()}</p>
+
+              {/* Delete confirmation */}
+              {deleteConfirm && !editMode && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-4 space-y-3">
+                  <p className="text-sm text-red-800 font-medium">Deactivate this document?</p>
+                  <p className="text-xs text-red-700">
+                    The document will be marked inactive and hidden from the knowledge base.
+                    It can be restored later using the Restore button.
+                  </p>
+                  {editError && (
+                    <div className="text-xs text-red-700">{editError}</div>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => void handleDelete()}
+                      disabled={deleting}
+                      className="inline-flex items-center gap-2 rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-50"
+                    >
+                      {deleting && <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+                      {deleting ? 'Deleting…' : 'Confirm Delete'}
+                    </button>
+                    <button
+                      onClick={() => setDeleteConfirm(false)}
+                      className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           </aside>
         </div>
       )}
-    </div>
+
+      {/* ── Add Document Drawer ──────────────────────────────────────────── */}
+      {addOpen && (
+        <div className="fixed inset-0 z-50 bg-black/30" onClick={() => setAddOpen(false)}>
+          <aside
+            className="absolute right-0 top-0 h-full w-full max-w-lg bg-white shadow-2xl overflow-y-auto"
+            onClick={e => e.stopPropagation()}
+          >
+            {/* Drawer header */}
+            <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+              <h2 className="text-base font-semibold text-gray-900">Add Overlay Document</h2>
+              <button onClick={() => setAddOpen(false)} className="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
+            </div>
+
+            <div className="p-5 space-y-4">
+              {/* Type */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Overlay Type <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={addForm.type}
+                  onChange={e => setAddForm(f => ({ ...f, type: e.target.value }))}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                >
+                  {OVERLAY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+
+              {/* Title */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Title <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={addForm.title}
+                  onChange={e => setAddForm(f => ({ ...f, title: e.target.value }))}
+                  placeholder="e.g. CNSSI-1253 SC Family Overlay"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                />
+              </div>
+
+              {/* Control ID */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Control ID <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={addForm.controlId}
+                  onChange={e => setAddForm(f => ({ ...f, controlId: e.target.value.toUpperCase() }))}
+                  placeholder="e.g. AC-1"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                />
+              </div>
+
+              {/* Content */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Content <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={addForm.content}
+                  onChange={e => setAddForm(f => ({ ...f, content: e.target.value }))}
+                  rows={8}
+                  placeholder="Overlay guidance text (plain text or Markdown)…"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 font-mono"
+                />
+              </div>
+
+              {/* Source Reference */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">Source Reference</label>
+                <input
+                  type="text"
+                  value={addForm.sourceReference}
+                  onChange={e => setAddForm(f => ({ ...f, sourceReference: e.target.value }))}
+                  placeholder="e.g. CNSSI No. 1253 Annex D, SC Family"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                />
+              </div>
+
+              {/* Tenant ID (optional) */}
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Tenant ID <span className="text-gray-400">(optional — leave blank for platform-wide)</span>
+                </label>
+                <input
+                  type="text"
+                  value={addForm.tenantId}
+                  onChange={e => setAddForm(f => ({ ...f, tenantId: e.target.value }))}
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                />
+              </div>
+
+              {addError && (
+                <div className="rounded-lg bg-red-50 border border-red-200 p-2 text-xs text-red-700">{addError}</div>
+              )}
+
+              {/* Actions */}
+              <div className="flex gap-2 pt-2">
+                <button
+                  onClick={() => void handleAddSave()}
+                  disabled={addSaving || !addForm.title || !addForm.controlId || !addForm.content}
+                  className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {addSaving && <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+                  {addSaving ? 'Saving…' : 'Add Document'}
+                </button>
+                <button
+                  onClick={() => setAddOpen(false)}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </aside>
+        </div>
+      )}
+    </PageLayout>
   );
 }

--- a/src/Ato.Copilot.Mcp/Endpoints/OverlayDocumentEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/OverlayDocumentEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 
 namespace Ato.Copilot.Mcp.Endpoints;
 
@@ -19,13 +20,18 @@ public static class OverlayDocumentEndpoints
             .WithTags("OverlayDocuments")
             .RequireAuthorization("AdminOnly");
 
+        // GET /api/v1/admin/overlay-documents
         group.MapGet("/", async (
                 string? controlId,
                 string? type,
+                bool? includeInactive,
                 AtoCopilotContext db,
                 CancellationToken ct) =>
         {
-            var query = db.OverlayDocuments.Where(o => o.IsActive);
+            var query = db.OverlayDocuments.AsQueryable();
+            // By default only return active documents; opt-in to include inactive.
+            if (!(includeInactive ?? false))
+                query = query.Where(o => o.IsActive);
             if (!string.IsNullOrEmpty(controlId))
                 query = query.Where(o => o.ControlId == controlId.ToUpperInvariant());
             if (!string.IsNullOrEmpty(type))
@@ -38,6 +44,7 @@ public static class OverlayDocumentEndpoints
             return Results.Ok(items);
         }).WithName("ListOverlayDocuments");
 
+        // GET /api/v1/admin/overlay-documents/{id}
         group.MapGet("/{id:guid}", async (
                 Guid id,
                 AtoCopilotContext db,
@@ -47,11 +54,17 @@ public static class OverlayDocumentEndpoints
             return doc is null ? Results.NotFound() : Results.Ok(new OverlayDocumentDto(doc));
         }).WithName("GetOverlayDocument");
 
+        // POST /api/v1/admin/overlay-documents
         group.MapPost("/", async (
                 CreateOverlayDocumentRequest req,
+                HttpContext httpContext,
                 AtoCopilotContext db,
                 CancellationToken ct) =>
         {
+            var actor = httpContext.User.FindFirstValue("oid")
+                     ?? httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                     ?? "system";
+
             var doc = new OverlayDocument
             {
                 Type = req.Type,
@@ -61,41 +74,55 @@ public static class OverlayDocumentEndpoints
                 SourceReference = req.SourceReference,
                 TenantId = req.TenantId,
                 IsActive = true,
-                CreatedBy = "admin"
+                CreatedBy = actor
             };
             db.OverlayDocuments.Add(doc);
             await db.SaveChangesAsync(ct);
             return Results.Created($"/api/v1/admin/overlay-documents/{doc.Id}", new OverlayDocumentDto(doc));
         }).WithName("CreateOverlayDocument");
 
+        // PUT /api/v1/admin/overlay-documents/{id}
         group.MapPut("/{id:guid}", async (
                 Guid id,
                 UpdateOverlayDocumentRequest req,
+                HttpContext httpContext,
                 AtoCopilotContext db,
                 CancellationToken ct) =>
         {
             var doc = await db.OverlayDocuments.FindAsync([id], ct);
             if (doc is null) return Results.NotFound();
 
+            var actor = httpContext.User.FindFirstValue("oid")
+                     ?? httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                     ?? "system";
+
             doc.Title = req.Title ?? doc.Title;
             doc.Content = req.Content ?? doc.Content;
             doc.SourceReference = req.SourceReference ?? doc.SourceReference;
             doc.IsActive = req.IsActive ?? doc.IsActive;
-            doc.ModifiedBy = "admin";
+            doc.ModifiedBy = actor;
             doc.ModifiedAt = DateTime.UtcNow;
 
             await db.SaveChangesAsync(ct);
             return Results.Ok(new OverlayDocumentDto(doc));
         }).WithName("UpdateOverlayDocument");
 
+        // DELETE /api/v1/admin/overlay-documents/{id}  (soft delete)
         group.MapDelete("/{id:guid}", async (
                 Guid id,
+                HttpContext httpContext,
                 AtoCopilotContext db,
                 CancellationToken ct) =>
         {
             var doc = await db.OverlayDocuments.FindAsync([id], ct);
             if (doc is null) return Results.NotFound();
+
+            var actor = httpContext.User.FindFirstValue("oid")
+                     ?? httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                     ?? "system";
+
             doc.IsActive = false;
+            doc.ModifiedBy = actor;
             doc.ModifiedAt = DateTime.UtcNow;
             await db.SaveChangesAsync(ct);
             return Results.NoContent();

--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -672,6 +672,8 @@ async Task RunHttpModeAsync(string[] args)
     app.MapAuditQueryEndpoints();
     // Feature 048 (T124, FR-073..FR-076): CSP-Admin migration utility surface.
     app.MapAdminMigrationEndpoints();
+    // Feature #134 / Issue #202: NIST KB overlay document CRUD surface.
+    app.MapOverlayDocumentEndpoints();
     // Feature 048 (T135, FR-081/FR-082): CSP-Admin cross-tenant baseline publish/unpublish surface.
     app.MapGlobalBaselineEndpoints();
 


### PR DESCRIPTION
## 1. Problem

The NIST Knowledge Base Management page (`/admin/knowledge-base`) was read-only and broken:

1. **Backend never wired**: `MapOverlayDocumentEndpoints()` was never called in `Program.cs` — all 5 CRUD endpoints returned 404.
2. **Seed data never loaded**: `OverlayDocumentSeed.GetSeedData()` existed but was not called — the DB had no overlay documents.
3. **Frontend read-only**: Existing 166-line page only showed a filterable table with a read-only detail drawer — no create, edit, delete, or restore functionality.
4. **Hardcoded `CreatedBy`**: POST handler used `"admin"` as the creator rather than the authenticated user's identity.

## 2. Goal

Complete the NIST Knowledge Base Management UI: wire the backend, seed initial data, and add full CRUD functionality to the admin page.

## 3. Scope

**In scope:** Backend route wiring, seed data, `CreatedBy` fix, typed API client module, full CRUD UI with create/edit/delete/restore and inactive document management.

**Out of scope:** Full-text search of document content, AI re-indexing trigger (follow-on with Epic 16), tenant-specific overlay management.

## 4. UX Flow

**Before:** Admin navigates to `/admin/knowledge-base` — sees empty table, all API calls return 404.

**After:** Admin sees a list of overlay documents with type/control ID/source filters. Can add new documents (type, title, control ID, content, source reference), edit existing ones, soft-delete with confirmation, restore inactive docs, and toggle "show inactive" to view the full history.

## 5. Functional Requirements

- `GET /api/v1/admin/overlay-documents` returns overlay documents (supports `includeInactive` query param)
- `POST` creates a new document with the authenticated user's identity as `CreatedBy`
- `PUT` updates title, content, source reference, and/or active status
- `DELETE` soft-deletes (sets `IsActive=false`)
- UI shows Add/Edit/Delete/Restore actions
- Show-inactive toggle surfaces soft-deleted records

## 6. Technical Design

- `Program.cs`: added `app.MapOverlayDocumentEndpoints();` after `app.MapAdminMigrationEndpoints()`
- `OverlayDocumentEndpoints.cs`: added `includeInactive` param; updated `CreatedBy`/`ModifiedBy` to use `HttpContext.User.FindFirstValue("oid") ?? FindFirstValue(NameIdentifier) ?? "system"`
- `AtoCopilotContext.cs`: added entity configuration + `HasData(OverlayDocumentSeed.GetSeedData())` in `OnModelCreating`
- `api/overlayDocuments.ts`: typed API client module (mirrors `orgControlOverrides.ts` pattern)
- `KnowledgeBaseManagementPage.tsx`: full rewrite with `PageLayout`/`PageHero` alignment, create drawer, edit mode in detail drawer, delete confirmation, restore button

## 7. Architecture Decisions

- Soft delete (not hard delete) preserved — compliance audit trail requires document history
- Create form includes tenant ID as optional field for multi-tenant overlay support
- `includeInactive` param defaults to `false` — inactive docs hidden by default, shown via toggle

## 8. Acceptance Criteria

- [ ] `GET /api/v1/admin/overlay-documents` returns 200 (not 404)
- [ ] Seed documents (CNSSI-1253, SECNAVINST, DoD-8140) visible on page load
- [ ] Admin can create a new overlay document and see it in the list
- [ ] Admin can edit title/content/source reference
- [ ] Admin can delete (soft) a document and see it disappear from the active list
- [ ] Show-inactive toggle reveals soft-deleted documents with a Restore button
- [ ] `CreatedBy` field shows the authenticated user's OID (not "admin")

## 9. NFRs

- All CRUD operations require `AdminOnly` authorization policy (unchanged from existing endpoint)
- No migration required — `OverlayDocuments` table and `Feature134` migration already exist

## 10. Test Plan

1. Navigate to `/admin/knowledge-base` as Admin → table should show seed documents
2. Click "Add Document" → fill form → Save → verify document appears in list
3. Click a document → Edit → change Title → Save → verify update persisted
4. Delete a document → verify it disappears from list
5. Toggle "Show inactive" → verify deleted document appears with Restore button
6. Click Restore → verify document reappears in active list

## 11. Definition of Done

- [ ] All CRUD routes return correct status codes
- [ ] Full UI functionality confirmed manually
- [ ] PR approved and merged
- [ ] Issue #202 closed

## 12. Anti-patterns / Constraints

- Do NOT hard-delete overlay documents — `IsActive=false` is the only delete path
- Do NOT expose tenant-specific overlays to other tenants — `AdminOnly` policy enforces isolation at the endpoint level

## 13. Files Changed

- `src/Ato.Copilot.Mcp/Program.cs`
- `src/Ato.Copilot.Mcp/Endpoints/OverlayDocumentEndpoints.cs`
- `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs`
- `src/Ato.Copilot.Dashboard/src/api/overlayDocuments.ts` (new)
- `src/Ato.Copilot.Dashboard/src/pages/KnowledgeBaseManagementPage.tsx`

## 14. Linked Issues

Closes #202

## 15. Reviewer Notes

The key change is Program.cs — one line that unlocks all 5 endpoints that were already built but dead. The frontend is a full rewrite (~500 lines) but structurally follows the `AdminMigrationPage.tsx` pattern exactly.
