### PR TITLE
fix(#386): inject user-assigned MI client ID to prevent SQL Error 18456 on ACA cold start

### DIFF
--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -252,6 +252,12 @@ jobs:
             # AI client registration and causes revision activation failure.
             ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__ENDPOINT=${{ vars.ATO_AZUREAI_ENDPOINT }}"
             ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_AZUREAI__DEPLOYMENTNAME=${{ vars.ATO_AZUREAI_DEPLOYMENTNAME || 'gpt-5.4-mini' }}"
+            # ATO_DATABASE__MANAGEDIDENTITYCLIENTID: user-assigned MI client ID for SQL Server auth.
+            # Without this, SqlClient falls back to the system-assigned identity on ACA hosts that
+            # have both identity types — causing Error 18456 (Login failed). Set via repo variable.
+            if [ -n "${{ vars.ATO_DATABASE__MANAGEDIDENTITYCLIENTID || '' }}" ]; then
+              ENV_ARGS_BASE="${ENV_ARGS_BASE} ATO_DATABASE__MANAGEDIDENTITYCLIENTID=${{ vars.ATO_DATABASE__MANAGEDIDENTITYCLIENTID }}"
+            fi
           elif [ "${{ inputs.workload }}" = "dashboard" ]; then
             MCP_OVERRIDE="${{ inputs.mcp_base_url_override }}"
             if [ -n "$MCP_OVERRIDE" ]; then

--- a/src/Ato.Copilot.Core/Configuration/DatabaseOptions.cs
+++ b/src/Ato.Copilot.Core/Configuration/DatabaseOptions.cs
@@ -59,4 +59,15 @@ public class DatabaseOptions
     /// </summary>
     [Range(30, 1800)]
     public int MigrationTimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Client ID of the user-assigned Managed Identity to use for SQL Server authentication
+    /// (<c>Authentication=Active Directory Managed Identity</c>).
+    /// When set, this value is injected as <c>User Id=…</c> into the connection string,
+    /// ensuring <c>Microsoft.Data.SqlClient</c> selects the correct identity on hosts
+    /// that have both system-assigned and user-assigned identities (e.g. Azure Container Apps).
+    /// Leave empty for SQLite or when the connection string already includes <c>User Id</c>.
+    /// Bound from <c>Database:ManagedIdentityClientId</c>.
+    /// </summary>
+    public string? ManagedIdentityClientId { get; set; }
 }

--- a/src/Ato.Copilot.Core/Extensions/CoreServiceExtensions.cs
+++ b/src/Ato.Copilot.Core/Extensions/CoreServiceExtensions.cs
@@ -232,6 +232,20 @@ public static class CoreServiceExtensions
         var connectionString = configuration.GetConnectionString("DefaultConnection")
                                ?? "Data Source=ato-copilot.db";
 
+        // ACA + user-assigned MI: SqlClient picks system-assigned identity by default when
+        // both identity types are present. Inject User Id=<client-id> so the correct
+        // user-assigned MI is always selected. Only applied when:
+        //   1. ManagedIdentityClientId is configured, AND
+        //   2. the connection string uses Active Directory Managed Identity auth, AND
+        //   3. User Id is not already present in the connection string.
+        if (!string.IsNullOrWhiteSpace(dbOptions.ManagedIdentityClientId)
+            && connectionString.Contains("Active Directory Managed Identity", StringComparison.OrdinalIgnoreCase)
+            && !connectionString.Contains("User Id=", StringComparison.OrdinalIgnoreCase))
+        {
+            connectionString = connectionString.TrimEnd(';')
+                + $";User Id={dbOptions.ManagedIdentityClientId};";
+        }
+
         services.AddDbContextFactory<AtoCopilotContext>((sp, options) =>
         {
             // Suppress PendingModelChangesWarning — model snapshot may lag behind

--- a/src/Ato.Copilot.Mcp/appsettings.json
+++ b/src/Ato.Copilot.Mcp/appsettings.json
@@ -118,7 +118,8 @@
     "CommandTimeoutSeconds": 60,
     "MaxRetryCount": 5,
     "MaxRetryDelay": 30,
-    "MigrationTimeoutSeconds": 300
+    "MigrationTimeoutSeconds": 300,
+    "ManagedIdentityClientId": ""
   },
   "Agents": {
     "Compliance": {

--- a/tests/Ato.Copilot.Tests.Unit/CrossCutting/StructuredLoggingTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/CrossCutting/StructuredLoggingTests.cs
@@ -186,12 +186,16 @@ public class StructuredLoggingTests
         // Act
         await middleware.InvokeAsync(context, _tenantContext);
 
-        // Assert — second log should include status code
+        // Assert — second log should include status code.
+        // Use "Status: 200" rather than bare "200" to avoid a false-positive
+        // match against the request-phase log whose ReqId (12-char hex) can
+        // contain the substring "200" (e.g. "0200d9d1c880"). Times.Once()
+        // would then see two matches and fail. See issue #401.
         _loggerMock.Verify(
             x => x.Log(
                 LogLevel.Information,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("200")),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Status: 200")),
                 null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once());


### PR DESCRIPTION
## Summary

Closes #386. Permanent fix for the recurring `Login failed for user '<token-identified principal>'` (Error 18456) that caused revision `ActivationFailed` on Azure Container Apps.

## Root Cause

`Microsoft.Data.SqlClient` selects the **system-assigned** Managed Identity by default when a host has both system-assigned and user-assigned MIs. The user-assigned MI (`id-ato-copilot-mcp`, client ID `4c6063a6-...`) is the SQL AAD admin — but was never being picked up. The result: every new ACA revision cold-started against SQL with the wrong identity and immediately crashed.

This was masked by previous hotfixes (patching the ACA secret directly) which were overwritten by each subsequent CD deploy.

## Changes

| File | Change |
|------|--------|
| `DatabaseOptions.cs` | Add `ManagedIdentityClientId` property (bound from `Database:ManagedIdentityClientId`) |
| `CoreServiceExtensions.cs` | Auto-inject `User Id=<client-id>` when using MI auth and client ID is configured (idempotent — skips if already present) |
| `appsettings.json` | Add `ManagedIdentityClientId: ""` as empty default |
| `deploy-containerapp-stage.yml` | Wire `ATO_DATABASE__MANAGEDIDENTITYCLIENTID` repo variable into container env args |

## Production Fix Already Applied

- GitHub Actions secret `ATO_DB_CONNECTION_STRING` updated with `User Id=` — keeps existing deploys working until this PR merges
- GitHub Actions variable `ATO_DATABASE__MANAGEDIDENTITYCLIENTID` set to `4c6063a6-5069-4b58-bd5e-a57cb6fe2433`
- Revision `--0000044` restarted and healthy

## After Merge

Next CD run will inject `ATO_DATABASE__MANAGEDIDENTITYCLIENTID` as an env var. `CoreServiceExtensions` will inject `User Id=...` automatically — eliminating the dependency on the connection string secret being exactly right.

## Test Plan
- [ ] CI green
- [ ] Next CD deploy: revision activates without Error 18456
- [ ] `/health` returns HTTP 200
- [ ] Dashboard loads without 500 bootstrap error