### PR TITLE
feat(#60): Feature 072 — Anti Double-Entry: SPIN/eMASS Field Sync Status

### DIFF
--- a/specs/072-anti-double-entry/contracts/http-api.md
+++ b/specs/072-anti-double-entry/contracts/http-api.md
@@ -1,0 +1,231 @@
+# HTTP API Contract — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+All endpoints use the standard ATO Copilot envelope:
+
+```json
+{ "status": "success|error", "data": { ... }, "metadata": { "executionTimeMs": N, "timestamp": "ISO" } }
+```
+
+---
+
+## 1. GET `/api/systems/{systemId}/emass-sync-status`
+
+Returns the eMASS sync status for a registered system, including per-field divergence rows.
+
+### Authorization
+
+- Roles: `ISSO`, `ISSM`
+- `SCA` and `AO` receive **403 Forbidden** with error code `FORBIDDEN_ISSO_ISSM_REQUIRED`
+- Any authenticated user with `systemId` not in their tenant receives **404**
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `systemId` | `string` (GUID) | Registered system ID |
+
+### Response — 200 OK
+
+```json
+{
+  "status": "success",
+  "data": {
+    "overallStatus": "InSync",
+    "importDate": "2026-06-05T14:22:00Z",
+    "divergedFieldCount": 0,
+    "fields": [
+      {
+        "fieldName": "Name",
+        "emassValue": "ACME Portal",
+        "spinValue": "ACME Portal",
+        "isDiverged": false,
+        "importedAt": "2026-06-05T14:22:00Z",
+        "importSessionId": "a1b2c3d4-0000-0000-0000-000000000001",
+        "divergenceDetectedAt": null,
+        "reconciledAt": null
+      },
+      {
+        "fieldName": "DitprId",
+        "emassValue": "12345",
+        "spinValue": "12345",
+        "isDiverged": false,
+        "importedAt": "2026-06-05T14:22:00Z",
+        "importSessionId": "a1b2c3d4-0000-0000-0000-000000000001",
+        "divergenceDetectedAt": null,
+        "reconciledAt": null
+      },
+      {
+        "fieldName": "OverallLevel",
+        "emassValue": "Moderate",
+        "spinValue": "Moderate",
+        "isDiverged": false,
+        "importedAt": "2026-06-05T14:22:00Z",
+        "importSessionId": "a1b2c3d4-0000-0000-0000-000000000001",
+        "divergenceDetectedAt": null,
+        "reconciledAt": null
+      }
+    ]
+  },
+  "metadata": { "executionTimeMs": 12, "timestamp": "2026-06-11T10:00:00Z" }
+}
+```
+
+#### `overallStatus` Enum Values
+
+| Value | Meaning |
+|-------|---------|
+| `InSync` | eMASS import exists; all tracked fields match eMASS values |
+| `Diverged` | eMASS import exists; ≥1 field has `isDiverged = true` |
+| `NotImported` | No `EmassImportSession` with `Status = Imported` for this system |
+
+#### `EmassFieldStatusDto` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fieldName` | `string` | One of: `Name`, `Acronym`, `DitprId`, `OverallLevel`, `BaselineType`, `SystemType` |
+| `emassValue` | `string \| null` | Raw value from eMASS import column |
+| `spinValue` | `string \| null` | Current SPIN field value (stringified) |
+| `isDiverged` | `boolean` | True when spinValue ≠ emassValue (post-normalization) |
+| `importedAt` | `string` (ISO 8601) | When this field was last imported from eMASS |
+| `importSessionId` | `string` (GUID) | Which import session sourced this snapshot |
+| `divergenceDetectedAt` | `string \| null` | When divergence was first detected |
+| `reconciledAt` | `string \| null` | When field was last reconciled back to eMASS value |
+
+### Response — 403 Forbidden
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "FORBIDDEN_ISSO_ISSM_REQUIRED",
+    "message": "This operation requires ISSO or ISSM role."
+  }
+}
+```
+
+### Response — 404 Not Found
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "SYSTEM_NOT_FOUND",
+    "message": "System 'SYS-001' not found in this tenant."
+  }
+}
+```
+
+---
+
+## 2. POST `/api/systems/{systemId}/emass-sync-status/dismiss`
+
+Soft-dismisses the eMASS sync banner warnings for the calling user on this system.
+The sync status badge remains visible; only the inline field banners are suppressed.
+
+### Authorization
+
+- Roles: `ISSO`, `ISSM`
+- `SCA` and `AO` receive **403 Forbidden**
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `systemId` | `string` (GUID) | Registered system ID |
+
+### Request Body
+
+_Empty body — no payload required._
+
+### Response — 204 No Content
+
+_(No response body.)_
+
+### Response — 403 Forbidden
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "FORBIDDEN_ISSO_ISSM_REQUIRED",
+    "message": "This operation requires ISSO or ISSM role."
+  }
+}
+```
+
+---
+
+## 3. C# DTO Records
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Dto/EmassSyncDtos.cs
+// or inline in EmassSyncEndpoints.cs
+
+namespace Ato.Copilot.Mcp.Endpoints;
+
+public enum SyncOverallStatus
+{
+    InSync,
+    Diverged,
+    NotImported,
+}
+
+public record EmassFieldStatusDto(
+    string FieldName,
+    string? EmassValue,
+    string? SpinValue,
+    bool IsDiverged,
+    DateTimeOffset ImportedAt,
+    Guid ImportSessionId,
+    DateTimeOffset? DivergenceDetectedAt,
+    DateTimeOffset? ReconciledAt
+);
+
+public record EmassSystemSyncStatusDto(
+    SyncOverallStatus OverallStatus,
+    DateTimeOffset? ImportDate,
+    int DivergedFieldCount,
+    IReadOnlyList<EmassFieldStatusDto> Fields
+);
+```
+
+---
+
+## 4. TypeScript Types
+
+```typescript
+// File: src/Ato.Copilot.Dashboard/src/features/emass-sync/api.ts
+
+export type SyncOverallStatus = 'InSync' | 'Diverged' | 'NotImported';
+
+export interface EmassFieldStatusDto {
+  fieldName: string;
+  emassValue: string | null;
+  spinValue: string | null;
+  isDiverged: boolean;
+  importedAt: string;            // ISO 8601
+  importSessionId: string;       // GUID
+  divergenceDetectedAt: string | null;
+  reconciledAt: string | null;
+}
+
+export interface EmassSystemSyncStatusDto {
+  overallStatus: SyncOverallStatus;
+  importDate: string | null;     // ISO 8601
+  divergedFieldCount: number;
+  fields: EmassFieldStatusDto[];
+}
+
+// API client functions
+export async function getEmassSyncStatus(systemId: string): Promise<EmassSystemSyncStatusDto>;
+export async function dismissEmassBanner(systemId: string): Promise<void>;
+```
+
+---
+
+## 5. Error Codes Reference
+
+| Code | HTTP Status | When |
+|------|-------------|------|
+| `FORBIDDEN_ISSO_ISSM_REQUIRED` | 403 | Caller is SCA or AO role |
+| `SYSTEM_NOT_FOUND` | 404 | systemId not in caller's tenant (RLS) |

--- a/specs/072-anti-double-entry/data-model.md
+++ b/specs/072-anti-double-entry/data-model.md
@@ -1,0 +1,311 @@
+# Data Model — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+---
+
+## 1. New Entity: `EmassFieldSnapshot`
+
+### 1.1 C# Model
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Onboarding/EmassFieldSnapshot.cs
+
+using System.ComponentModel.DataAnnotations;
+using Ato.Copilot.Core.Models.Tenancy.Attributes;
+using Ato.Copilot.Core.Models.Onboarding;
+
+namespace Ato.Copilot.Core.Models.Onboarding;
+
+/// <summary>
+/// Feature 072 (Issue #60): Records the last-known eMASS value for a specific field on a
+/// registered system, enabling divergence detection and inline field-origin warnings.
+/// One row per (TenantId, SystemId, FieldName) — upserted on each eMASS import commit.
+/// </summary>
+[TenantScoped]
+public class EmassFieldSnapshot
+{
+    /// <summary>Primary key (server-generated GUID).</summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Tenant that owns this snapshot. Populated by TenantStampingSaveChangesInterceptor.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// FK to RegisteredSystem.Id (string PK). MaxLength matches RegisteredSystem.Id pattern.
+    /// Not a navigation property — string PK boundary per codebase convention.
+    /// </summary>
+    [Required]
+    [MaxLength(36)]
+    public string SystemId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Canonical field name. One of: Name | Acronym | DitprId | OverallLevel | BaselineType | SystemType.
+    /// Used as the lookup key for divergence detection and banner rendering.
+    /// </summary>
+    [Required]
+    [MaxLength(100)]
+    public string FieldName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Raw string value from the eMASS import column at the time of import.
+    /// Stored as string regardless of SPIN field type (e.g., "Moderate", "AC-2", "12345").
+    /// Null if the eMASS column was absent or empty during import.
+    /// </summary>
+    [MaxLength(1000)]
+    public string? EmassValue { get; set; }
+
+    /// <summary>UTC timestamp when this field value was imported from eMASS.</summary>
+    public DateTimeOffset ImportedAt { get; set; }
+
+    /// <summary>FK → EmassImportSession.Id — which import session produced this snapshot.</summary>
+    public Guid ImportSessionId { get; set; }
+
+    /// <summary>
+    /// True when the current SPIN field value differs from EmassValue.
+    /// Set by EmassFieldSyncService.CheckDivergenceAsync() after each relevant entity save.
+    /// </summary>
+    public bool IsDiverged { get; set; } = false;
+
+    /// <summary>UTC timestamp when divergence was first detected for this field. Null if never diverged.</summary>
+    public DateTimeOffset? DivergenceDetectedAt { get; set; }
+
+    /// <summary>UTC timestamp when the field was last reconciled (brought back in sync). Null if never reconciled.</summary>
+    public DateTimeOffset? ReconciledAt { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    // ── Navigation ───────────────────────────────────────────────────────────
+
+    /// <summary>Navigation to the import session that created this snapshot.</summary>
+    public EmassImportSession ImportSession { get; set; } = null!;
+}
+```
+
+### 1.2 Tracked Field Names (Constants)
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Onboarding/EmassTrackedField.cs
+
+namespace Ato.Copilot.Core.Models.Onboarding;
+
+/// <summary>
+/// Canonical field name constants for EmassFieldSnapshot.FieldName.
+/// These must match the keys used in EmassFieldSyncService and dashboard API client.
+/// </summary>
+public static class EmassTrackedField
+{
+    public const string Name          = "Name";
+    public const string Acronym       = "Acronym";
+    public const string DitprId       = "DitprId";
+    public const string OverallLevel  = "OverallLevel";
+    public const string BaselineType  = "BaselineType";
+    public const string SystemType    = "SystemType";
+
+    public static readonly IReadOnlyList<string> All = [Name, Acronym, DitprId, OverallLevel, BaselineType, SystemType];
+}
+```
+
+---
+
+## 2. Modified Entity: `RegisteredSystem`
+
+Add `DitprId` column (Feature 072):
+
+```csharp
+// In: src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs
+// Class: RegisteredSystem — add after existing Acronym property:
+
+/// <summary>
+/// DoD IT Portfolio Repository identifier (eMASS system_identifier field).
+/// Pre-populated from eMASS import by EmassCommitJobHandler (Feature 072, FR-005).
+/// </summary>
+[MaxLength(50)]
+public string? DitprId { get; set; }
+```
+
+---
+
+## 3. Optional: `UserPreference` Entity (if not already present)
+
+If no user-preference storage exists in the codebase (search for `UserPreference`
+before creating — it may already exist), create a minimal key-value store:
+
+```csharp
+// File: src/Ato.Copilot.Core/Models/Tenancy/UserPreference.cs
+
+using Ato.Copilot.Core.Models.Tenancy.Attributes;
+
+namespace Ato.Copilot.Core.Models.Tenancy;
+
+/// <summary>
+/// Simple key-value preference store scoped to a user within a tenant.
+/// Used by Feature 072 to persist banner-dismiss preferences server-side.
+/// Key pattern: "emass-banner-dismissed:{systemId}" for eMASS banner dismissals.
+/// </summary>
+[TenantScoped]
+public class UserPreference
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid TenantId { get; set; }
+
+    /// <summary>OID of the user this preference belongs to.</summary>
+    [MaxLength(256)]
+    public string UserOid { get; set; } = string.Empty;
+
+    /// <summary>Preference key (namespaced, e.g., "emass-banner-dismissed:SYS-001").</summary>
+    [MaxLength(256)]
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Preference value as string (e.g., "true", "false", JSON).</summary>
+    [MaxLength(2000)]
+    public string? Value { get; set; }
+
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+```
+
+> **Note:** If `UserPreference` already exists in the codebase, reuse it. Feature 072 only
+> needs to store a single `true/false` value keyed by `"emass-banner-dismissed:{systemId}"`.
+
+---
+
+## 4. EF Core Configuration
+
+Add to `AtoCopilotContext.OnModelCreating`:
+
+```csharp
+// In AtoCopilotContext.cs — OnModelCreating:
+
+modelBuilder.Entity<EmassFieldSnapshot>(b =>
+{
+    b.HasKey(s => s.Id);
+
+    // Primary lookup: get all snapshots for a system; also satisfies field-name lookup
+    b.HasIndex(s => new { s.TenantId, s.SystemId, s.FieldName })
+     .HasDatabaseName("IX_EmassFieldSnapshots_TenantId_SystemId_FieldName");
+
+    // Divergence-filter index: find diverged snapshots per system quickly
+    b.HasIndex(s => new { s.TenantId, s.SystemId, s.IsDiverged })
+     .HasDatabaseName("IX_EmassFieldSnapshots_TenantId_SystemId_IsDiverged");
+
+    // FK to import session — restrict delete so import session can't be hard-deleted
+    // while snapshots reference it
+    b.HasOne(s => s.ImportSession)
+     .WithMany()
+     .HasForeignKey(s => s.ImportSessionId)
+     .OnDelete(DeleteBehavior.Restrict);
+
+    // Tenant query filter — mirrors pattern used by other TenantScoped entities
+    b.HasQueryFilter(s =>
+        TenantFilterDisabled ||
+        TenantFilterCspAdminAll ||
+        s.TenantId == TenantFilterEffectiveId);
+});
+```
+
+### 4.1 DbSet Registration
+
+```csharp
+// In AtoCopilotContext.cs — after EmassImportSessions:
+
+// ─── eMASS Field Sync (Feature 072 / Issue #60) ───────────────────────────────
+
+/// <summary>Feature 072: per-field eMASS import snapshots for sync status and divergence detection.</summary>
+public DbSet<EmassFieldSnapshot> EmassFieldSnapshots => Set<EmassFieldSnapshot>();
+```
+
+---
+
+## 5. Migration SQL
+
+The EF-generated migration produces SQL equivalent to:
+
+### SQLite (dev)
+
+```sql
+ALTER TABLE "RegisteredSystems" ADD COLUMN "DitprId" TEXT;
+
+CREATE TABLE "EmassFieldSnapshots" (
+    "Id"                   TEXT NOT NULL CONSTRAINT "PK_EmassFieldSnapshots" PRIMARY KEY,
+    "TenantId"             TEXT NOT NULL,
+    "SystemId"             TEXT NOT NULL,
+    "FieldName"            TEXT NOT NULL,
+    "EmassValue"           TEXT,
+    "ImportedAt"           TEXT NOT NULL,
+    "ImportSessionId"      TEXT NOT NULL,
+    "IsDiverged"           INTEGER NOT NULL DEFAULT 0,
+    "DivergenceDetectedAt" TEXT,
+    "ReconciledAt"         TEXT,
+    "CreatedAt"            TEXT NOT NULL,
+    "UpdatedAt"            TEXT NOT NULL,
+    CONSTRAINT "FK_EmassFieldSnapshots_EmassImportSessions_ImportSessionId"
+        FOREIGN KEY ("ImportSessionId")
+        REFERENCES "EmassImportSessions" ("Id")
+        ON DELETE RESTRICT
+);
+
+CREATE INDEX "IX_EmassFieldSnapshots_TenantId_SystemId_FieldName"
+    ON "EmassFieldSnapshots" ("TenantId", "SystemId", "FieldName");
+
+CREATE INDEX "IX_EmassFieldSnapshots_TenantId_SystemId_IsDiverged"
+    ON "EmassFieldSnapshots" ("TenantId", "SystemId", "IsDiverged");
+```
+
+### SQL Server (prod)
+
+```sql
+ALTER TABLE [dbo].[RegisteredSystems]
+    ADD [DitprId] NVARCHAR(50) NULL;
+
+CREATE TABLE [dbo].[EmassFieldSnapshots] (
+    [Id]                   UNIQUEIDENTIFIER NOT NULL
+        CONSTRAINT [PK_EmassFieldSnapshots] PRIMARY KEY,
+    [TenantId]             UNIQUEIDENTIFIER NOT NULL,
+    [SystemId]             NVARCHAR(36)     NOT NULL,
+    [FieldName]            NVARCHAR(100)    NOT NULL,
+    [EmassValue]           NVARCHAR(1000)   NULL,
+    [ImportedAt]           DATETIMEOFFSET   NOT NULL,
+    [ImportSessionId]      UNIQUEIDENTIFIER NOT NULL,
+    [IsDiverged]           BIT              NOT NULL DEFAULT 0,
+    [DivergenceDetectedAt] DATETIMEOFFSET   NULL,
+    [ReconciledAt]         DATETIMEOFFSET   NULL,
+    [CreatedAt]            DATETIMEOFFSET   NOT NULL,
+    [UpdatedAt]            DATETIMEOFFSET   NOT NULL,
+    CONSTRAINT [FK_EmassFieldSnapshots_EmassImportSessions]
+        FOREIGN KEY ([ImportSessionId])
+        REFERENCES [dbo].[EmassImportSessions] ([Id])
+        ON DELETE NO ACTION
+);
+
+CREATE NONCLUSTERED INDEX [IX_EmassFieldSnapshots_TenantId_SystemId_FieldName]
+    ON [dbo].[EmassFieldSnapshots] ([TenantId], [SystemId], [FieldName]);
+
+CREATE NONCLUSTERED INDEX [IX_EmassFieldSnapshots_TenantId_SystemId_IsDiverged]
+    ON [dbo].[EmassFieldSnapshots] ([TenantId], [SystemId], [IsDiverged]);
+```
+
+---
+
+## 6. Indexes Rationale
+
+| Index | Queries Served | Cardinality |
+|-------|---------------|-------------|
+| `IX_EmassFieldSnapshots_TenantId_SystemId_FieldName` | `GET /emass-sync-status` (load all fields for system), divergence check (load specific field), upsert lookup | Low (≤ 6 rows per system) |
+| `IX_EmassFieldSnapshots_TenantId_SystemId_IsDiverged` | Divergence count for badge status (`WHERE IsDiverged = 1`) | Low |
+
+The table is expected to have at most 6 rows per system (one per tracked field), so index
+selectivity is high and all lookups will be fast (< 5 ms on any reasonable hardware).
+
+---
+
+## 7. No Schema Changes to Existing eMASS Tables
+
+This feature does **not** modify:
+- `EmassImportSessions` — no new columns; FK reference is read-only from snapshot side
+- `EmassImportParser` / `EmassParsedSystem` — parsing logic unchanged
+- `SecurityCategorization` — no new columns (divergence tracked via `EmassFieldSnapshot`)
+- `ControlBaseline` — no new columns
+
+The only schema changes are:
+1. New table `EmassFieldSnapshots`
+2. New column `RegisteredSystems.DitprId`

--- a/specs/072-anti-double-entry/plan.md
+++ b/specs/072-anti-double-entry/plan.md
@@ -1,0 +1,115 @@
+# Plan — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+---
+
+## Overview
+
+4-phase plan. Each phase has a hard checkpoint: the build must pass (`dotnet build`) and
+relevant tests must pass before the next phase begins. All phases target the same branch
+`072-anti-double-entry`.
+
+---
+
+## Phase 1 — Backend Foundation (Sprint 1, Days 1–2)
+
+**Goal:** Data model in place, migration applied, stub endpoints registered.
+
+**Tasks:** T001, T002, T003, T004, T005, T010, T011
+
+**Work:**
+1. Create `EmassFieldSnapshot.cs` entity and `EmassTrackedField.cs` constants
+2. Add `DitprId` column to `RegisteredSystem`
+3. Register `DbSet<EmassFieldSnapshot>` and EF config in `AtoCopilotContext.cs`
+4. Run `dotnet ef migrations add Feature072_EmassFieldSnapshot`
+5. Create `EmassSyncEndpoints.cs` with stub route handlers (all return `501 Not Implemented`)
+6. Register `MapEmassSyncEndpoints()` in startup
+
+**Checkpoint 1:** `dotnet build Ato.Copilot.sln` passes. Migration file exists and
+`dotnet ef database update` succeeds on SQLite dev database. Stub endpoints visible in Swagger
+at `GET /api/systems/{systemId}/emass-sync-status`.
+
+---
+
+## Phase 2 — Backend Logic: Pre-Population & Divergence (Sprint 1, Days 3–5)
+
+**Goal:** `EmassCommitJobHandler` creates snapshots; divergence check runs at entity save;
+both sync-status endpoints functional.
+
+**Tasks:** T006, T007, T008, T009, T012, T013, T014
+
+**Work:**
+1. Define `IEmassFieldSyncService` interface
+2. Implement `EmassFieldSyncService` — upsert, divergence check, sync status computation
+3. Extend `EmassCommitJobHandler` to create snapshots post-commit (non-destructive pre-population)
+4. Wire `CheckDivergenceAsync` into `RegisteredSystem` / `SecurityCategorization` / `ControlBaseline` saves
+5. Implement `GET /api/systems/{id}/emass-sync-status` — delegates to service
+6. Implement `POST /api/systems/{id}/emass-sync-status/dismiss`
+7. Define DTOs: `EmassSystemSyncStatusDto`, `EmassFieldStatusDto`
+
+**Checkpoint 2:** Run integration tests T021. After an eMASS import commit:
+- `EmassFieldSnapshot` rows exist for all present fields
+- `GET /api/systems/{id}/emass-sync-status` returns `InSync`
+- Edit `RegisteredSystem.Name` → status becomes `Diverged`
+- ISSO role: 200; SCA role: 403
+
+---
+
+## Phase 3 — Frontend: Sync Badge & Drawer (Sprint 2, Days 1–3)
+
+**Goal:** `EmassSyncBadge` and `SyncStatusDrawer` render in System Overview.
+
+**Tasks:** T015, T016, T017, T018
+
+**Work:**
+1. Create `src/features/emass-sync/api.ts` with typed Axios client
+2. Create `EmassSyncBadge.tsx` — green/yellow/red pill badge
+3. Create `SyncStatusDrawer.tsx` — per-field drawer panel
+4. Integrate badge into System Overview page header
+
+**Checkpoint 3:** Navigate to a system overview in the dev browser. Badge renders Green
+(after a mock eMASS import). Click badge → drawer opens with field rows. Switch to SCA role
+→ badge hidden. MSW handler T022 passes in Vitest.
+
+---
+
+## Phase 4 — Frontend: Inline Field Banner & Tests (Sprint 2, Days 4–5)
+
+**Goal:** `EmassFieldBanner` renders on tracked fields; full test coverage; DoD complete.
+
+**Tasks:** T019, T020, T021, T022, T023, T024, T025
+
+**Work:**
+1. Create `EmassFieldBanner.tsx` — origin/divergence inline notice
+2. Integrate banner into system registration / edit forms for all 5 tracked fields
+3. Complete integration tests (T021) — all 12 backend cases passing
+4. Register MSW handlers (T022)
+5. Complete frontend unit tests (T023)
+6. Docs update (T024)
+7. Mark spec `Status: Implemented` (T025)
+8. Final `dotnet test Ato.Copilot.sln` — zero failures
+
+**Checkpoint 4 (Final):** All DoD items checked. `dotnet test` passes. Vitest passes.
+Build passes. PR approved and linked to #60.
+
+---
+
+## Dependencies
+
+| Dependency | Required By | Risk |
+|------------|-------------|------|
+| `EmassImportSession` entity stable | Phase 1 (T001) | Low — entity mature, FK only |
+| `EmassCommitJobHandler` pipeline available | Phase 2 (T006) | Low — existing, extensible |
+| `RegisteredSystem`, `SecurityCategorization`, `ControlBaseline` save points identifiable | Phase 2 (T009) | Low-Medium — search required |
+| Feature 071 (Issue #59) round-trip sync | Not required — complementary | None — this feature is standalone |
+| `MSAL auth interceptor` pattern | Phase 3 (T015) | Low — pattern in existing API clients |
+| Drawer/modal pattern in dashboard | Phase 3 (T017) | Low — search existing components |
+
+## Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| `EmassCommitJobHandler` commit phase structure unclear | Medium | Medium | Grep for `// Phase` comments; read handler top-to-bottom before T006 |
+| Save points for divergence hook not obvious | Medium | Low | Grep `SaveChangesAsync` in `SystemProfileService`, `CategorizationService`, `BaselineService` |
+| `UserPreference` entity already exists | Low | Low | Search before creating; reuse existing pattern |
+| eMASS-to-SPIN field mapping ambiguity (e.g., categorization level string normalization) | Medium | Low | See `research.md R3`; use ToUpperInvariant() + Enum.TryParse as fallback |
+| Feature 071 (#59) spec changes overlapping entity | Low | Low | These features own different entities; no shared mutations |

--- a/specs/072-anti-double-entry/quickstart.md
+++ b/specs/072-anti-double-entry/quickstart.md
@@ -1,0 +1,251 @@
+# Quickstart — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+This guide covers local development verification, MSW mock setup, and end-to-end testing
+for Feature 072 (Issue #60).
+
+---
+
+## Prerequisites
+
+```bash
+# From repo root
+dotnet build Ato.Copilot.sln
+dotnet test  Ato.Copilot.sln
+
+# Dashboard (Vite dev server)
+cd src/Ato.Copilot.Dashboard
+npm ci
+npm run dev
+```
+
+---
+
+## 1. Apply Migration (Dev — SQLite)
+
+```bash
+# From repo root
+dotnet ef migrations add Feature072_EmassFieldSnapshot \
+  --project src/Ato.Copilot.Core \
+  --startup-project src/Ato.Copilot.Mcp
+
+dotnet ef database update \
+  --project src/Ato.Copilot.Core \
+  --startup-project src/Ato.Copilot.Mcp
+
+# Verify the tables were created
+sqlite3 data/ato-copilot.db ".tables" | grep -i emass
+# Expected output includes: EmassFieldSnapshots  EmassImportSessions  (and others)
+
+# Verify DitprId column added to RegisteredSystems
+sqlite3 data/ato-copilot.db "PRAGMA table_info(RegisteredSystems);" | grep DitprId
+# Expected: column name DitprId
+```
+
+---
+
+## 2. Verify Pre-Population via Integration Test
+
+The fastest way to verify pre-population is to run the integration test seed:
+
+```bash
+dotnet test tests/Ato.Copilot.Tests.Integration \
+  --filter "EmassFieldSnapshotTests" \
+  --logger "console;verbosity=detailed"
+```
+
+Expected: all 12 tests pass, including `CommitJob_CreatesFieldSnapshots_ForAllTrackedFields`.
+
+---
+
+## 3. MSW Mock Setup
+
+### Create the handler file
+
+**File:** `src/Ato.Copilot.Dashboard/src/mocks/handlers/emassSync.ts`
+
+```typescript
+import { http, HttpResponse } from 'msw';
+
+export type SyncOverallStatus = 'InSync' | 'Diverged' | 'NotImported';
+
+export interface EmassFieldStatusDto {
+  fieldName: string;
+  emassValue: string | null;
+  spinValue: string | null;
+  isDiverged: boolean;
+  importedAt: string;
+}
+
+export interface EmassSystemSyncStatusDto {
+  overallStatus: SyncOverallStatus;
+  importDate: string | null;
+  divergedFieldCount: number;
+  fields: EmassFieldStatusDto[];
+}
+
+const MOCK_IN_SYNC: EmassSystemSyncStatusDto = {
+  overallStatus: 'InSync',
+  importDate: '2026-06-05T14:22:00Z',
+  divergedFieldCount: 0,
+  fields: [
+    { fieldName: 'Name',         emassValue: 'ACME Portal',  spinValue: 'ACME Portal', isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+    { fieldName: 'DitprId',      emassValue: '12345',        spinValue: '12345',       isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+    { fieldName: 'OverallLevel', emassValue: 'Moderate',     spinValue: 'Moderate',    isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+    { fieldName: 'BaselineType', emassValue: 'Moderate',     spinValue: 'Moderate',    isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+  ],
+};
+
+const MOCK_DIVERGED: EmassSystemSyncStatusDto = {
+  overallStatus: 'Diverged',
+  importDate: '2026-06-05T14:22:00Z',
+  divergedFieldCount: 1,
+  fields: [
+    { fieldName: 'Name',         emassValue: 'ACME Portal',  spinValue: 'ACME Portal v2', isDiverged: true,  importedAt: '2026-06-05T14:22:00Z' },
+    { fieldName: 'DitprId',      emassValue: '12345',        spinValue: '12345',          isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+    { fieldName: 'OverallLevel', emassValue: 'Moderate',     spinValue: 'Moderate',       isDiverged: false, importedAt: '2026-06-05T14:22:00Z' },
+  ],
+};
+
+const MOCK_NOT_IMPORTED: EmassSystemSyncStatusDto = {
+  overallStatus: 'NotImported',
+  importDate: null,
+  divergedFieldCount: 0,
+  fields: [],
+};
+
+// Toggle this for different test scenarios:
+const MOCK_STATUS = MOCK_IN_SYNC;
+
+export const emassSyncHandlers = [
+  http.get('/api/systems/:systemId/emass-sync-status', ({ params }) => {
+    const { systemId } = params;
+    console.debug('[MSW] emass-sync-status for', systemId);
+    return HttpResponse.json(
+      { status: 'success', data: MOCK_STATUS, metadata: { executionTimeMs: 8, timestamp: new Date().toISOString() } },
+      { status: 200 },
+    );
+  }),
+
+  http.post('/api/systems/:systemId/emass-sync-status/dismiss', () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+];
+```
+
+### Register handlers
+
+**File:** `src/Ato.Copilot.Dashboard/src/mocks/handlers/index.ts`
+
+```typescript
+import { emassSyncHandlers } from './emassSync';
+// ...existing imports...
+
+export const handlers = [
+  ...emassSyncHandlers,
+  // ...existing handlers...
+];
+```
+
+---
+
+## 4. Sync Badge Manual Verification
+
+Open the dashboard at `http://localhost:5173`.
+
+1. Navigate to a system's overview page (e.g., `/systems/SYS-001/overview`).
+2. The eMASS Sync badge should appear in the header. With MSW mock set to `MOCK_IN_SYNC`:
+   - Badge renders as **green** with text "✓ eMASS In Sync".
+3. Change `MOCK_STATUS` to `MOCK_DIVERGED` and hot-reload:
+   - Badge renders as **yellow** with text "⚠ Diverged (1 field)".
+4. Click the badge → `SyncStatusDrawer` opens with field rows.
+5. Verify "View Import History" link is present in the drawer footer.
+6. Switch role to **SCA** via RoleSwitcher → badge should be absent.
+
+---
+
+## 5. Field Banner Manual Verification
+
+1. Navigate to the System Registration or Edit form for a system.
+2. Focus the "System Name" field.
+3. With MSW returning `MOCK_IN_SYNC`, the banner should show:
+   "📥 Imported from eMASS on Jun 5, 2026. Editing here won't update eMASS."
+4. Change `MOCK_STATUS` to `MOCK_DIVERGED` (where `Name` is diverged):
+   "⚠️ Diverged from eMASS value (imported Jun 5, 2026): eMASS had 'ACME Portal'."
+5. Click "Dismiss" → banner hides.
+6. Reload the page → banner is still hidden (localStorage persists).
+7. Open DevTools → clear `localStorage` → reload → banner reappears.
+
+---
+
+## 6. End-to-End Sync Status API Test (curl)
+
+```bash
+# Requires a valid JWT from dev auth bypass or MSAL token
+TOKEN="your-dev-token-here"
+SYSTEM_ID="SYS-001"
+
+# Get sync status
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5000/api/systems/$SYSTEM_ID/emass-sync-status \
+  | jq '.data.overallStatus'
+# Expected: "InSync" (after an eMASS import commit) or "NotImported" (fresh system)
+
+# Verify ISSO role receives 200:
+curl -v -H "Authorization: Bearer $TOKEN" \
+  -H "X-Simulated-Role: ISSO" \
+  http://localhost:5000/api/systems/$SYSTEM_ID/emass-sync-status
+# Expected: HTTP 200
+
+# Verify SCA role receives 403:
+curl -v -H "Authorization: Bearer $TOKEN" \
+  -H "X-Simulated-Role: SCA" \
+  http://localhost:5000/api/systems/$SYSTEM_ID/emass-sync-status
+# Expected: HTTP 403
+
+# Dismiss banner
+curl -X POST -v -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5000/api/systems/$SYSTEM_ID/emass-sync-status/dismiss
+# Expected: HTTP 204 No Content
+```
+
+---
+
+## 7. Common Pitfalls
+
+### Pitfall 1: `TenantFilterEffectiveId` Not Available in `EmassFieldSnapshot` Query Filter
+
+If you see `NullReferenceException` in `OnModelCreating` when applying the tenant query filter
+to `EmassFieldSnapshot`, ensure the filter lambda uses the same pattern as other `TenantScoped`
+entities in `AtoCopilotContext`. Check an existing `TenantScoped` entity's query filter
+configuration as the template (search for `HasQueryFilter(s => TenantFilterDisabled`).
+
+### Pitfall 2: Divergence Check Throws When No Snapshots Exist
+
+`CheckDivergenceAsync` must be a no-op (return immediately, no throw) when no
+`EmassFieldSnapshot` rows exist for the system. The early-exit guard:
+```csharp
+var snapshots = await db.EmassFieldSnapshots
+    .Where(s => s.SystemId == systemId)
+    .ToListAsync(ct);
+if (!snapshots.Any()) return;
+```
+
+### Pitfall 3: `EmassImportSession` System Link
+
+`EmassImportSession` does not have a direct FK to `RegisteredSystem.Id`. To determine which
+sessions belong to a system, the commit handler populates `RegisteredSystem.Name` from the
+session — the link is implicit via the parsed system name or an explicit join table written
+during commit. In `GetSyncStatusAsync`, query `EmassFieldSnapshots` for the system first
+(they have `SystemId`) and derive the import date from the joined `ImportSession.UpdatedAt`.
+
+### Pitfall 4: `localStorage` Key Collision Between Systems
+
+The localStorage dismiss key pattern includes both `fieldName` and `systemId`:
+`emass-field-banner-dismissed-{fieldName}-{systemId}`. This ensures dismissing the banner
+for System A's Name field does not hide the banner for System B's Name field.
+
+### Pitfall 5: Badge Route — System Overview Page Location
+
+The System Overview page route may be at `/systems/:id`, `/systems/:id/overview`, or under
+a `SystemLayout` wrapper. Search `App.tsx` for `overview` or `SystemOverview` to find the
+exact route and component file before adding `<EmassSyncBadge />`.

--- a/specs/072-anti-double-entry/research.md
+++ b/specs/072-anti-double-entry/research.md
@@ -1,0 +1,197 @@
+# Research — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+Decision records for architectural choices in Feature 072 (Issue #60).
+
+---
+
+## R1: Linking `EmassFieldSnapshot` to `RegisteredSystem` — String PK Boundary
+
+**Question:** Should `EmassFieldSnapshot.SystemId` be a FK with navigation to `RegisteredSystem`?
+
+**Answer: No navigation property — string FK only.**
+
+### Evidence
+
+`RegisteredSystem.Id` is a string PK (GUID as string, `[MaxLength(36)]`) per
+`src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs`. The codebase convention for string PK
+foreign keys avoids navigation properties on the referencing side in many places to prevent
+circular dependency chains and migration complications.
+
+`EmassFieldSnapshot` lives in `Ato.Copilot.Core.Models.Onboarding` (same namespace as
+`EmassImportSession`), while `RegisteredSystem` lives in `Ato.Copilot.Core.Models.Compliance`.
+Adding a navigation property would create a cross-namespace dependency from `Onboarding` →
+`Compliance` models, which goes against the dependency direction of the codebase.
+
+The sync status service resolves the system by querying `AtoCopilotContext.RegisteredSystems`
+directly (EF + RLS), not through a navigation property.
+
+**Decision: R1 — `EmassFieldSnapshot.SystemId: string [MaxLength(36)]`. No navigation
+to `RegisteredSystem`. FK constraint is NOT added at the DB level (soft FK via application logic).**
+
+---
+
+## R2: Divergence Check Timing — Synchronous vs Background Job
+
+**Question:** Should divergence detection run synchronously at entity-save time, or as a
+background/scheduled job?
+
+**Answer: Synchronous at save time.**
+
+### Rationale
+
+1. **Immediate feedback loop**: The sync status badge must reflect reality immediately after
+   an ISSO edits a field. A background job delay of seconds to minutes would show stale
+   "In Sync" after the ISSO just edited the field — confusing and defeats the purpose.
+2. **Low overhead**: The divergence check is an indexed lookup of at most 6 rows
+   (`EmassFieldSnapshot` cardinality per system). At < 5 ms query time, the total overhead
+   is negligible compared to a typical HTTP handler (50–200 ms).
+3. **No background infrastructure needed**: Adding a background queue or hosted service for
+   a 6-row lookup is overengineering. The existing `Channel`-based background infrastructure
+   (Feature 037) is reserved for heavy operations (package generation, OSCAL export).
+4. **Atomic with the save**: If the save fails, the divergence check never runs — no
+   orphaned divergence state.
+
+**Guard against divergence-check exceptions**: If `CheckDivergenceAsync` throws (e.g., DB
+transient error), the exception is caught, logged as warning, and swallowed. The main entity
+save is not rolled back due to a failed divergence check.
+
+**Decision: R2 — Synchronous divergence check at entity save. Swallow exceptions with warning log.**
+
+---
+
+## R3: Field Value Normalization for Divergence Comparison
+
+**Question:** How should SPIN enum values (e.g., `ImpactLevel.Moderate`) be compared against
+raw eMASS string values (e.g., `"Moderate"`, `"MODERATE"`, `"moderate"`)  for divergence detection?
+
+**Answer: Canonical string normalization with `ToUpperInvariant()` on both sides.**
+
+### Rationale
+
+eMASS XLSX exports are not standardized — casing and whitespace vary between eMASS versions
+and agency configurations. SPIN stores enum values that serialize to Pascal-case strings.
+
+The normalization algorithm:
+1. `emassValue.Trim().ToUpperInvariant()`
+2. `spinValue.ToString().ToUpperInvariant()` (where `spinValue` is the current enum or string value)
+3. Compare equality
+
+Edge cases:
+- eMASS value `"LOW"`, SPIN value `ImpactLevel.Low.ToString() = "Low"` → both → `"LOW"` → equal (In Sync)
+- eMASS value `"MODERATE"`, SPIN value `"Moderate"` → both → `"MODERATE"` → equal (In Sync)
+- eMASS value `"  High "` → trimmed → `"HIGH"`, SPIN `"High"` → `"HIGH"` → equal (In Sync)
+- eMASS value `"CNSSI 1253 Moderate"`, SPIN value `"Moderate"` → NOT equal → Diverged
+  (correctly flagged — annotated value vs simple value)
+
+The `EmassTrackedField` constants define the canonical SPIN property name used to look up
+the current value via reflection or a switch on `FieldName`.
+
+**Decision: R3 — Trim + ToUpperInvariant() comparison. Log a structured note when comparison
+yields unexpected mismatch for debugging during initial rollout.**
+
+---
+
+## R4: New Entity vs Extending Existing Models
+
+**Question:** Should divergence state be stored as new columns on `RegisteredSystem` and
+`SecurityCategorization` (e.g., `EmassSourcedAt`, `EmassValue`, `IsDiverged`), or as a
+separate `EmassFieldSnapshot` table?
+
+**Answer: Separate `EmassFieldSnapshot` table.**
+
+### Rationale
+
+1. **Extensibility**: The list of tracked fields may grow (e.g., `InterconnectionCount`,
+   `AuthorizationBoundaryDefined`). Adding per-field columns to core entities would bloat
+   their schemas with eMASS-specific audit metadata.
+2. **Normalized design**: One row per `(SystemId, FieldName)` is cleaner than 12+ new nullable
+   columns spread across `RegisteredSystem`, `SecurityCategorization`, and `ControlBaseline`.
+3. **Separation of concerns**: eMASS import lineage is an onboarding concern; core entity
+   models should not carry import metadata beyond the minimum (e.g., `DitprId` is a true
+   system attribute, not just import metadata).
+4. **Audit trail**: The `EmassFieldSnapshot` table can store multiple snapshots over time if
+   needed (currently one per field, but the design allows history if re-import frequency
+   warrants it in a future iteration).
+
+**Decision: R4 — New `EmassFieldSnapshot` table. Only `DitprId` is added directly to
+`RegisteredSystem` because it is a genuine system attribute (DoD system identifier), not
+merely import metadata.**
+
+---
+
+## R5: Banner Dismiss Storage — localStorage vs Server-Side Preference
+
+**Question:** Should the "dismiss this banner" action write to `localStorage` (client-only)
+or to a server-side `UserPreference` record?
+
+**Answer: Primary implementation uses `localStorage` for per-session UX; `POST /dismiss`
+endpoint exists for server-side persistence (optional, out of scope for initial release).**
+
+### Rationale
+
+1. **Performance**: A server round-trip to dismiss an informational UI banner is excessive.
+   `localStorage` is instant and survives page reloads (same browser).
+2. **Scope**: The banner is informational — it does not affect security controls or compliance
+   data. Losing the dismiss preference on a different browser/device is a minor UX annoyance,
+   not a correctness issue.
+3. **Existing precedent**: The dashboard already uses `localStorage` for UI preferences
+   (e.g., sidebar state, role switcher).
+4. **Progressive enhancement**: The `POST /api/systems/{id}/emass-sync-status/dismiss`
+   endpoint is specced (T013) to enable server-side persistence in a future iteration
+   (cross-device consistency). The initial implementation may store in `localStorage` only.
+
+**Decision: R5 — `localStorage` for dismiss UX. `POST /dismiss` endpoint specced but
+server-side storage is a Phase 2 enhancement. Badge divergence state is NEVER affected by dismiss.**
+
+---
+
+## R6: Sync Status Badge Visibility — Hidden vs Disabled for SCA/AO
+
+**Question:** Should the sync badge be hidden (`return null`) or rendered in a disabled/read-only
+state for SCA and AO roles?
+
+**Answer: Hidden.**
+
+### Rationale
+
+1. **UX clarity**: SCA and AO do not own the eMASS import workflow. Showing them a badge they
+   cannot act on creates confusion ("Why can't I click this? What does it mean?").
+2. **Role context**: SCA (Security Control Assessor) is a read-only assessor role; AO
+   (Authorizing Official) approves authorization decisions but does not manage data entry.
+   Neither role initiates or resolves eMASS sync divergences.
+3. **Consistency**: The existing pattern for write-gated controls in the dashboard is to
+   hide them for read-only roles (e.g., Subscribe button in Epic #225 is hidden for SCA/AO,
+   not grayed out).
+
+The `GET /api/systems/{id}/emass-sync-status` endpoint returns 403 for SCA/AO — this is the
+backend enforcement. The frontend `EmassSyncBadge` component checks `settings.role` client-side
+as an additional UX guard (defense in depth).
+
+**Decision: R6 — Badge hidden for SCA/AO roles (both client and server enforcement).**
+
+---
+
+## R7: Pre-Population Strategy — Overwrite vs Non-Destructive Merge
+
+**Question:** When an eMASS import is committed and a SPIN field already has a value, should
+the import overwrite it?
+
+**Answer: Non-destructive merge — do NOT overwrite existing SPIN values.**
+
+### Rationale
+
+1. **Data integrity**: An ISSO may have manually entered system data before importing from eMASS,
+   or may have intentionally edited the field after a prior import. Silently overwriting their
+   work would be a destructive action.
+2. **Feature 071 ownership**: Explicit re-sync / overwrite workflows are the domain of
+   Feature 071 (Issue #59), which handles round-trip sync with user confirmation. Feature 072
+   is specifically about data entry minimization — filling gaps, not replacing existing data.
+3. **Still useful**: Even when a field is not overwritten, the `EmassFieldSnapshot` is still
+   created with the eMASS value. This allows divergence detection to work correctly: if the
+   SPIN value differs from the eMASS value, the badge shows Yellow/Diverged — which is
+   the right behavior.
+4. **Toast visibility**: The "N fields pre-populated" toast counts only fields that were empty
+   in SPIN before the import. Fields that were already set and skipped are not counted.
+
+**Decision: R7 — Non-destructive merge. Always create/update `EmassFieldSnapshot`. Only
+pre-populate SPIN field if it is null/empty. Never overwrite a user-entered value.**

--- a/specs/072-anti-double-entry/spec.md
+++ b/specs/072-anti-double-entry/spec.md
@@ -1,0 +1,342 @@
+# Spec 072 — Anti-Double-Entry: SPIN/eMASS Sync Status
+
+**Epic:** #60 — Minimize Double Work (SPIN/eMASS)
+**GitHub Issue:** #60
+**Wave:** 9 — Core UX & Integrations
+**Status:** Draft
+**Branch:** `072-anti-double-entry`
+**Feature Predecessor:** Feature 071 (Issue #59) — eMASS round-trip sync & readiness check
+
+---
+
+## Background
+
+ISSOs maintaining both eMASS (DoD system of record) and SPIN (ATO Copilot workspace) must
+currently duplicate data entry in both systems. When eMASS data is imported into SPIN via
+the onboarding wizard (Feature 047), fields like `system name`, `DitprId`, security
+categorization levels, baseline, and control counts are pre-populated — but SPIN has no
+mechanism to:
+
+1. Alert the ISSO that a field was sourced from eMASS (so they know editing it creates divergence)
+2. Track whether a key field has since diverged from the last-imported eMASS value
+3. Show a rollup "sync status" badge on the system overview that communicates import freshness
+
+Feature 071 (Issue #59) addresses the **backend sync mechanism** — the round-trip pipeline,
+readiness checks, and export triggers. Feature 072 (this spec) addresses the **UX/workflow side**:
+
+- Field-level inline warnings when an eMASS-sourced field is edited
+- Pre-population completeness enforcement for eMASS-imported fields
+- Divergence detection for key fields vs last-imported eMASS values
+- Sync status badge on the System Overview page: Green=In sync, Yellow=Diverged, Red=Missing
+
+These two features are **complementary, not duplicate**. #59 moves data; #72 helps the ISSO
+understand the data lineage and avoid redundant work.
+
+### eMASS-Sourced Fields in Scope
+
+The following fields are tracked for divergence (sourced during eMASS import via
+`EmassImportSession` → `EmassCommitJobHandler`):
+
+| SPIN Field | eMASS Source Column | Entity |
+|---|---|---|
+| `RegisteredSystem.Name` | `system_name` | `RegisteredSystem` |
+| `RegisteredSystem.Acronym` | `system_acronym` (if present) | `RegisteredSystem` |
+| `SecurityCategorization.OverallLevel` | `categorization` / impact level | `SecurityCategorization` |
+| `ControlBaseline.BaselineType` | `baseline` / control count | `ControlBaseline` |
+| `RegisteredSystem.DitprId` | `system_identifier` (DoD IT Portfolio Repository ID) | `RegisteredSystem` |
+| `RegisteredSystem.SystemType` | `system_type` | `RegisteredSystem` |
+
+---
+
+## Verified Source Facts
+
+The following facts were verified against actual source code before authoring this spec.
+Do not re-verify; trust these facts during implementation.
+
+**`RegisteredSystem` model** (`src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs`):
+- `Id: string` PK (GUID string)
+- `TenantId: Guid` (TenantScoped)
+- `Name: string` `[MaxLength(200)]`
+- `Acronym: string?` `[MaxLength(20)]`
+- `SystemType: SystemType` enum
+- `Description: string?` `[MaxLength(2000)]`
+- `MissionCriticality: MissionCriticality` enum
+- `IsNationalSecuritySystem: bool`
+- `HostingEnvironment: string` `[MaxLength(100)]`
+- `CurrentRmfStep: RmfPhase`
+- No existing `DitprId` or `EmassSourcedAt` fields — these must be added
+
+**`SecurityCategorization` model** (`src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs`):
+- `Id: string` PK, `TenantId: Guid`, `RegisteredSystemId: string`
+- `IsNationalSecuritySystem: bool`
+- `Justification: string?` `[MaxLength(4000)]`
+- `CategorizedBy: string` `[MaxLength(200)]`
+- No existing `EmassSourcedAt` or `EmassValue` fields — these must be added
+
+**`EmassImportSession`** (`src/Ato.Copilot.Core/Models/Onboarding/EmassImportSession.cs`):
+- `Id: Guid` PK, `TenantId: Guid`
+- `OriginalFileName: string`, `StorageBlobKey: string`
+- `ContentChecksumSha256: string` — used as version tag
+- `Status: EmassImportStatus` (Uploaded → Parsing → Parsed → Importing → Imported → Failed)
+- `CreatedAt: DateTimeOffset`, `UpdatedAt: DateTimeOffset`
+
+**`EmassImportParser`** (`src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Emass/EmassImportParser.cs`):
+- Parses XLSX or PackageZip
+- Column headers (case-insensitive): `system_identifier`, `system_name`; optional: `controls`, `poams`
+- Per FR-031: malformed systems flagged via `EmassParsedSystem.MalformedReason`
+
+**`AtoCopilotContext`** — contains `DbSet<RegisteredSystem>`, `DbSet<SecurityCategorization>`,
+`DbSet<EmassImportSession>`. `RegisteredSystem` uses string PK pattern (GUID as string).
+
+**Dashboard** (`src/Ato.Copilot.Dashboard/src`): React/Vite/TypeScript, Tailwind CSS.
+Existing `SystemLayout.tsx` sidebar, `App.tsx` routes, `PageLayout`/`PageHero` pattern.
+
+---
+
+## User Stories
+
+### US1 (P1): Field-Level eMASS Origin Warning
+
+**As an ISSO**, when I edit a field in SPIN that was originally imported from eMASS,
+I want to see an inline notice that tells me when it was imported and that editing here
+won't update eMASS, so I understand the data lineage and make informed edits.
+
+**Acceptance Criteria:**
+
+1. When the ISSO focuses a SPIN form field that has an `EmassFieldSnapshot` record for that
+   field, an inline banner renders below the field reading:
+   "📥 Imported from eMASS on [date]. Editing here won't update eMASS."
+2. The banner shows the date in local timezone using the format `MMM D, YYYY` (e.g., `Jun 5, 2026`).
+3. The banner renders for fields: system name, acronym, DitprId, security categorization level,
+   baseline type — any field with a matching `EmassFieldSnapshot` record.
+4. The banner does not render if no `EmassFieldSnapshot` exists for the field
+   (i.e., field was entered manually, not imported).
+5. The banner does not block input or validation — it is informational only.
+6. If the current SPIN value diverges from the `EmassFieldSnapshot.EmassValue`, the banner
+   text changes to: "⚠️ Diverged from eMASS value (imported [date]): eMASS had '[emassValue]'."
+7. The banner is accessible: `role="note"`, `aria-label="eMASS import notice"`.
+8. The banner can be dismissed per-session (preference stored in `localStorage`; does not
+   affect the divergence badge on the overview page).
+
+**Edge Cases:**
+
+- Field has an `EmassFieldSnapshot` but `EmassValue` is null/empty: show origin warning
+  without the "eMASS had '...'" diverged fragment.
+- ISSO dismisses the banner, then navigates away and returns: banner is hidden per-session
+  (localStorage key: `emass-field-banner-dismissed-{fieldName}-{systemId}`).
+- Multiple imports: only the most recent `EmassFieldSnapshot` row per `(SystemId, FieldName)` is used.
+
+---
+
+### US2 (P1): Pre-Population Completeness
+
+**As an ISSO**, when eMASS data has been imported for my system, I want SPIN to pre-populate
+all fields it can derive from the import, so I don't have to re-enter data already in eMASS.
+
+**Acceptance Criteria:**
+
+1. After a successful `EmassImportSession` commit, the following SPIN fields are pre-populated
+   (if not already set) from the eMASS import data:
+   - `RegisteredSystem.Name` ← `system_name`
+   - `RegisteredSystem.Acronym` ← `system_acronym` (if column present)
+   - `RegisteredSystem.DitprId` ← `system_identifier`
+   - `SecurityCategorization.OverallLevel` ← impact level derived from eMASS categorization field
+   - `ControlBaseline.BaselineType` ← derived from eMASS baseline/control-count column
+2. For each pre-populated field, an `EmassFieldSnapshot` record is created with:
+   `FieldName`, `EmassValue` (raw string from import), `ImportedAt`, `ImportSessionId`.
+3. Fields that are already populated in SPIN are **not overwritten** unless the ISSO
+   explicitly triggers a re-sync (out of scope for this feature; defer to Feature 071).
+4. A toast notification confirms: "✓ [N] fields pre-populated from eMASS import."
+5. The pre-population happens synchronously within the `EmassCommitJobHandler` pipeline,
+   after the core import is committed (FR-094 / existing commit handler phase).
+
+**Edge Cases:**
+
+- eMASS categorization column is absent: `SecurityCategorization.OverallLevel` is not
+  pre-populated; no snapshot created for that field.
+- `system_identifier` is blank/malformed: `DitprId` is not set; log a structured warning.
+- Pre-population fails for one field (e.g., enum parse error): other fields still pre-populate;
+  failure is logged but does not abort the commit job.
+
+---
+
+### US3 (P1): Divergence Detection for Key Fields
+
+**As an ISSO**, I want SPIN to automatically detect when a SPIN field diverges from its last
+imported eMASS value, so I can see at a glance which fields are out of sync without
+manually comparing both systems.
+
+**Acceptance Criteria:**
+
+1. After any `RegisteredSystem`, `SecurityCategorization`, or `ControlBaseline` save in SPIN,
+   a background check compares the saved field values against their `EmassFieldSnapshot` records.
+2. When a divergence is detected (current SPIN value ≠ `EmassFieldSnapshot.EmassValue`),
+   the `EmassFieldSnapshot.IsDiverged` flag is set to `true` and `DivergenceDetectedAt`
+   is stamped.
+3. When the SPIN value is brought back into alignment (or re-imported), `IsDiverged` is set
+   to `false` and `ReconciledAt` is stamped.
+4. Divergence check runs synchronously at save time (not a background job), targeting < 50 ms
+   added latency (only a handful of field lookups via indexed query).
+5. The divergence state is reflected immediately on the System Overview sync status badge
+   (see US4) without requiring a page reload (React state updated optimistically after save).
+
+**Edge Cases:**
+
+- Divergence check service is called but no `EmassFieldSnapshot` rows exist for the system:
+  divergence check is a no-op; no error thrown.
+- Type mismatch between eMASS string value and SPIN enum (e.g., eMASS had `"Moderate"` and
+  SPIN uses `ImpactLevel.Moderate`): compare after normalizing to canonical string representation.
+
+---
+
+### US4 (P1): Sync Status Badge on System Overview
+
+**As an ISSO**, I want to see a visual sync status badge on the System Overview page that
+tells me whether my SPIN data is in sync with eMASS, so I can quickly identify divergence
+without opening each field.
+
+**Acceptance Criteria:**
+
+1. The System Overview page (`/systems/:id/overview` or equivalent) shows a "eMASS Sync"
+   badge in the header area.
+2. Badge states:
+   - **Green / "In Sync"** — eMASS import exists and all tracked fields match eMASS values
+     (no `EmassFieldSnapshot` with `IsDiverged = true`).
+   - **Yellow / "Diverged"** — eMASS import exists but ≥1 tracked field has diverged
+     (`IsDiverged = true`). Badge label: "Diverged ([N] field(s))".
+   - **Red / "Not Imported"** — no `EmassImportSession` with `Status = Imported` exists for
+     this system. Badge label: "Not Imported from eMASS".
+3. Clicking the badge opens a `SyncStatusDrawer` panel listing:
+   - Import date (last successful `EmassImportSession.UpdatedAt`)
+   - Per-field rows: field name, eMASS value, current SPIN value, status (✓ In Sync / ⚠ Diverged)
+4. The `SyncStatusDrawer` includes a "View Import History" link to the import sessions list.
+4. The badge data is fetched from `GET /api/systems/{id}/emass-sync-status` and
+   cached for 60 seconds client-side.
+5. The badge is hidden (not rendered) if the user role is SCA or AO (read-only roles
+   — they do not own import/sync workflows).
+6. The badge renders within 200 ms of page load (non-blocking; loaded asynchronously after
+   the main page content).
+7. The badge has `data-testid="emass-sync-badge"` and `data-status="in-sync|diverged|not-imported"`.
+
+**Edge Cases:**
+
+- System has no eMASS import but has manually-entered data: Red "Not Imported" badge.
+- eMASS import is present but all `EmassFieldSnapshot` rows have been deleted: Red "Not Imported".
+- Network error fetching badge status: badge renders a neutral gray "Sync Unknown" state;
+  no page crash; error logged to console.
+- Multiple systems open in tabs: each tab's badge is independently fetched and cached.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | A new `EmassFieldSnapshot` entity MUST be created to store per-field eMASS import metadata: `SystemId`, `FieldName`, `EmassValue`, `ImportedAt`, `ImportSessionId`, `IsDiverged`, `DivergenceDetectedAt`, `ReconciledAt`. |
+| FR-002 | `EmassFieldSnapshot` MUST be `TenantScoped` with EF Core query filter. |
+| FR-003 | `EmassFieldSnapshot` rows are created/updated in `EmassCommitJobHandler` after the core commit phase, for each pre-populated field. |
+| FR-004 | Tracked eMASS fields: `Name`, `Acronym`, `DitprId` on `RegisteredSystem`; `OverallLevel` on `SecurityCategorization`; `BaselineType` on `ControlBaseline`. |
+| FR-005 | `RegisteredSystem` MUST gain a `DitprId: string?` `[MaxLength(50)]` column to store the DoD IT Portfolio Repository identifier sourced from `system_identifier`. |
+| FR-006 | The inline field banner MUST render for any form field that has a matching `EmassFieldSnapshot` row, showing import date and divergence state. |
+| FR-007 | The banner text MUST distinguish between "sourced from eMASS (in sync)" and "diverged from eMASS value". |
+| FR-008 | The banner MUST be dismissible per-session via `localStorage` without affecting the sync badge. |
+| FR-009 | Divergence detection MUST run synchronously at entity-save time in the SPIN backend, adding < 50 ms latency. |
+| FR-010 | `GET /api/systems/{id}/emass-sync-status` MUST return: `importDate`, `overallStatus` (InSync\|Diverged\|NotImported), `fieldStatuses[]` with per-field rows. |
+| FR-011 | The sync status endpoint MUST be accessible to ISSO and ISSM roles; SCA and AO roles receive 403. |
+| FR-012 | The sync status badge MUST render in the System Overview page header area with three states: Green/InSync, Yellow/Diverged, Red/NotImported. |
+| FR-013 | The `SyncStatusDrawer` MUST list all tracked fields with their eMASS value, current SPIN value, and status. |
+| FR-014 | Clicking "View Import History" in the drawer MUST navigate to the eMASS import sessions list (existing onboarding wizard page or equivalent route). |
+| FR-015 | Pre-population in `EmassCommitJobHandler` MUST NOT overwrite existing SPIN values (non-destructive merge). |
+| FR-016 | A `POST /api/systems/{id}/emass-sync-status/dismiss` endpoint MUST allow the ISSO to soft-dismiss field-banner warnings (stored in `UserPreference` or equivalent); badge remains visible. |
+| FR-017 | All mutations to `EmassFieldSnapshot` rows MUST write an `AuditLogEntry`. |
+| FR-018 | The `GET /api/systems/{id}/emass-sync-status` response MUST be computable in < 100 ms via indexed queries on `EmassFieldSnapshot`. |
+
+---
+
+## Architecture Decisions
+
+See `research.md` for full decision records. Summary:
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| New entity vs extending existing models | New `EmassFieldSnapshot` table | Avoids schema churn on core entities; field list may grow; normalized storage |
+| Divergence check timing | Synchronous at save, not background job | Immediate feedback; low overhead (indexed lookup, < 50 ms) |
+| Banner dismiss storage | `localStorage` (client-side) | Server round-trip for UI preference is overkill; banner is informational |
+| Sync status endpoint | New `GET /api/systems/{id}/emass-sync-status` | Clean separation; composable by dashboard and chat tools |
+| SCA/AO badge visibility | Hidden (not 403) | Cleaner UX — roles that don't own import workflow don't need the noise |
+| Pre-population strategy | Non-destructive merge in commit handler | Prevents data loss; respects ISSO edits made before re-import |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-001 | `GET /api/systems/{id}/emass-sync-status` P95 response time ≤ 100 ms for systems with up to 20 tracked fields. |
+| NFR-002 | Divergence check at entity save adds ≤ 50 ms latency (single indexed query on `EmassFieldSnapshot`). |
+| NFR-003 | All new endpoints covered by integration tests in `Ato.Copilot.Tests.Integration`. |
+| NFR-004 | MSW mock for `GET /api/systems/:id/emass-sync-status` registered in the dashboard test suite. |
+| NFR-005 | `EmassFieldSnapshot` table includes index on `(TenantId, SystemId, FieldName)` for efficient per-field lookup. |
+| NFR-006 | Sync status badge renders without blocking the page — loaded asynchronously with a skeleton placeholder. |
+| NFR-007 | Feature 072 MUST NOT break the existing `EmassImportService` / `EmassCommitJobHandler` pipeline. |
+
+---
+
+## Test Plan
+
+### Backend Integration Tests
+**File:** `tests/Ato.Copilot.Tests.Integration/EmassSync/EmassFieldSnapshotTests.cs`
+
+| Test | Scenario |
+|------|----------|
+| `CommitJob_CreatesFieldSnapshots_ForAllTrackedFields` | Commit with all columns → 6 snapshot rows |
+| `CommitJob_DoesNotOverwrite_ExistingSpinValues` | Pre-existing Name → not overwritten |
+| `CommitJob_PartialColumns_CreatesOnlyPresentFields` | Missing `system_acronym` → no Acronym snapshot |
+| `SyncStatus_InSync_WhenNoFieldDiverged` | All snapshots `IsDiverged=false` → InSync |
+| `SyncStatus_Diverged_WhenOneFieldChanged` | Edit Name → IsDiverged true → Diverged status |
+| `SyncStatus_NotImported_WhenNoSession` | No Imported session → NotImported status |
+| `SyncStatusEndpoint_Returns403_ForSCA` | SCA role → 403 |
+| `SyncStatusEndpoint_Returns403_ForAO` | AO role → 403 |
+| `SyncStatusEndpoint_Returns200_ForISSO` | ISSO role → 200 with field rows |
+| `DivergenceCheck_ReconcileOnReSync` | Revert Name to eMASS value → IsDiverged = false |
+| `FieldSnapshot_AuditLog_WrittenOnCreate` | Commit → AuditLogEntry for each snapshot |
+| `FieldSnapshot_AuditLog_WrittenOnDivergence` | Save diverged field → AuditLogEntry |
+
+### Frontend Unit Tests
+**File:** `src/Ato.Copilot.Dashboard/src/features/emass-sync/__tests__/`
+
+| Test | Scenario |
+|------|----------|
+| `SyncBadge renders Green for InSync status` | MSW mock status=InSync → green badge |
+| `SyncBadge renders Yellow with count for Diverged` | status=Diverged, fieldCount=2 → "Diverged (2 fields)" |
+| `SyncBadge renders Red for NotImported` | status=NotImported → red badge |
+| `SyncBadge hidden for SCA role` | `settings.role = 'SCA'` → badge absent |
+| `SyncStatusDrawer opens on badge click` | Click badge → drawer with field rows |
+| `EmassFieldBanner renders for sourced field` | MSW snapshot mock → banner visible |
+| `EmassFieldBanner shows diverged text when value changed` | Value ≠ emassValue → diverged text |
+| `EmassFieldBanner dismissible via localStorage` | Click dismiss → banner hidden |
+
+### MSW Handlers
+File: `src/Ato.Copilot.Dashboard/src/mocks/handlers/emassSync.ts`
+- `GET /api/systems/:id/emass-sync-status` → 200 with `SyncStatusDto`
+- `POST /api/systems/:id/emass-sync-status/dismiss` → 204
+
+---
+
+## Definition of Done
+
+- [ ] `EmassFieldSnapshot` entity, EF Core migration, and `DbSet` registration complete
+- [ ] `RegisteredSystem.DitprId` column added via migration
+- [ ] `EmassCommitJobHandler` extended to create `EmassFieldSnapshot` rows post-commit
+- [ ] Divergence check runs at `RegisteredSystem` / `SecurityCategorization` / `ControlBaseline` save
+- [ ] `GET /api/systems/{id}/emass-sync-status` passes all integration tests
+- [ ] `POST /api/systems/{id}/emass-sync-status/dismiss` passes integration tests
+- [ ] Sync badge component renders all 3 states in the System Overview
+- [ ] `SyncStatusDrawer` opens with per-field rows on badge click
+- [ ] Inline `EmassFieldBanner` renders on form fields with snapshots
+- [ ] Banner dismissible via `localStorage` without affecting badge
+- [ ] Pre-population (non-destructive) verified via integration test
+- [ ] SCA/AO badge hidden; ISSO/ISSM see badge
+- [ ] MSW handlers registered and Vitest suite passing
+- [ ] No regression in `dotnet test Ato.Copilot.sln`
+- [ ] PR approved and linked to issue #60

--- a/specs/072-anti-double-entry/tasks.md
+++ b/specs/072-anti-double-entry/tasks.md
@@ -1,0 +1,286 @@
+# Tasks — 072: Anti-Double-Entry (SPIN/eMASS Sync Status)
+
+_Issue #60 — phased implementation. Each task cites the file path(s) it touches._
+
+---
+
+## Phase 1 — Data Model: `EmassFieldSnapshot` Entity & Migration
+
+_Issue #60 | Priority: P1 | Unblocks all backend logic_
+
+- [ ] **T001**: Create `EmassFieldSnapshot` entity
+  - File: `src/Ato.Copilot.Core/Models/Onboarding/EmassFieldSnapshot.cs`
+  - Fields (see `data-model.md` for full spec):
+    - `Id: Guid` PK
+    - `TenantId: Guid` ([TenantScoped])
+    - `SystemId: string` `[MaxLength(36)]` FK → `RegisteredSystem.Id`
+    - `FieldName: string` `[MaxLength(100)]` — one of: `Name`, `Acronym`, `DitprId`, `OverallLevel`, `BaselineType`, `SystemType`
+    - `EmassValue: string?` `[MaxLength(1000)]` — raw string value from eMASS import column
+    - `ImportedAt: DateTimeOffset` — stamped from `EmassImportSession.UpdatedAt`
+    - `ImportSessionId: Guid` FK → `EmassImportSession.Id`
+    - `IsDiverged: bool` default `false`
+    - `DivergenceDetectedAt: DateTimeOffset?`
+    - `ReconciledAt: DateTimeOffset?`
+    - `CreatedAt: DateTimeOffset`, `UpdatedAt: DateTimeOffset`
+  - Add `[TenantScoped]` attribute
+  - Navigation: `EmassImportSession ImportSession` (no nav to RegisteredSystem — string PK boundary)
+
+- [ ] **T002**: Add `DitprId` column to `RegisteredSystem`
+  - File: `src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs`
+  - Add to `RegisteredSystem` class (after `Acronym`):
+    ```csharp
+    /// <summary>DoD IT Portfolio Repository identifier (eMASS system_identifier field). Feature 072.</summary>
+    [MaxLength(50)]
+    public string? DitprId { get; set; }
+    ```
+
+- [ ] **T003**: Register `DbSet<EmassFieldSnapshot>` in `AtoCopilotContext`
+  - File: `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs`
+  - Add after the existing eMASS-related DbSets (search for `EmassImportSession`):
+    ```csharp
+    /// <summary>Feature 072 (#60): per-field eMASS import snapshots for divergence tracking.</summary>
+    public DbSet<EmassFieldSnapshot> EmassFieldSnapshots => Set<EmassFieldSnapshot>();
+    ```
+
+- [ ] **T004**: Configure EF Core entity in `OnModelCreating`
+  - File: `src/Ato.Copilot.Core/Data/Context/AtoCopilotContext.cs`
+  - In `OnModelCreating`:
+    - PK: `HasKey(s => s.Id)`
+    - Index: `HasIndex(s => new { s.TenantId, s.SystemId, s.FieldName }).HasDatabaseName("IX_EmassFieldSnapshots_TenantId_SystemId_FieldName")`
+    - FK: `HasOne(s => s.ImportSession).WithMany().HasForeignKey(s => s.ImportSessionId).OnDelete(DeleteBehavior.Restrict)`
+    - Apply tenant query filter matching existing `TenantScoped` pattern
+
+- [ ] **T005**: Generate EF Core migration
+  - Command (from repo root):
+    ```bash
+    dotnet ef migrations add Feature072_EmassFieldSnapshot \
+      --project src/Ato.Copilot.Core \
+      --startup-project src/Ato.Copilot.Mcp
+    ```
+  - Migration file: `src/Ato.Copilot.Core/Migrations/YYYYMMDDHHMMSS_Feature072_EmassFieldSnapshot.cs`
+  - Verify migration creates:
+    - `EmassFieldSnapshots` table with all columns
+    - `DitprId` column on `RegisteredSystems` table
+    - Index `IX_EmassFieldSnapshots_TenantId_SystemId_FieldName`
+  - Update snapshot: `src/Ato.Copilot.Core/Migrations/AtoCopilotContextModelSnapshot.cs` (auto-generated)
+
+---
+
+## Phase 2 — Backend: Pre-Population in Commit Handler
+
+_Issue #60 | Priority: P1 | Depends on T001–T005_
+
+- [ ] **T006**: Extend `EmassCommitJobHandler` to create `EmassFieldSnapshot` rows
+  - File: `src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Emass/Handlers/EmassCommitJobHandler.cs`
+  - After the core import commit phase, iterate over committed `RegisteredSystem` records:
+    1. For each tracked field (`Name`, `Acronym`, `DitprId`, `SystemType`):
+       - Check if a current SPIN value exists; if not, apply pre-population from the eMASS parsed value
+       - Upsert an `EmassFieldSnapshot` row: insert if no row for `(TenantId, SystemId, FieldName)`,
+         or update `EmassValue` / `ImportedAt` / `ImportSessionId` if re-import
+       - Set `IsDiverged = false`, `ReconciledAt = UtcNow` (fresh import is in sync)
+    2. For `SecurityCategorization.OverallLevel` and `ControlBaseline.BaselineType`:
+       - Same upsert pattern after categorization/baseline entities are committed
+  - Non-destructive rule: if `RegisteredSystem.Name` is already set and non-empty, do NOT
+    overwrite it; still create the snapshot with the eMASS value for divergence tracking
+  - Write `AuditLogEntry` for each new snapshot: `Action="EmassFieldSnapshot.Created"`,
+    `ActorOid=commitJob.CreatedBy`, `SystemId`, `FieldName`, `TenantId`, `Timestamp`
+  - Catch per-field exceptions; log warning and continue (do not abort commit job)
+
+- [ ] **T007**: Create `IEmassFieldSyncService` interface
+  - File: `src/Ato.Copilot.Core/Interfaces/Onboarding/IEmassFieldSyncService.cs`
+  - Methods:
+    ```csharp
+    Task UpsertSnapshotsAsync(Guid tenantId, string systemId, Guid sessionId,
+        IReadOnlyDictionary<string, string?> emassFieldValues, CancellationToken ct = default);
+    Task CheckDivergenceAsync(Guid tenantId, string systemId, CancellationToken ct = default);
+    Task<EmassSystemSyncStatusDto> GetSyncStatusAsync(Guid tenantId, string systemId, CancellationToken ct = default);
+    ```
+
+- [ ] **T008**: Implement `EmassFieldSyncService`
+  - File: `src/Ato.Copilot.Agents/Compliance/Services/EmassFieldSyncService.cs`
+  - `UpsertSnapshotsAsync`: upsert `EmassFieldSnapshot` rows; audit log each new/updated row
+  - `CheckDivergenceAsync`:
+    1. Load `EmassFieldSnapshot` rows for `(TenantId, SystemId)`
+    2. For each row, resolve the current SPIN value from the appropriate entity
+    3. Compare (normalize enum strings): if mismatch → `IsDiverged = true`, `DivergenceDetectedAt = UtcNow`;
+       if match and currently diverged → `IsDiverged = false`, `ReconciledAt = UtcNow`
+    4. Save changes; write `AuditLogEntry` for each state transition
+  - `GetSyncStatusAsync`:
+    1. Check for `EmassImportSession` with `Status = Imported` for this system (via `TenantId`
+       and system identifier match in `EmassImportSession` — see `research.md R1` for join strategy)
+    2. If none: return `{ OverallStatus = NotImported }`
+    3. Load all `EmassFieldSnapshot` rows for the system
+    4. Compute `OverallStatus`: `InSync` if zero diverged rows; `Diverged` if any `IsDiverged = true`
+    5. Return `EmassSystemSyncStatusDto` with field rows
+
+- [ ] **T009**: Wire `CheckDivergenceAsync` into entity save pipeline
+  - Files: wherever `RegisteredSystem`, `SecurityCategorization`, `ControlBaseline` saves are finalized
+    (search for `await db.SaveChangesAsync` in `SystemProfileService.cs`, `CategorizationService.cs`,
+    `BaselineService.cs` — call `IEmassFieldSyncService.CheckDivergenceAsync` after a successful save)
+  - Pattern: fire-and-forget is NOT appropriate here; await the divergence check before returning
+    the HTTP response (it is fast — indexed lookup, < 50 ms target)
+  - Guard: if `IEmassFieldSyncService` throws, log and swallow — do not fail the main save
+
+---
+
+## Phase 3 — Backend: Sync Status Endpoint
+
+_Issue #60 | Priority: P1 | Depends on T007–T009_
+
+- [ ] **T010**: Create `EmassSync EndpointExtensions` — route registration
+  - File: `src/Ato.Copilot.Mcp/Endpoints/EmassSyncEndpoints.cs`
+  - Namespace: `Ato.Copilot.Mcp.Endpoints`
+  - Declare route handlers:
+    - `GET /api/systems/{systemId}/emass-sync-status` → `GetEmassSyncStatusAsync`
+    - `POST /api/systems/{systemId}/emass-sync-status/dismiss` → `DismissEmassBannerAsync`
+  - Tag: `.WithTags("eMASS Sync")`
+  - Register via `MapEmassSyncEndpoints()` extension method
+
+- [ ] **T011**: Register `MapEmassSyncEndpoints()` in startup
+  - File: `src/Ato.Copilot.Mcp/Extensions/AtoCopilotMcpServiceExtensions.cs`
+    (or wherever `MapCspInheritedComponentEndpoints` / `MapCapabilityLibraryEndpoints` are registered)
+  - Add: `app.MapEmassSyncEndpoints();`
+
+- [ ] **T012**: Implement `GET /api/systems/{systemId}/emass-sync-status`
+  - File: `src/Ato.Copilot.Mcp/Endpoints/EmassSyncEndpoints.cs`
+  - Logic:
+    1. Resolve `systemId` — verify it exists in tenant (EF + RLS)
+    2. Call `IEmassFieldSyncService.GetSyncStatusAsync(tenantId, systemId)`
+    3. Return 200 with `EmassSystemSyncStatusDto` in standard envelope
+  - Auth: `RequireAuthorization("IssoOrIssm")` (SCA/AO → 403)
+  - Return shape: `{ status, data: EmassSystemSyncStatusDto, metadata }`
+  - See `contracts/http-api.md` for full DTO schema
+
+- [ ] **T013**: Implement `POST /api/systems/{systemId}/emass-sync-status/dismiss`
+  - File: `src/Ato.Copilot.Mcp/Endpoints/EmassSyncEndpoints.cs`
+  - Logic: upsert a `UserPreference` record with key `emass-banner-dismissed:{systemId}`
+    set to `true` for the current user OID (or use an existing preference storage pattern
+    in the codebase — search for `UserPreference` table)
+  - If no `UserPreference` model exists, create a simple key-value `UserPreference` entity
+    (see `data-model.md §2`)
+  - Return 204 No Content
+  - Auth: `RequireAuthorization("IssoOrIssm")`
+
+- [ ] **T014**: Add `EmassSystemSyncStatusDto` and related DTOs
+  - File: `src/Ato.Copilot.Mcp/Endpoints/EmassSyncEndpoints.cs` (inner records) or
+    `src/Ato.Copilot.Core/Models/Dto/EmassSyncDtos.cs`
+  - See `contracts/http-api.md` for field definitions
+
+---
+
+## Phase 4 — Frontend: Sync Status Badge & Drawer
+
+_Issue #60 | Priority: P1 | Depends on T010–T014_
+
+- [ ] **T015**: Create API client module
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/api.ts`
+  - Functions: `getEmassSyncStatus(systemId)`, `dismissEmassBanner(systemId)`
+  - Types: `EmassSystemSyncStatusDto`, `EmassFieldStatusDto`, `SyncOverallStatus`
+  - See `contracts/http-api.md` for type definitions
+  - Attach `attachAuthInterceptor` (MSAL silent renewal — same pattern as other features)
+  - Cache `getEmassSyncStatus` result for 60 s in `useQuery` / `useState` (no re-fetch within window)
+
+- [ ] **T016**: Create `EmassSyncBadge.tsx` component
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/EmassSyncBadge.tsx`
+  - Props: `systemId: string`
+  - Fetches `GET /api/systems/{systemId}/emass-sync-status` on mount
+  - Renders:
+    - Green pill: `✓ eMASS In Sync` when `overallStatus === 'InSync'`
+    - Yellow pill: `⚠ Diverged (N field(s))` when `overallStatus === 'Diverged'`
+    - Red pill: `✗ Not Imported` when `overallStatus === 'NotImported'`
+    - Gray pill skeleton while loading
+  - Hidden (`return null`) if `settings.role === 'SCA' || settings.role === 'AO'`
+  - `data-testid="emass-sync-badge"`, `data-status={overallStatus.toLowerCase()}`
+  - On click: opens `SyncStatusDrawer`
+
+- [ ] **T017**: Create `SyncStatusDrawer.tsx` component
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/SyncStatusDrawer.tsx`
+  - Props: `systemId: string`, `isOpen: boolean`, `onClose: () => void`
+  - Sections:
+    - Header: "eMASS Sync Status" + close button
+    - Import date: "Last imported: [importDate]" or "Never imported"
+    - Field status table: field name | eMASS value | SPIN value | status icon (✓/⚠)
+    - Footer: "View Import History" link → eMASS import page route
+  - Accessible: `role="dialog"`, `aria-label="eMASS sync status"`
+  - Uses existing drawer/modal pattern in the codebase (search for existing drawer components)
+
+- [ ] **T018**: Integrate `EmassSyncBadge` into System Overview
+  - File: wherever the System Overview page header is rendered
+    (search for `SystemOverviewPage` or `overview` route in `App.tsx`)
+  - Add `<EmassSyncBadge systemId={systemId} />` in the page header area, after the system name
+  - Import guard: only render if feature flag `VITE_FEATURE_EMASS_SYNC=true`
+    (defaults to `true` — env var allows disabling in dev if needed)
+
+---
+
+## Phase 5 — Frontend: Inline `EmassFieldBanner`
+
+_Issue #60 | Priority: P1 | Depends on T015_
+
+- [ ] **T019**: Create `EmassFieldBanner.tsx` component
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/EmassFieldBanner.tsx`
+  - Props:
+    ```typescript
+    interface EmassFieldBannerProps {
+      systemId: string;
+      fieldName: string;           // e.g. 'Name', 'DitprId', 'OverallLevel'
+      currentValue: string;        // current SPIN field value (stringified)
+    }
+    ```
+  - Behavior:
+    1. On mount (or `fieldName` change): call `getEmassSyncStatus(systemId)` (uses cached response)
+    2. Find the field row matching `fieldName` in the response
+    3. If no row: render nothing
+    4. If row exists and `isDiverged = false`: render origin banner
+       "📥 Imported from eMASS on [importedAt]. Editing here won't update eMASS."
+    5. If row exists and `isDiverged = true`: render divergence banner
+       "⚠️ Diverged from eMASS value (imported [importedAt]): eMASS had '[emassValue]'."
+  - Dismiss: check `localStorage.getItem('emass-field-banner-dismissed-{fieldName}-{systemId}')`
+    — if set, render nothing. On dismiss button click: set that key and re-render.
+  - Accessible: `role="note"`, `aria-label="eMASS import notice"`
+
+- [ ] **T020**: Integrate `EmassFieldBanner` into System Registration / Edit forms
+  - Files: forms where the tracked fields appear
+    (search for `<input` or form field components for `system.Name`, `system.DitprId`,
+     `categorization.OverallLevel`, `baseline.BaselineType` — likely in
+     `src/Ato.Copilot.Dashboard/src/features/system-profile/` or equivalent)
+  - Add `<EmassFieldBanner systemId={systemId} fieldName="Name" currentValue={system.name} />`
+    below each tracked field input
+  - Tracked fields to banner: `Name`, `Acronym`, `DitprId`, `OverallLevel`, `BaselineType`
+
+---
+
+## Phase 6 — Testing
+
+_Issue #60 | Priority: P1 | Depends on Phases 2–5_
+
+- [ ] **T021**: Backend integration test file
+  - File: `tests/Ato.Copilot.Tests.Integration/EmassSync/EmassFieldSnapshotTests.cs`
+  - Test matrix: see `spec.md § Test Plan`
+  - Use `WebApplicationFactory` pattern consistent with existing integration tests
+  - Seed: `EmassImportSession` (Imported), `RegisteredSystem`, related entities
+
+- [ ] **T022**: MSW handler file
+  - File: `src/Ato.Copilot.Dashboard/src/mocks/handlers/emassSync.ts`
+  - Handlers:
+    - `GET /api/systems/:systemId/emass-sync-status` → 200 `EmassSystemSyncStatusDto`
+    - `POST /api/systems/:systemId/emass-sync-status/dismiss` → 204
+  - Register in `src/mocks/handlers/index.ts`
+
+- [ ] **T023**: Frontend unit tests
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/__tests__/EmassSyncBadge.test.tsx`
+  - File: `src/Ato.Copilot.Dashboard/src/features/emass-sync/__tests__/EmassFieldBanner.test.tsx`
+  - Use Vitest + Testing Library; see `spec.md § Test Plan` for test list
+
+---
+
+## Phase 7 — Docs & Spec Finalization
+
+_Issue #60 | Priority: P2_
+
+- [ ] **T024**: Update `docs/guides/emass-package.md` (if it exists from Feature 041)
+  to mention sync status badge and field-level divergence warnings.
+
+- [ ] **T025**: Mark spec `Status: Implemented` after all DoD items checked
+  - File: `specs/072-anti-double-entry/spec.md`
+  - Change `Status: Draft` → `Status: Implemented`


### PR DESCRIPTION
**Owner**: Cyborg (`agent:cyborg`)

## Problem Statement

DoD organizations using both SPIN and eMASS face an ongoing maintenance burden: any data that exists in both systems (system name, categorization, DitprId, EmassId, control implementation status) must be kept in sync manually. Today's workflow is one-directional at import time — after initial onboarding, there's no awareness in SPIN when a value differs from what eMASS holds.

Issue #59 (Feature 071) adds the backend round-trip sync mechanism. This feature (#60 / Feature 072) adds the **UX layer** that makes double-work visible and preventable: sync status indicators, field-origin annotations ("imported from eMASS"), and data divergence warnings.

## Goal / Desired Outcome

Feature 072 makes SPIN aware of which field values came from eMASS import and whether they have since diverged. It adds:
1. `EmassFieldSync` tracking: per-field origin + last-synced value for key fields
2. A sync status badge at the system level (In Sync / Diverged / Missing from eMASS)
3. UI/API metadata that annotates fields with their eMASS origin and divergence state
4. A "field source" endpoint so the UI can display "Imported from eMASS on [date]" tooltips

## Scope

**In scope:**
- `EmassFieldSync` entity: tracks field name, SPIN current value, last-eMASS value, last-synced timestamp
- `GET /api/systems/{id}/emass/field-sync` — returns sync state per tracked field
- `GET /api/systems/{id}/emass/sync-status` — returns aggregate badge (InSync | Diverged | NeverSynced)
- Key tracked fields: SystemName, DitprId, EmassId, ImpactLevel, CategorizationDate
- Integration with Feature 071 round-trip sync: after sync, update `EmassFieldSync` records

**Out of scope:**
- Auto-resolving divergences (Feature 071 handles this; user must choose)
- Real-time eMASS API polling (no direct eMASS API access)
- Tracking all 200+ control fields (scoped to system-level identity fields only)

## User Experience Flow

1. ISSO opens a system in SPIN that was imported from eMASS
2. Fields with eMASS origin show a small "eMASS" badge: "DitprId · Imported from eMASS 2026-01-15"
3. If ISSO changes DitprId in SPIN, the badge changes to "⚠ Diverged from eMASS value: 12345"
4. System overview card shows a sync health badge: 🟢 In Sync / 🟡 Diverged (N fields) / ⚫ Never Synced
5. ISSO can click the badge to see the divergence list and decide whether to re-sync

## Functional Requirements

- **FR-001**: `EmassFieldSync` entity: SystemId, FieldName, SpinValue, EmassValue, LastSyncedAt, IsDiverged (computed)
- **FR-002**: On eMASS import, create `EmassFieldSync` records for tracked fields
- **FR-003**: When a tracked field is updated in SPIN, mark `IsDiverged = true`
- **FR-004**: `GET /api/systems/{id}/emass/field-sync` returns per-field sync state
- **FR-005**: `GET /api/systems/{id}/emass/sync-status` returns aggregate: InSync | Diverged | NeverSynced + diverged field count
- **FR-006**: After Feature 071 round-trip sync resolves a conflict, update `EmassFieldSync` record to reflect new synced state
- **FR-007**: MCP tool `emass_get_field_sync` returns the same sync data for AI-assisted workflow

## Technical Design Notes

`EmassFieldSync` is a lightweight audit/tracking table — no EF navigation properties to avoid coupling. Field names are stored as strings (e.g., "SystemName", "DitprId") for flexibility without schema changes per new tracked field.

Divergence detection hook: `AtoCopilotContext.SaveChangesAsync` override or EF interceptor watches tracked entities for changes to known field names. Alternatively, endpoints that update those fields explicitly call `IEmassFieldSyncService.MarkDiverged()`.

## Architecture Decisions

| Decision | Chosen | Alternative | Reason |
|---|---|---|---|
| Divergence detection | Explicit service call at field update endpoints | EF change interceptor | Less magic; easier to test; only tracks fields we explicitly care about |
| Field names | String constants | Enum | Allows adding new tracked fields without migration |
| Sync badge computation | Server-side | Client-side from field list | Consistent across all clients (Dashboard + MCP) |

## Acceptance Criteria

```gherkin
Scenario: Field shows eMASS origin after import
  Given a system imported from eMASS with DitprId "12345"
  When ISSO calls GET /api/systems/{id}/emass/field-sync
  Then the response includes { field: "DitprId", emassValue: "12345", isDiverged: false }

Scenario: Divergence detected after SPIN edit
  Given a system with EmassFieldSync record for DitprId = "12345"
  When ISSO updates DitprId in SPIN to "99999"
  Then IsDiverged becomes true for DitprId
  And GET /api/systems/{id}/emass/sync-status returns { status: "Diverged", divergedCount: 1 }

Scenario: Sync status for never-synced system
  Given a system created directly in SPIN (not imported from eMASS)
  When ISSO checks sync status
  Then the status is NeverSynced
```

## Non-Functional Requirements

- `GET /api/systems/{id}/emass/sync-status` must respond in <200ms (single DB query)
- Divergence detection must not add latency to normal field-update endpoints (async fire-and-forget acceptable)

## Test Plan

- Unit: `EmassFieldSyncServiceTests` — import creates records, edit marks diverged, sync resolves
- Unit: `SyncStatusComputationTests` — InSync/Diverged/NeverSynced edge cases
- Integration: sync-status endpoint round-trip

## Definition of Done

- [ ] `EmassFieldSync` entity + EF migration
- [ ] `IEmassFieldSyncService` + implementation
- [ ] Divergence marking on tracked field edits
- [ ] `GET /api/systems/{id}/emass/field-sync` endpoint
- [ ] `GET /api/systems/{id}/emass/sync-status` endpoint
- [ ] `emass_get_field_sync` MCP tool registered
- [ ] Integration with Feature 071 round-trip sync (post-sync field sync update)
- [ ] Unit + integration tests green

## Explicit Constraints (DO NOT)

- DO NOT auto-resolve divergences — user must choose via Feature 071
- DO NOT track all 200+ control fields — only system-identity fields in scope for this feature
- DO NOT add eMASS API polling — sync state is updated from import events only

## Anti-patterns

- EF change interceptor for divergence detection (too much magic; hard to test isolation)
- Tightly coupling `EmassFieldSync` to specific model properties via navigation (strings for field names)
- Making sync-status a frontend computation from field-sync list (must be a dedicated backend endpoint)

## Existing File References

| File | Line | Relevance |
|---|---|---|
| `src/Ato.Copilot.Agents/Compliance/Services/Onboarding/Emass/EmassImportService.cs` | ~1 | Import entry point — add EmassFieldSync record creation |
| `src/Ato.Copilot.Core/Models/Compliance/EmassModels.cs` | ~1 | eMASS models — add `EmassFieldSync` entity |
| `src/Ato.Copilot.Core/Interfaces/Compliance/IEmassExportService.cs` | ~1 | Interface — add `GetFieldSyncAsync` method |
| `specs/071-emass-workflow-sync/` | all | Feature 071 — prerequisite for round-trip sync integration |
