### PR TITLE
fix(sec)[P0]: exempt [GlobalReference] entities from TenantScopedQueryGuardInterceptor (#396)

### DIFF
--- a/src/Ato.Copilot.Core/Data/Interceptors/TenantScopedQueryGuardInterceptor.cs
+++ b/src/Ato.Copilot.Core/Data/Interceptors/TenantScopedQueryGuardInterceptor.cs
@@ -1,6 +1,10 @@
+using System.Collections.Concurrent;
 using System.Data.Common;
+using System.Reflection;
 using Ato.Copilot.Core.Interfaces.Tenancy;
+using Ato.Copilot.Core.Models.Tenancy.Attributes;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -17,10 +21,18 @@ namespace Ato.Copilot.Core.Data.Interceptors;
 /// filter on every <c>[TenantScoped]</c> entity for the duration of that
 /// request.</para>
 ///
-/// <para>Allow-list: background services (<see cref="IHttpContextAccessor.HttpContext"/>
+/// <para>Allow-list 1: background services (<see cref="IHttpContextAccessor.HttpContext"/>
 /// is <c>null</c>) are never blocked — the guard only fires when there is an
 /// active HTTP context, which means a real web request is in flight without a
 /// tenant on the accessor.</para>
+///
+/// <para>Allow-list 2: <c>[GlobalReference]</c> entities (NIST controls, CspProfile,
+/// Tenant, NistControl catalog, framework tables, etc.) do NOT have a tenant query
+/// filter and are intentionally cross-tenant-readable. When the <em>only</em> entity
+/// types touched by a command are <c>[GlobalReference]</c>, the guard is skipped.
+/// This is required for <c>TenantResolutionMiddleware</c> Stage A0, which reads
+/// <c>CspProfile</c> (a <c>[GlobalReference]</c> entity) before
+/// <c>accessor.Push(ctx)</c> runs at Stage E. See issue #396.</para>
 ///
 /// <para>Registration: added alongside <see cref="TenantStampingSaveChangesInterceptor"/>
 /// in <c>CoreServiceExtensions.AddAtoCopilotCore()</c>.</para>
@@ -33,6 +45,18 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
     private readonly ITenantContextAccessor _accessor;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<TenantScopedQueryGuardInterceptor> _logger;
+
+    // Lazy-initialized set of table names (lower-case) that belong exclusively to
+    // [GlobalReference] entities. Built once from the EF model on the first request
+    // that hits the guard (i.e. first time the context is available). Thread-safe
+    // via ConcurrentDictionary<string, byte> used as a set.
+    //
+    // Key: lower-cased table name. Value: 1 = [GlobalReference], 0 = [TenantScoped] / unknown.
+    // The map is populated lazily from eventData.Context the first time the guard trips
+    // (HttpContext != null AND accessor.Current == null), so it has zero overhead on the
+    // happy path (accessor already populated).
+    private readonly ConcurrentDictionary<string, byte> _globalRefTableNames = new(StringComparer.OrdinalIgnoreCase);
+    private volatile bool _modelLoaded;
 
     public TenantScopedQueryGuardInterceptor(
         ITenantContextAccessor accessor,
@@ -50,7 +74,7 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
         CommandEventData eventData,
         InterceptionResult<DbDataReader> result)
     {
-        ThrowIfTenantFilterBypass(command);
+        ThrowIfTenantFilterBypass(command, eventData);
         return base.ReaderExecuting(command, eventData, result);
     }
 
@@ -61,28 +85,42 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
         InterceptionResult<DbDataReader> result,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfTenantFilterBypass(command);
+        ThrowIfTenantFilterBypass(command, eventData);
         return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
     }
 
     // ─── Guard implementation ─────────────────────────────────────────────
 
-    private void ThrowIfTenantFilterBypass(DbCommand command)
+    private void ThrowIfTenantFilterBypass(DbCommand command, CommandEventData eventData)
     {
-        // Allow-list: no active HTTP request (background service, CLI,
+        // Allow-list 1: no active HTTP request (background service, CLI,
         // hosted service, startup path) → let the query proceed.
         if (_httpContextAccessor.HttpContext is null)
         {
             return;
         }
 
-        // Allow-list: accessor already has a tenant context → EF filter is live.
+        // Allow-list 2: accessor already has a tenant context → EF filter is live.
         if (_accessor.Current is not null)
         {
             return;
         }
 
-        // We are inside a real HTTP request with no ambient tenant context.
+        // Allow-list 3: [GlobalReference] entities. These are intentionally
+        // cross-tenant-readable (no HasQueryFilter, no RLS policy). The guard
+        // MUST NOT fire for them — doing so breaks TenantResolutionMiddleware
+        // Stage A0 (CspProfile lookup) and any other pre-resolution EF reads.
+        //
+        // Strategy: build a lazy-initialized table-name → isGlobalReference map
+        // from the EF model. If ALL tables touched by this SQL command are in the
+        // [GlobalReference] set, skip the throw.
+        if (IsGlobalReferenceOnlyQuery(command, eventData))
+        {
+            return;
+        }
+
+        // We are inside a real HTTP request with no ambient tenant context AND the
+        // query touches at least one [TenantScoped] table.
         // This is the exact signature of the SEC-P1 bug (issue #100):
         // middleware resolved the tenant but never called accessor.Push().
         //
@@ -106,5 +144,140 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
             $"The tenant query filter is not active — this would silently return cross-tenant rows. " +
             $"Root cause: TenantResolutionMiddleware did not call accessor.Push(ctx) before " +
             $"invoking the next middleware. See SECURITY.md § Scope-to-AsyncLocal Bridge Bugs.");
+    }
+
+    // ─── [GlobalReference] table detection ───────────────────────────────
+
+    /// <summary>
+    /// Returns <c>true</c> if every EF entity type referenced by <paramref name="command"/>
+    /// is annotated with <c>[GlobalReference]</c>. A <c>true</c> result means the guard
+    /// should be bypassed — there is no tenant filter to enforce and no cross-tenant
+    /// data leak risk.
+    /// </summary>
+    /// <remarks>
+    /// Table names are extracted from the SQL <c>FROM</c> clause via a simple
+    /// bracket/quote-aware token scan. This is intentionally conservative: if we
+    /// cannot identify the table (e.g., a raw SQL query with an unusual quoting style),
+    /// we return <c>false</c> (i.e., we enforce the guard). False-positives from parse
+    /// failures are safe; false-negatives would be a security regression.
+    ///
+    /// The EF model scan (lazy init) runs once per <see cref="DbContext"/> type and
+    /// is thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+    /// </remarks>
+    private bool IsGlobalReferenceOnlyQuery(DbCommand command, CommandEventData eventData)
+    {
+        // Populate the model cache on first invocation.
+        if (!_modelLoaded && eventData.Context is { } ctx)
+        {
+            PopulateGlobalRefTableNames(ctx);
+        }
+
+        // Extract table names from the SQL text. If we can't find any recognizable
+        // table references → be conservative and let the guard proceed (return false).
+        var tableNames = ExtractTableNames(command.CommandText);
+        if (tableNames.Count == 0)
+        {
+            return false;
+        }
+
+        // The command is [GlobalReference]-only if EVERY table in the SQL is in the
+        // global-ref set. A single [TenantScoped] table → guard fires.
+        foreach (var table in tableNames)
+        {
+            if (!_globalRefTableNames.ContainsKey(table))
+            {
+                // Not in the [GlobalReference] set → assume [TenantScoped] or unknown.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Lazily populates <see cref="_globalRefTableNames"/> from the EF Core model.
+    /// Thread-safe (ConcurrentDictionary; worst case: two threads both populate once,
+    /// result is idempotent).
+    /// </summary>
+    private void PopulateGlobalRefTableNames(DbContext context)
+    {
+        foreach (var entityType in context.Model.GetEntityTypes())
+        {
+            var clrType = entityType.ClrType;
+            if (clrType is null) continue;
+
+            var isGlobal = clrType.GetCustomAttributes(typeof(GlobalReferenceAttribute), inherit: false).Length > 0;
+            if (!isGlobal) continue;
+
+            var tableName = entityType.GetTableName();
+            if (tableName is null) continue;
+
+            // Value byte: 1 = confirmed [GlobalReference]. The dictionary acts as a set.
+            _globalRefTableNames.TryAdd(tableName, 1);
+        }
+
+        _modelLoaded = true;
+    }
+
+    /// <summary>
+    /// Extracts unqualified table names from a SQL command text.
+    ///
+    /// <para>Handles the two quoting styles EF Core emits:</para>
+    /// <list type="bullet">
+    ///   <item>SQL Server: <c>[TableName]</c></item>
+    ///   <item>SQLite / generic: <c>"TableName"</c></item>
+    /// </list>
+    ///
+    /// <para>Only table names that appear after <c>FROM</c> or <c>JOIN</c>
+    /// keywords are extracted. Schema prefixes (e.g. <c>[dbo].[TableName]</c>) are
+    /// stripped — only the final token is kept.</para>
+    /// </summary>
+    private static HashSet<string> ExtractTableNames(string sql)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(sql)) return names;
+
+        // Tokenize on whitespace / newlines and scan for FROM/JOIN keywords.
+        var tokens = sql.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < tokens.Length - 1; i++)
+        {
+            var tok = tokens[i];
+            if (!tok.Equals("FROM", StringComparison.OrdinalIgnoreCase) &&
+                !tok.Equals("JOIN", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var candidate = tokens[i + 1];
+
+            // Strip schema prefix: "[dbo].[TableName]" → "[TableName]"
+            // Handles both "." separator and AS alias immediately following.
+            var dotIdx = candidate.LastIndexOf('.');
+            if (dotIdx >= 0)
+            {
+                candidate = candidate[(dotIdx + 1)..];
+            }
+
+            // Strip SQL Server brackets: [TableName] → TableName
+            if (candidate.StartsWith('[') && candidate.EndsWith(']'))
+            {
+                candidate = candidate[1..^1];
+            }
+            // Strip double-quotes: "TableName" → TableName
+            else if (candidate.StartsWith('"') && candidate.EndsWith('"'))
+            {
+                candidate = candidate[1..^1];
+            }
+
+            // Ignore subquery / CTE starts
+            if (candidate.StartsWith('(') || string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+            names.Add(candidate);
+        }
+
+        return names;
     }
 }

--- a/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
@@ -1,0 +1,256 @@
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Data.Interceptors;
+using Ato.Copilot.Core.Interfaces.Tenancy;
+using Ato.Copilot.Core.Models.Tenancy;
+using Ato.Copilot.Core.Services.Tenancy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Tenancy;
+
+/// <summary>
+/// Issue #396 — Regression tests for <see cref="TenantScopedQueryGuardInterceptor"/>
+/// <c>[GlobalReference]</c> exemption.
+///
+/// <para>
+/// <c>TenantResolutionMiddleware</c> Stage A0 reads <c>CspProfile</c> (a
+/// <c>[GlobalReference]</c> entity) BEFORE <c>accessor.Push(ctx)</c> runs at
+/// Stage E. Without the exemption, the guard interceptor throws and every
+/// API call returns HTTP 500 on cold start (cache miss).
+/// </para>
+///
+/// <para>
+/// Three correctness properties are tested:
+/// <list type="number">
+///   <item>A SELECT against a <c>[GlobalReference]</c> table (e.g. <c>CspProfiles</c>,
+///   <c>Tenants</c>) succeeds when <c>accessor.Current == null</c> inside an HTTP
+///   request.</item>
+///   <item>A SELECT against a <c>[TenantScoped]</c> table still throws when
+///   <c>accessor.Current == null</c> inside an HTTP request — the guard remains
+///   active for tenant-scoped data.</item>
+///   <item>All queries succeed when <c>accessor.Current != null</c> (fast early-
+///   return path, unaffected by this change).</item>
+/// </list>
+/// </para>
+/// </summary>
+public class TenantScopedQueryGuardGlobalReferenceTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private ServiceProvider _sp = null!;
+    private Mock<IHttpContextAccessor> _httpContextAccessorMock = null!;
+    private TenantContextAccessor _accessor = null!;
+
+    private static readonly Guid TenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public async Task InitializeAsync()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        await _connection.OpenAsync();
+
+        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ITenantContextAccessor, TenantContextAccessor>();
+        services.AddSingleton(_httpContextAccessorMock.Object);
+        services.AddSingleton<TenantScopedQueryGuardInterceptor>();
+        services.AddDbContext<AtoCopilotContext>((sp, opt) =>
+        {
+            opt.UseSqlite(_connection);
+            opt.AddInterceptors(sp.GetRequiredService<TenantScopedQueryGuardInterceptor>());
+        });
+
+        _sp = services.BuildServiceProvider();
+        _accessor = (TenantContextAccessor)_sp.GetRequiredService<ITenantContextAccessor>();
+
+        // Create schema
+        await using var scope = _sp.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+        await db.Database.EnsureCreatedAsync();
+
+        // Seed a Tenant row (GlobalReference) for look-up tests.
+        db.Tenants.Add(new Tenant
+        {
+            Id = TenantId,
+            DisplayName = "Test Tenant",
+            CreatedBy = "seed",
+        });
+
+        // Seed a CspProfile row (GlobalReference). CspProfile has no TenantId column —
+        // it is a singleton cross-tenant record.
+        db.CspProfiles.Add(new CspProfile
+        {
+            LegalEntityName = "ACME DoD LLC",
+            DisplayName = "ACME",
+            CreatedBy = "seed",
+        });
+
+        // Seed an Organization row (TenantScoped) so the SELECT can find rows.
+        using (_accessor.Push(new TenantContext(TenantId)))
+        {
+            db.Organizations.Add(new Organization
+            {
+                TenantId = TenantId,
+                Name = "Test Org",
+                CreatedBy = "seed",
+            });
+            await db.SaveChangesAsync();
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _sp.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    // ─── [GlobalReference] queries must succeed without tenant context ────
+
+    /// <summary>
+    /// Reproduces the Stage A0 production scenario: HTTP request is active,
+    /// accessor.Current is null, but the query targets <c>CspProfile</c>
+    /// (<c>[GlobalReference]</c>). The guard MUST NOT throw.
+    /// </summary>
+    [Fact]
+    public async Task GlobalReference_CspProfile_SucceedsWithoutTenantContext()
+    {
+        // Arrange — HTTP context active, NO tenant pushed (mimics Stage A0)
+        _accessor.Current.Should().BeNull("precondition: no tenant context pushed");
+
+        await using var scope = _sp.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // Act — read CspProfile (GlobalReference) with no tenant context
+        Func<Task> act = async () =>
+        {
+            _ = await db.CspProfiles.FirstOrDefaultAsync();
+        };
+
+        // Assert — must NOT throw; guard exempts [GlobalReference] entities
+        await act.Should().NotThrowAsync(
+            because: "CspProfile is [GlobalReference] and must be readable before tenant resolution");
+    }
+
+    /// <summary>
+    /// <c>Tenant</c> is also <c>[GlobalReference]</c>. Verify the exemption
+    /// applies to all global-reference tables, not only <c>CspProfile</c>.
+    /// </summary>
+    [Fact]
+    public async Task GlobalReference_Tenant_SucceedsWithoutTenantContext()
+    {
+        _accessor.Current.Should().BeNull("precondition: no tenant context pushed");
+
+        await using var scope = _sp.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        Func<Task> act = async () =>
+        {
+            _ = await db.Tenants.FirstOrDefaultAsync();
+        };
+
+        await act.Should().NotThrowAsync(
+            because: "Tenant is [GlobalReference] and must be readable without a tenant context");
+    }
+
+    // ─── [TenantScoped] queries must still throw without tenant context ───
+
+    /// <summary>
+    /// The guard MUST still fire for <c>[TenantScoped]</c> entities when
+    /// <c>accessor.Current == null</c> inside an HTTP request. The exemption
+    /// only covers <c>[GlobalReference]</c> — it must not weaken the guard
+    /// for any tenant-scoped data.
+    /// </summary>
+    [Fact]
+    public async Task TenantScoped_ThrowsWhenNoTenantContext()
+    {
+        // Arrange — HTTP context active, NO tenant pushed
+        _accessor.Current.Should().BeNull("precondition: no tenant context pushed");
+
+        await using var scope = _sp.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        // Act — read Organizations (TenantScoped) with no tenant context
+        Func<Task> act = async () =>
+        {
+            _ = await db.Organizations.FirstOrDefaultAsync();
+        };
+
+        // Assert — guard MUST throw: Organization is [TenantScoped]
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "Organization is [TenantScoped] and the guard must block reads without a tenant context")
+            .WithMessage("*[SEC]*");
+    }
+
+    // ─── Guard is still bypassed entirely when accessor is populated ──────
+
+    /// <summary>
+    /// With <c>accessor.Current != null</c> (normal request path after Stage E),
+    /// the guard is bypassed via the fast early-return. Both <c>[GlobalReference]</c>
+    /// and <c>[TenantScoped]</c> queries succeed.
+    /// </summary>
+    [Fact]
+    public async Task AllEntities_SucceedWhenTenantContextPushed()
+    {
+        await using var scope = _sp.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+        using (_accessor.Push(new TenantContext(TenantId)))
+        {
+            Func<Task> actGlobal = async () =>
+            {
+                _ = await db.CspProfiles.FirstOrDefaultAsync();
+            };
+
+            Func<Task> actScoped = async () =>
+            {
+                _ = await db.Organizations.FirstOrDefaultAsync();
+            };
+
+            await actGlobal.Should().NotThrowAsync(
+                because: "tenant context is live; guard early-returns regardless of entity type");
+
+            await actScoped.Should().NotThrowAsync(
+                because: "tenant context is live; guard early-returns regardless of entity type");
+        }
+    }
+
+    // ─── No HTTP context → guard is never triggered ───────────────────────
+
+    /// <summary>
+    /// Background services (no <c>HttpContext</c>) are always allowed through.
+    /// This is existing Allow-list 1 behaviour and must remain intact.
+    /// </summary>
+    [Fact]
+    public async Task NoHttpContext_NeverThrows_EvenForTenantScoped()
+    {
+        // Arrange — simulate a background service (no HttpContext)
+        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext?)null);
+
+        try
+        {
+            _accessor.Current.Should().BeNull("precondition: no tenant context pushed");
+
+            await using var scope = _sp.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
+
+            Func<Task> act = async () =>
+            {
+                _ = await db.Organizations.FirstOrDefaultAsync();
+            };
+
+            await act.Should().NotThrowAsync(
+                because: "no HttpContext means background service; guard must not fire");
+        }
+        finally
+        {
+            // Restore for other tests in this class
+            _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**P0 production fix.** `TenantScopedQueryGuardInterceptor` was throwing `InvalidOperationException` for **all** EF queries when `HttpContext != null && accessor.Current == null` — including `[GlobalReference]` entity reads that are intentionally exempt from tenant filtering.

## Root Cause

`TenantResolutionMiddleware.InvokeAsync()` calls `cspProfileService.GetAsync()` at Stage A0 (CSP onboarding gate) **before** `accessor.Push(ctx)` at Stage E. On cache miss, this issues an EF `SELECT` against `CspProfile` — a `[GlobalReference]` entity. The interceptor saw no tenant context and threw for every request, returning HTTP 500 to all `/api/dashboard/*` callers.

## Fix — `TenantScopedQueryGuardInterceptor.cs`

Added **Allow-list 3: `[GlobalReference]` entities** inside `ThrowIfTenantFilterBypass()`.

**How it works:**

1. On the first guard invocation (lazy init), walk `eventData.Context.Model.GetEntityTypes()` and record every table whose CLR type has `[GlobalReference]` into a `ConcurrentDictionary<string, byte>` (thread-safe set, populated once per process lifetime).

2. `ExtractTableNames(sql)` scans the SQL command text for `FROM`/`JOIN` table tokens, handling SQL Server `[bracket]` and SQLite `"double-quote"` styles, stripping schema prefixes.

3. If **every** referenced table is in the `[GlobalReference]` set → skip the throw. If **any** table is `[TenantScoped]` or unrecognized → throw as before.

**Existing allow-lists unchanged:**
- Allow-list 1: `HttpContext == null` (background services) — still fast-returns first
- Allow-list 2: `accessor.Current != null` (normal post-Stage-E path) — still fast-returns before any model walk

**Security properties preserved:**
- `[TenantScoped]` entities remain fully guarded
- Mixed queries (`[GlobalReference]` + `[TenantScoped]` tables in one SELECT) are treated as `[TenantScoped]` — conservative default
- Parse failures return `tableNames.Count == 0` → guard proceeds to throw (fail-safe, never a silent bypass)

## Tests — `TenantScopedQueryGuardGlobalReferenceTests.cs` (5 new tests)

| Test | Verifies |
|------|---------|
| `GlobalReference_CspProfile_SucceedsWithoutTenantContext` | Stage A0 reproduction — the exact production failure |
| `GlobalReference_Tenant_SucceedsWithoutTenantContext` | All `[GlobalReference]` tables exempted, not only `CspProfile` |
| `TenantScoped_ThrowsWhenNoTenantContext` | Guard still active for `[TenantScoped]` entities — no security regression |
| `AllEntities_SucceedWhenTenantContextPushed` | Fast early-return path unaffected |
| `NoHttpContext_NeverThrows_EvenForTenantScoped` | Allow-list 1 (background services) unchanged |

## Rollback

```
git revert 735e355
```

The guard reverts to always-throw behaviour when `HttpContext != null && accessor.Current == null`. To prevent the 500s while the rollback is in flight, the workaround is to pre-seed `CspProfile` in the DB so `cspProfileService.GetAsync()` returns from cache without hitting EF.

## Checklist

- [x] Root cause identified and documented
- [x] Production code change is minimal (single method + lazy init field)
- [x] Security invariant verified: `[TenantScoped]` guard still enforced
- [x] 5 regression tests covering all correctness properties
- [x] Rollback documented
