### PR TITLE
feat(#84): Feature 075 — CSP Integration: AWS Commercial, AWS GovCloud & GCP

### DIFF
--- a/specs/075-csp-aws-gcp-integration/checklists/requirements.md
+++ b/specs/075-csp-aws-gcp-integration/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Requirements Checklist — Feature 075: CSP AWS/GCP Integration
+
+## Functional Requirements (FR)
+
+- [ ] FR-001: `CloudProvider` enum (Azure | AwsCommercial | AwsGovCloud | Gcp) defined
+- [ ] FR-002: `ICloudScanProvider` abstraction with `ScanAsync` + `TestConnectionAsync`
+- [ ] FR-003: `AzureCloudScanProvider` wraps existing `IAtoComplianceEngine` (no Azure regression)
+- [ ] FR-004: `AwsCloudScanProvider` fetches Security Hub findings and maps to NIST 800-53
+- [ ] FR-005: `GcpCloudScanProvider` fetches SCC findings and maps to NIST 800-53
+- [ ] FR-006: `AwsCredential` + `GcpCredential` entities with Key Vault backing (no creds in DB)
+- [ ] FR-007: `compliance_assess` MCP tool accepts `cloud_provider` parameter
+- [ ] FR-008: Feature flags `AwsScanning` + `GcpScanning` gate provider registration
+- [ ] FR-009: Clear error when scan attempted on disabled CSP feature
+- [ ] FR-010: Credential connection test endpoint
+
+## Security Requirements (SEC)
+
+- [ ] SEC-001: AWS/GCP credentials NEVER stored in DB — Key Vault secret ID only
+- [ ] SEC-002: Credential endpoints require ISSM role
+- [ ] SEC-003: AWS AssumeRole uses external ID (prevents confused deputy attack)
+- [ ] SEC-004: GCP service account key JSON written to Key Vault then discarded from request
+
+## Non-Functional Requirements (NFR)
+
+- [ ] NFR-001: Azure scanning performance unaffected by refactoring (p95 <30s preserved)
+- [ ] NFR-002: AWS Security Hub scan completes within 60s for accounts with ≤1000 findings
+- [ ] NFR-003: GCP SCC scan completes within 60s for projects with ≤1000 findings
+- [ ] NFR-004: Credential store operations complete in <500ms
+
+## Test Coverage (TC)
+
+- [ ] TC-001: `AwsNistControlMapper` — maps all AWS FSBP controls to at least one NIST control
+- [ ] TC-002: `GcpNistControlMapper` — maps all SCC categories to at least one NIST control
+- [ ] TC-003: `AzureCloudScanProvider` (refactored) passes all existing Azure scan tests
+- [ ] TC-004: AWS mock response → ComplianceFinding records correct
+- [ ] TC-005: GCP mock response → ComplianceFinding records correct
+- [ ] TC-006: Feature flag disabled → clear error, no scan attempted
+
+## Definition of Done Gate
+
+All checkboxes above must be checked before PR merge.

--- a/specs/075-csp-aws-gcp-integration/contracts/http-api.md
+++ b/specs/075-csp-aws-gcp-integration/contracts/http-api.md
@@ -1,0 +1,88 @@
+# HTTP API Contract — Feature 075: CSP AWS/GCP Integration
+
+## Endpoints
+
+### POST /api/systems/{id}/cloud-credentials/aws
+Register AWS credentials for a system.
+
+**Authorization**: ISSM role required
+**Request:**
+```json
+{
+  "accountId": "123456789012",
+  "iamRoleArn": "arn:aws:iam::123456789012:role/SpinReader",
+  "externalId": "spin-tenant-uuid",
+  "region": "us-east-1",
+  "provider": "AwsCommercial"
+}
+```
+**Response 201:**
+```json
+{
+  "credentialId": "uuid",
+  "provider": "AwsCommercial",
+  "accountId": "123456789012",
+  "createdAt": "2026-06-11T00:00:00Z"
+}
+```
+**Errors:** 400 (validation), 409 (credential already exists for system)
+
+---
+
+### POST /api/systems/{id}/cloud-credentials/gcp
+Register GCP credentials for a system.
+
+**Authorization**: ISSM role required
+**Request:**
+```json
+{
+  "projectId": "my-dod-project",
+  "serviceAccountEmail": "spin-reader@my-dod-project.iam.gserviceaccount.com",
+  "serviceAccountKeyJson": "{ ... }"
+}
+```
+**Response 201:**
+```json
+{
+  "credentialId": "uuid",
+  "provider": "Gcp",
+  "projectId": "my-dod-project",
+  "createdAt": "2026-06-11T00:00:00Z"
+}
+```
+**Notes:** `serviceAccountKeyJson` is stored in Key Vault — never returned after creation.
+
+---
+
+### POST /api/systems/{id}/cloud-credentials/test
+Test connectivity for registered credentials.
+
+**Authorization**: ISSM role required
+**Response 200:**
+```json
+{
+  "success": true,
+  "provider": "AwsCommercial",
+  "accountId": "123456789012",
+  "message": "Connection successful"
+}
+```
+
+---
+
+### GET /api/systems/{id}/compliance/findings?cloudProvider=AwsCommercial
+Returns `ComplianceFinding` records for a specific CSP.
+Existing endpoint extended with optional `cloudProvider` filter parameter.
+
+---
+
+## Extended compliance_assess Tool Parameters
+
+```json
+{
+  "subscription_id": "string (Azure only — omit for AWS/GCP)",
+  "cloud_provider": "Azure | AwsCommercial | AwsGovCloud | Gcp (optional, default: Azure)",
+  "system_id": "string (required for AWS/GCP — identifies RegisteredSystem)",
+  "scan_type": "quick | policy | full"
+}
+```

--- a/specs/075-csp-aws-gcp-integration/data-model.md
+++ b/specs/075-csp-aws-gcp-integration/data-model.md
@@ -1,0 +1,103 @@
+# Data Model — Feature 075: CSP AWS/GCP Integration
+
+## New Enums
+
+```csharp
+// src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs
+public enum CloudProvider
+{
+    Azure = 0,
+    AwsCommercial = 1,
+    AwsGovCloud = 2,
+    Gcp = 3
+}
+```
+
+## Modified Entities
+
+### RegisteredSystem (extension — additive)
+```csharp
+// Add nullable CloudProvider — null means Azure (backwards compat)
+public CloudProvider? CloudProvider { get; set; }
+
+// Existing AzureEnvironmentProfile nullable — preserved
+public AzureEnvironmentProfile? AzureProfile { get; set; }
+
+// New: credential reference (Key Vault secret ID, not the credential itself)
+public string? CloudCredentialSecretId { get; set; }
+```
+
+## New Entities
+
+### AwsCredential
+```csharp
+public class AwsCredential
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public Guid TenantId { get; set; }
+    public string RegisteredSystemId { get; set; } = string.Empty;
+    public string AccountId { get; set; } = string.Empty;
+    public string IamRoleArn { get; set; } = string.Empty;
+    public string ExternalId { get; set; } = string.Empty;
+    public string Region { get; set; } = "us-east-1"; // or us-gov-east-1
+    public CloudProvider Provider { get; set; } = CloudProvider.AwsCommercial;
+    // Key Vault secret ID — actual credentials never stored in DB
+    public string KeyVaultSecretId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = string.Empty;
+    
+    public RegisteredSystem RegisteredSystem { get; set; } = null!;
+}
+```
+
+### GcpCredential
+```csharp
+public class GcpCredential
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public Guid TenantId { get; set; }
+    public string RegisteredSystemId { get; set; } = string.Empty;
+    public string ProjectId { get; set; } = string.Empty;
+    public string ServiceAccountEmail { get; set; } = string.Empty;
+    // Key Vault secret ID for service account JSON key
+    public string KeyVaultSecretId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = string.Empty;
+    
+    public RegisteredSystem RegisteredSystem { get; set; } = null!;
+}
+```
+
+## New Interface
+
+```csharp
+// src/Ato.Copilot.Core/Interfaces/Compliance/ICloudScanProvider.cs
+public interface ICloudScanProvider
+{
+    CloudProvider Provider { get; }
+    
+    Task<IReadOnlyList<ComplianceFinding>> ScanAsync(
+        CloudScanRequest request, CancellationToken ct);
+    
+    Task<ConnectionTestResult> TestConnectionAsync(
+        string credentialSecretId, CancellationToken ct);
+}
+
+public record CloudScanRequest(
+    string RegisteredSystemId,
+    string CredentialSecretId,
+    string? ControlFamily,
+    CloudProvider Provider);
+
+public record ConnectionTestResult(
+    bool Success,
+    string? ErrorMessage,
+    string? AccountId);
+```
+
+## EF Core Migration Notes
+
+- `RegisteredSystem`: additive columns `CloudProvider` (nullable int) and `CloudCredentialSecretId` (nullable string)
+- New tables: `AwsCredentials`, `GcpCredentials` (both with TenantId for RLS)
+- Existing `AzureEnvironmentProfile` table: untouched
+- Seed data: `AwsNistControlMappings` and `GcpNistControlMappings` in a JSON seed file (not DB rows — loaded at runtime for mapping lookups)

--- a/specs/075-csp-aws-gcp-integration/plan.md
+++ b/specs/075-csp-aws-gcp-integration/plan.md
@@ -1,0 +1,42 @@
+# Plan — Feature 075: CSP AWS/GCP Integration
+
+## Overview
+
+Feature 075 extends ATO Copilot with multi-cloud scanning support (AWS Commercial, AWS GovCloud, GCP) using a provider abstraction pattern. The Azure engine is refactored as the first implementation; AWS and GCP follow.
+
+## Implementation Sequence
+
+### Phase 1: Abstraction (1–2 days)
+Introduce `ICloudScanProvider` and `CloudScanProviderRegistry`. Refactor `IAtoComplianceEngine` as `AzureCloudScanProvider`. Update `ComplianceAssessmentTool` to route by provider. No functional change — Azure still works exactly as before.
+
+**Done signal:** `compliance_assess` tool works unchanged; new `cloud_provider` param accepted but ignored (Azure default).
+
+### Phase 2: Credentials (1 day)
+Add `AwsCredential` + `GcpCredential` entities and EF migration. Implement `ICloudCredentialStore` reading from Azure Key Vault. Unit test credential round-trip.
+
+**Done signal:** Credentials stored/retrieved without actual credential values in DB.
+
+### Phase 3: AWS (3–4 days)
+`AwsCloudScanProvider`: Security Hub API calls, Config Rules API calls, NIST control mapping. Feature flag gate. Integration tests with mock AWS responses.
+
+**Done signal:** Mock Security Hub response → ComplianceFinding records with correct control IDs.
+
+### Phase 4: GCP (2–3 days)
+`GcpCloudScanProvider`: Security Command Center API, NIST control mapping. Feature flag gate.
+
+**Done signal:** Mock SCC response → ComplianceFinding records.
+
+### Phase 5: Onboarding (1 day)
+Update `RegisteredSystem` model additively. Onboarding step 2 shows cloud provider selector. Scan routing uses registered provider.
+
+### Phase 6: Testing + CI (1 day)
+Regression tests for Azure. Integration tests for AWS/GCP with mocked cloud SDK responses.
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| AWS SDK version conflicts | Pin `AWSSDK.Core` to same version used by other AWS integrations in solution |
+| GCP SDK size bloat | Use `Google.Cloud.SecurityCenter.V1` only — avoid pulling in full GCP SDK |
+| Credential leakage | Never store credential values in DB; always Key Vault secret ID reference |
+| Azure regression | AzureCloudScanProvider is an exact refactor — existing tests must pass before any new code |

--- a/specs/075-csp-aws-gcp-integration/quickstart.md
+++ b/specs/075-csp-aws-gcp-integration/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart — Feature 075: CSP AWS/GCP Integration
+
+## Prerequisites
+
+- AWS SDK: `dotnet add package AWSSDK.SecurityHub` + `AWSSDK.ConfigService` + `AWSSDK.SecurityToken`
+- GCP SDK: `dotnet add package Google.Cloud.SecurityCenter.V1`
+- Feature flags enabled in `appsettings.Development.json`:
+  ```json
+  "FeatureFlags": {
+    "AwsScanning": true,
+    "GcpScanning": true
+  }
+  ```
+
+## Local Dev Setup
+
+### AWS (using test account)
+1. Create a test IAM role in your AWS account with `SecurityHub:GetFindings` + `config:DescribeComplianceByConfigRule` permissions
+2. Set env var: `AWS_TEST_ROLE_ARN=arn:aws:iam::123456789:role/SpinTestRole`
+3. Set env var: `AWS_TEST_EXTERNAL_ID=spin-dev-external-id`
+
+### GCP (using test project)
+1. Create a service account with `securitycenter.findings.list` permission in your test GCP project
+2. Download the JSON key
+3. Set env var: `GCP_TEST_SA_JSON=/path/to/sa-key.json`
+
+## Running Unit Tests
+
+```bash
+dotnet test tests/Ato.Copilot.Tests.Unit \
+  --filter "FullyQualifiedName~AwsCloudScanProvider|GcpCloudScanProvider|AwsNistControlMapper"
+```
+
+## Running Integration Tests
+
+```bash
+# Requires AWS + GCP env vars above
+dotnet test tests/Ato.Copilot.Tests.Integration \
+  --filter "FullyQualifiedName~CspIntegration"
+```
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `AccessDeniedException: AssumeRole` | IAM role trust policy missing SPIN principal | Update trust policy |
+| `PERMISSION_DENIED: request had insufficient authentication` | GCP SA missing securitycenter permissions | Add `roles/securitycenter.findingsViewer` |
+| `AwsScanning feature is not enabled` | Feature flag off | Set `FeatureFlags:AwsScanning=true` in appsettings |

--- a/specs/075-csp-aws-gcp-integration/research.md
+++ b/specs/075-csp-aws-gcp-integration/research.md
@@ -1,0 +1,39 @@
+# Research — Feature 075: CSP AWS/GCP Integration
+
+## Options Considered
+
+### Option A: Per-CSP Scan Service (Chosen)
+Separate `AwsCloudScanProvider` + `GcpCloudScanProvider` behind `ICloudScanProvider` abstraction. Registered in DI by `CloudProvider` enum. `ComplianceAssessmentTool` routes to the correct provider.
+
+**Pros:** Clean separation, independently testable, no Azure regression risk, new CSPs can be added without touching existing code.
+**Cons:** Requires refactoring `IAtoComplianceEngine` as a first step.
+
+### Option B: Extend IAtoComplianceEngine with CSP flags
+Add AWS/GCP code paths directly into `IAtoComplianceEngine`.
+
+**Rejected:** Violates SRP, increases Azure regression risk, creates an unmaintainable monolith.
+
+### Option C: Separate compliance agent per CSP
+Separate `AwsComplianceAgent`, `GcpComplianceAgent` classes with no shared abstraction.
+
+**Rejected:** Duplicates tool registration, dispatch logic, no shared finding model pipeline.
+
+## AWS Scanning Decision
+
+AWS Security Hub is the primary signal source. It aggregates findings from AWS Config, GuardDuty, Inspector, and Macie into a single API surface. The ASFF (Amazon Security Finding Format) includes a `Compliance.SecurityControlId` field that maps directly to AWS Foundational Security Best Practices control IDs (e.g., `EC2.1`, `IAM.3`). AWS publishes a mapping from these to NIST 800-53 controls.
+
+AWS Config Rules are used as a secondary/evidence source (config rule → EvidenceArtifact) — their compliance states confirm resource-level configuration.
+
+## GCP Scanning Decision
+
+GCP Security Command Center (SCC) Standard tier is available in all GCP projects. SCC findings include a `category` field (e.g., `FIREWALL_RULE_LOGGING_DISABLED`) and Google publishes a NIST 800-53 mapping for GCP Public Sector. SCC is the closest AWS-equivalent for GCP.
+
+## Authentication Decision
+
+- AWS: IAM role assumption via STS `AssumeRole` with external ID. This is the AWS-recommended cross-account access pattern. No long-lived access keys stored.
+- GCP: Service account with workload identity. Key stored as JSON in Azure Key Vault, referenced by Key Vault secret ID in DB.
+- Azure (existing): Service principal + managed identity. No change.
+
+## Control Mapping Approach
+
+Both AWS and GCP publish their own NIST mappings. These will be loaded from JSON seed files at startup (not stored in DB as rows) for performance and ease of updates. The `NistControlMappings` static helper class will be extended.

--- a/specs/075-csp-aws-gcp-integration/spec.md
+++ b/specs/075-csp-aws-gcp-integration/spec.md
@@ -1,0 +1,123 @@
+# Spec 075 — CSP Integration: AWS Commercial, AWS GovCloud, GCP
+
+**Epic:** #84 — Feature 049: CSP Integration (AWS, GCP)
+**GitHub Issue:** #84
+**Wave:** 9 — Core UX & Integrations
+**Status:** Draft
+**Branch:** `075-csp-aws-gcp-integration`
+
+---
+
+## Background
+
+ATO Copilot is Azure-native today. The `AzureEnvironmentProfile` entity and `ComplianceAssessmentTool` (`compliance_assess`) are built exclusively around Azure subscriptions, Azure Policy, Microsoft Defender for Cloud, and Azure SDK clients. Mission owners running workloads in AWS Commercial, AWS GovCloud, or Google Cloud Platform (GCP) have no path to onboard those systems into SPIN.
+
+DoD multi-cloud reality: DISA's milCloud2 (AWS GovCloud), AWS GovCloud IL2/IL4/IL5, and GCP Public Sector are all in active use. SPIN must support these environments using the same `RegisteredSystem` → `ComplianceFinding` → POA&M / SSP pipeline that Azure uses.
+
+## Clarifications
+
+- All three CSPs must flow into the same compliance data model — no CSP-specific forks of core entities
+- AWS GovCloud (us-gov-east-1, us-gov-west-1) must be treated as a distinct CSP profile from AWS Commercial
+- Authentication: AWS uses IAM role + external ID (cross-account assume-role); GCP uses service account JSON credentials
+- Scanning: AWS uses Security Hub + Config Rules; GCP uses Security Command Center (SCC)
+- No changes to Azure scanning — this is additive CSP support
+
+## User Stories
+
+### US1 — Onboard AWS Account (P1)
+As a mission owner running workloads in AWS Commercial or AWS GovCloud, I want to authenticate ATO Copilot to my AWS account (IAM role + external ID) and register it as a `RegisteredSystem` so that I can begin the RMF process for that system.
+
+### US2 — Run AWS Security Hub Compliance Scan (P1)
+As an ISSO, I want to run a compliance scan against my registered AWS account that collects findings from AWS Security Hub (mapped to NIST 800-53 controls) so that I get a `ComplianceFinding` list equivalent to what Azure Defender provides.
+
+### US3 — AWS Config Rules Evidence Collection (P1)
+As an ISSO, I want AWS Config Rules compliance results automatically mapped to `EvidenceArtifact` records for relevant controls so that I have automated evidence for my SSP.
+
+### US4 — Onboard GCP Project (P2)
+As a mission owner with GCP workloads, I want to register a GCP project in SPIN using a service account credential so that my GCP environment participates in the RMF workflow.
+
+### US5 — GCP Security Command Center Scan (P2)
+As an ISSO, I want SCC findings from my GCP project mapped to NIST 800-53 controls and surfaced as `ComplianceFinding` records so that my GCP system has the same compliance posture visibility as Azure.
+
+### US6 — Unified Multi-CSP Dashboard (P2)
+As an ISSO managing systems across Azure, AWS, and GCP, I want a single compliance posture view that shows control coverage across all CSPs so that I do not need to switch between tools.
+
+## Architecture
+
+### Abstraction Layer
+
+Introduce `ICloudScanProvider` interface (per CSP):
+
+```csharp
+public interface ICloudScanProvider
+{
+    CloudProvider Provider { get; }
+    Task<IReadOnlyList<ComplianceFinding>> ScanAsync(CloudScanRequest request, CancellationToken ct);
+    Task<ConnectionTestResult> TestConnectionAsync(CancellationToken ct);
+}
+```
+
+Existing Azure scanner (`IAtoComplianceEngine`) becomes `AzureCloudScanProvider` implementing this interface. New `AwsCloudScanProvider` and `GcpCloudScanProvider` follow the same pattern.
+
+### New Entities
+
+- `CloudEnvironmentProfile` — generalized version of `AzureEnvironmentProfile`, with `CloudProvider` enum (Azure | AwsCommercial | AwsGovCloud | Gcp)
+- `AwsCredential` — IAM role ARN, external ID, account ID (stored in Key Vault, referenced by ID)
+- `GcpCredential` — project ID, service account key ID (stored in Key Vault)
+
+### Control Mapping
+
+AWS Security Hub findings map to NIST 800-53 controls via AWS's published control mappings (AWS Foundational Security Best Practices). GCP SCC findings map via Google's NIST mapping for GCP Public Sector.
+
+Both mappings stored as seed data in `NistControlMappings` table (already exists for Azure Policy).
+
+## Feature Flags
+
+AWS and GCP scanning are gated behind feature flags (`FeatureFlags.AwsScanning`, `FeatureFlags.GcpScanning`) — disabled by default. Operators enable per-deployment.
+
+---
+
+## Scope
+
+**In scope:**
+- `CloudProvider` enum + `CloudEnvironmentProfile` entity (generalized from `AzureEnvironmentProfile`)
+- `AwsCredential` + `GcpCredential` credential models (Key Vault backed)
+- `ICloudScanProvider` abstraction + `AwsCloudScanProvider` implementation (Security Hub + Config Rules)
+- `GcpCloudScanProvider` implementation (Security Command Center)
+- NIST 800-53 control mapping seed data for AWS and GCP findings
+- `compliance_assess` tool extended to accept `cloud_provider` parameter
+- Feature flags for AWS/GCP scanning
+- Unit tests for mapping logic + credential handling
+
+**Out of scope:**
+- milCloud2 / DISA-specific cloud profiles (future)
+- Azure Government changes (existing, not modified)
+- eMASS submission differences per CSP (tracked in Feature 071)
+- Multi-CSP dashboard UI components (tracked in Dashboard issues)
+
+---
+
+## Data Model (see data-model.md)
+
+---
+
+## Acceptance Criteria
+
+```gherkin
+Scenario: Register AWS account
+  Given a mission owner with AWS IAM role ARN "arn:aws:iam::123456789:role/SpinReader"
+  When they register the account via onboard_system with cloud_provider=AwsCommercial
+  Then a RegisteredSystem is created with CloudProvider=AwsCommercial
+  And the IAM role ARN is stored in credential store (not in DB directly)
+
+Scenario: AWS Security Hub scan produces ComplianceFinding records
+  Given a registered AWS system with valid IAM credentials
+  When compliance_assess is called for that system
+  Then findings from AWS Security Hub appear as ComplianceFinding records
+  And each finding maps to at least one NIST 800-53 control ID
+
+Scenario: Feature flag gates AWS scan
+  Given the AwsScanning feature flag is disabled
+  When an ISSO attempts to run a scan on an AWS system
+  Then the system returns a clear error: "AWS scanning is not enabled for this deployment"
+```

--- a/specs/075-csp-aws-gcp-integration/tasks.md
+++ b/specs/075-csp-aws-gcp-integration/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — Feature 075: CSP AWS/GCP Integration
+
+## Phase 1 — Abstraction Layer (Foundation)
+- T001: Define `CloudProvider` enum (Azure | AwsCommercial | AwsGovCloud | Gcp)
+- T002: Define `ICloudScanProvider` interface with `ScanAsync` + `TestConnectionAsync`
+- T003: Refactor `IAtoComplianceEngine` as `AzureCloudScanProvider` implementing `ICloudScanProvider`
+- T004: Create `CloudScanProviderRegistry` — DI-registered, returns provider by `CloudProvider` enum
+- T005: Update `ComplianceAssessmentTool` (`compliance_assess`) to accept optional `cloud_provider` param
+
+## Phase 2 — Credential Models
+- T006: Create `AwsCredential` entity (IAM role ARN, external ID, account ID, region, Key Vault secret ref)
+- T007: Create `GcpCredential` entity (project ID, service account key ID, Key Vault secret ref)
+- T008: Create `ICloudCredentialStore` interface + `KeyVaultCloudCredentialStore` implementation
+- T009: EF Core migration: `CloudCredentials` table (polymorphic — `CloudProvider` discriminator)
+
+## Phase 3 — AWS Cloud Scan Provider
+- T010: Create `AwsCloudScanProvider` class in `Ato.Copilot.Agents/Compliance/Scanners/Aws/`
+- T011: Implement Security Hub findings fetch via `AWSSDK.SecurityHub` NuGet
+- T012: Implement Config Rules compliance results fetch via `AWSSDK.ConfigService`
+- T013: Create `AwsNistControlMapper` — maps Security Hub controls to NIST 800-53 IDs
+- T014: Seed AWS NIST control mappings (AWS Foundational Security Best Practices)
+- T015: Connection test: verify AssumeRole succeeds before running scan
+- T016: Unit tests for `AwsCloudScanProvider` and `AwsNistControlMapper`
+
+## Phase 4 — GCP Cloud Scan Provider
+- T017: Create `GcpCloudScanProvider` class in `Ato.Copilot.Agents/Compliance/Scanners/Gcp/`
+- T018: Implement SCC findings fetch via `Google.Cloud.SecurityCenter.V1` NuGet
+- T019: Create `GcpNistControlMapper` — maps SCC categories to NIST 800-53 IDs
+- T020: Seed GCP NIST control mappings (GCP NIST 800-53 mapping)
+- T021: Unit tests for `GcpCloudScanProvider` and `GcpNistControlMapper`
+
+## Phase 5 — Onboarding Integration
+- T022: Extend `RegisteredSystem.AzureProfile` → `CloudEnvironmentProfile` (generalized, migration-safe)
+- T023: Update onboarding wizard (Step 2) to show cloud provider selector
+- T024: Route onboarding scan to correct `ICloudScanProvider` based on registered system's provider
+
+## Phase 6 — Feature Flags
+- T025: Add `FeatureFlags.AwsScanning` + `FeatureFlags.GcpScanning` constants
+- T026: Gate `AwsCloudScanProvider` + `GcpCloudScanProvider` registration behind feature flags
+- T027: Return clear error message when scan attempted on disabled CSP
+
+## Phase 7 — Integration Tests + CI
+- T028: Integration tests: AWS credential validation, mock Security Hub response → ComplianceFinding
+- T029: Integration tests: GCP credential validation, mock SCC response → ComplianceFinding
+- T030: Verify Azure scanning unaffected (regression suite)


### PR DESCRIPTION
**Owner**: Cyborg (`agent:cyborg`)

## Problem Statement

ATO Copilot is Azure-native. The compliance engine, onboarding wizard, scanner architecture, and credential management all assume Azure subscriptions. DoD mission owners running workloads in AWS Commercial, AWS GovCloud (IL2/IL4/IL5), or GCP Public Sector have no path to register those systems in SPIN, run compliance scans, generate findings, or produce SSPs/authorization packages.

This is a strategic gap. DISA milCloud2 runs on AWS GovCloud. A growing portion of DoD workloads are multi-cloud. Without AWS + GCP support, SPIN cannot serve these organizations.

Current state:
- `ComplianceAssessmentTool` requires `subscription_id` (Azure-only parameter)
- `AzureEnvironmentProfile` entity is Azure-specific with ARM, Auth, Defender endpoints
- All scanners in `Ato.Copilot.Agents/Compliance/Scanners/` use Azure SDK clients
- No credential model exists for IAM roles or GCP service accounts

## Goal / Desired Outcome

Feature 075 adds first-class AWS (Commercial + GovCloud) and GCP support via a `ICloudScanProvider` abstraction. AWS and GCP systems flow into the same `RegisteredSystem` → `ComplianceFinding` → POA&M / SSP / SAR pipeline that Azure uses today. No Azure behavior changes.

## Scope

**In scope:**
- `ICloudScanProvider` abstraction + `CloudScanProviderRegistry`
- `AzureCloudScanProvider` wrapping existing `IAtoComplianceEngine` (refactor, no behavior change)
- `AwsCloudScanProvider`: Security Hub + Config Rules → `ComplianceFinding` records + NIST 800-53 control mapping
- `GcpCloudScanProvider`: Security Command Center → `ComplianceFinding` records + NIST 800-53 control mapping
- `AwsCredential` + `GcpCredential` entities (Key Vault backed — no credentials in DB)
- Feature flags: `FeatureFlags.AwsScanning`, `FeatureFlags.GcpScanning` (disabled by default)
- `compliance_assess` tool extended with `cloud_provider` parameter
- Credential registration endpoints + connection test endpoint

**Out of scope:**
- Azure scanning changes (additive only — Azure untouched)
- Multi-CSP dashboard UI (tracked in Dashboard issues)
- milCloud2 / DISA-specific profiles (future)
- eMASS integration differences per CSP (Feature 071)

## User Experience Flow

1. ISSO opens onboarding wizard, selects "Cloud Provider: AWS GovCloud"
2. Enters IAM role ARN + external ID → clicks "Test Connection" → green check
3. System registered as `RegisteredSystem` with `CloudProvider=AwsGovCloud`
4. ISSO runs `compliance_assess` via MCP → `cloud_provider=AwsGovCloud` routes to `AwsCloudScanProvider`
5. Security Hub findings mapped to NIST 800-53 controls → `ComplianceFinding` records created
6. ISSO views compliance posture — same dashboard as Azure systems, driven by same `ComplianceFinding` data

## Functional Requirements

- **FR-001**: `CloudProvider` enum: Azure | AwsCommercial | AwsGovCloud | Gcp
- **FR-002**: `ICloudScanProvider` interface: `ScanAsync(CloudScanRequest, CancellationToken)` + `TestConnectionAsync`
- **FR-003**: `AzureCloudScanProvider` wraps existing `IAtoComplianceEngine` — all Azure tests must remain green
- **FR-004**: `AwsCloudScanProvider` fetches Security Hub findings, maps to NIST 800-53 via published AWS FSBP→NIST mapping, creates `ComplianceFinding` records
- **FR-005**: `GcpCloudScanProvider` fetches SCC findings, maps to NIST 800-53 via published GCP→NIST mapping
- **FR-006**: Credentials stored as Key Vault secret ID references — raw credential values never in DB
- **FR-007**: `compliance_assess` tool accepts `cloud_provider` parameter; routes to correct provider
- **FR-008**: Feature flags gate provider registration — `AwsScanning=false` means AWS provider not registered
- **FR-009**: Clear error message when scan attempted on disabled CSP: "AWS scanning is not enabled for this deployment"
- **FR-010**: `POST /api/systems/{id}/cloud-credentials/test` validates connectivity before saving creds

## Technical Design Notes

Provider abstraction follows DI pattern: `ICloudScanProvider` registered by `CloudProvider` enum discriminator in `CloudScanProviderRegistry`. `ComplianceAssessmentTool` calls `registry.GetProvider(provider).ScanAsync(request, ct)`.

AWS SDK: `AWSSDK.SecurityHub` + `AWSSDK.ConfigService` + `AWSSDK.SecurityToken`. GCP SDK: `Google.Cloud.SecurityCenter.V1`.

Control mappings loaded from embedded JSON resources at startup — not stored as DB rows. This pattern matches existing NIST control data loading.

## Architecture Decisions

| Decision | Chosen | Alternative | Reason |
|---|---|---|---|
| Provider pattern | `ICloudScanProvider` DI registry | Extend `IAtoComplianceEngine` | SRP; no Azure regression risk; new CSPs added without touching existing code |
| Credential storage | Key Vault secret ID in DB | Encrypted column in DB | Key Vault is DoD-appropriate; no encryption-at-rest gaps; consistent with existing Key Vault usage |
| Control mapping | Embedded JSON at startup | DB rows | Easier updates (no migration); matches existing NIST data loading pattern |
| Feature flags | Per-CSP flag | Single multi-cloud flag | Allows AWS to ship before GCP; per-deployment flexibility |

## Acceptance Criteria

```gherkin
Scenario: Register AWS system and scan
  Given a mission owner with IAM role ARN "arn:aws:iam::123456789:role/SpinReader"
  When they register the system with cloud_provider=AwsCommercial
  And call compliance_assess with cloud_provider=AwsCommercial
  Then Security Hub findings appear as ComplianceFinding records
  And each finding maps to at least one NIST 800-53 control ID

Scenario: Feature flag prevents AWS scan
  Given FeatureFlags.AwsScanning is false
  When compliance_assess is called with cloud_provider=AwsCommercial
  Then error: "AWS scanning is not enabled for this deployment"
  And no AWS SDK calls are made

Scenario: Azure regression — existing Azure scan unchanged
  Given a registered Azure system with subscription_id
  When compliance_assess is called (no cloud_provider param — defaults to Azure)
  Then the scan runs via AzureCloudScanProvider
  And results match previous Azure scan behavior
```

## Non-Functional Requirements

- Azure scan p95 latency unchanged after `IAtoComplianceEngine` → `AzureCloudScanProvider` refactor
- AWS Security Hub scan: ≤60s for accounts with ≤1000 findings
- GCP SCC scan: ≤60s for projects with ≤1000 findings
- Credentials never logged (redact Key Vault secret IDs in log output)

## Test Plan

- Unit: `AwsNistControlMapperTests` — all FSBP controls map to ≥1 NIST control
- Unit: `GcpNistControlMapperTests` — all SCC categories map to ≥1 NIST control
- Unit: `AwsCloudScanProviderTests` — mock Security Hub response → correct ComplianceFinding records
- Unit: `GcpCloudScanProviderTests` — mock SCC response → correct ComplianceFinding records
- Unit: `AzureCloudScanProviderTests` — refactor regression suite (existing tests pass)
- Integration: credential round-trip (store → retrieve → test connection mock)

## Definition of Done

- [ ] `CloudProvider` enum + `ICloudScanProvider` interface defined
- [ ] `AzureCloudScanProvider` wraps existing engine, all existing Azure tests green
- [ ] `AwsCloudScanProvider` implemented with Security Hub + Config Rules + NIST mapping
- [ ] `GcpCloudScanProvider` implemented with SCC + NIST mapping
- [ ] `AwsCredential` + `GcpCredential` entities + EF migrations
- [ ] Feature flags in place, disabled by default
- [ ] `compliance_assess` tool accepts `cloud_provider` parameter
- [ ] Credential registration + connection test endpoints live
- [ ] All new unit tests pass (mapper + scanner)
- [ ] Azure regression suite green

## Explicit Constraints (DO NOT)

- DO NOT store raw AWS access keys or GCP service account JSON in the database
- DO NOT modify existing Azure scanning behavior — `AzureCloudScanProvider` is a pure refactor
- DO NOT enable AwsScanning or GcpScanning feature flags by default in any environment
- DO NOT log credential values, ARNs, or Key Vault secret IDs in plaintext

## Anti-patterns

- Extending `IAtoComplianceEngine` with AWS/GCP code paths (SRP violation)
- Storing NIST control mappings as DB rows with per-CSP columns (maintenance burden; JSON seed files preferred)
- Single-cloud `ComplianceFinding` type with CSP-specific fields (use `SourceMetadata` JSON column for CSP-specific data)

## Existing File References

| File | Line | Relevance |
|---|---|---|
| `src/Ato.Copilot.Agents/Compliance/Tools/ComplianceTools.cs` | ~1 | `ComplianceAssessmentTool` — extend with `cloud_provider` param |
| `src/Ato.Copilot.Agents/Compliance/Scanners/BaseComplianceScanner.cs` | ~1 | Base scanner — `AzureCloudScanProvider` wraps this |
| `src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs` | ~211 | `AzureEnvironmentProfile` — `CloudEnvironmentProfile` generalizes this additively |
| `src/Ato.Copilot.Core/Models/Compliance/ComplianceModels.cs` | ~218 | Add `CloudProvider` enum here |
| `specs/001-core-compliance/` | all | Core compliance data model this feature extends |
