### PR TITLE
ops: CSP + tenant bootstrap SQL and workflow for post-wipe DB recovery

### DIFF
--- a/.github/workflows/bootstrap-csp-tenants.yml
+++ b/.github/workflows/bootstrap-csp-tenants.yml
@@ -1,0 +1,152 @@
+name: Bootstrap CSP + Tenant Data (One-Shot)
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource_group:
+        description: Resource group containing Azure SQL
+        required: true
+        default: rg-ato-copilot
+        type: string
+      sql_server_name:
+        description: Azure SQL server name (without .database.windows.net)
+        required: true
+        default: azsql-ato-copilot-04152047-902
+        type: string
+      sql_database_name:
+        description: Azure SQL database name
+        required: true
+        default: AtoCopilot
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Enable SQL public access + ensure SP is AAD admin
+        id: setup
+        shell: bash
+        run: |
+          set -euo pipefail
+          RG="${{ github.event.inputs.resource_group }}"
+          SQL_SERVER="${{ github.event.inputs.sql_server_name }}"
+
+          # Enable public network access
+          CURRENT=$(az sql server show -g "$RG" -n "$SQL_SERVER" \
+            --query publicNetworkAccess -o tsv)
+          if [ "$CURRENT" = "Disabled" ]; then
+            az sql server update -g "$RG" -n "$SQL_SERVER" \
+              --enable-public-network true --output none
+            echo "reenable_required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reenable_required=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Add firewall rule for GitHub Actions runner IP
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          az sql server firewall-rule create \
+            --resource-group "$RG" --server "$SQL_SERVER" \
+            --name Allow-GHRunner-Bootstrap \
+            --start-ip-address "$RUNNER_IP" \
+            --end-ip-address "$RUNNER_IP" \
+            --output none
+          echo "Firewall rule added for $RUNNER_IP"
+
+          # Set SP as AAD admin
+          SP_OID=$(az ad sp show --id "${{ secrets.AZURE_CLIENT_ID }}" \
+            --query id -o tsv 2>/dev/null || true)
+          EXISTING=$(az sql server ad-admin list -g "$RG" -n "$SQL_SERVER" \
+            --query "[0].login" -o tsv 2>/dev/null || true)
+          echo "existing_admin=$EXISTING" >> "$GITHUB_OUTPUT"
+          if [ "$EXISTING" != "${{ secrets.AZURE_CLIENT_ID }}" ]; then
+            az sql server ad-admin create \
+              -g "$RG" -s "$SQL_SERVER" \
+              --display-name "GH-Actions-SP" \
+              --object-id "$SP_OID" \
+              --output none
+            echo "sp_was_admin=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "sp_was_admin=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install go-sqlcmd
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.0/sqlcmd-linux-amd64.tar.bz2 \
+            | sudo tar -xj -C /usr/local/bin sqlcmd
+          sqlcmd --version
+
+      - name: Run bootstrap-csp-and-tenants.sql
+        shell: bash
+        run: |
+          set -euo pipefail
+          SQL_FQDN="${{ github.event.inputs.sql_server_name }}.database.windows.net"
+
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt/3..."
+            if sqlcmd \
+                -S "${SQL_FQDN}" \
+                --authentication-method=ActiveDirectoryDefault \
+                -d "${{ github.event.inputs.sql_database_name }}" \
+                -i scripts/bootstrap-csp-and-tenants.sql; then
+              echo "Bootstrap SQL completed successfully."
+              break
+            fi
+            if [ $attempt -lt 3 ]; then
+              echo "Failed — waiting 20s before retry..."
+              sleep 20
+            else
+              echo "All attempts failed."
+              exit 1
+            fi
+          done
+
+      - name: Cleanup — firewall + AAD admin + public access
+        if: always()
+        shell: bash
+        run: |
+          RG="${{ github.event.inputs.resource_group }}"
+          SQL_SERVER="${{ github.event.inputs.sql_server_name }}"
+
+          az sql server firewall-rule delete \
+            --resource-group "$RG" --server "$SQL_SERVER" \
+            --name Allow-GHRunner-Bootstrap \
+            --output none 2>/dev/null || true
+          echo "Firewall rule removed."
+
+          # Restore MI as AAD admin
+          MI_OID=$(az identity show \
+            --name id-ato-copilot-mcp \
+            --resource-group "$RG" \
+            --query principalId -o tsv 2>/dev/null || true)
+          if [ -n "$MI_OID" ]; then
+            az sql server ad-admin create \
+              -g "$RG" -s "$SQL_SERVER" \
+              --display-name "id-ato-copilot-mcp" \
+              --object-id "$MI_OID" \
+              --output none 2>/dev/null || true
+            echo "SQL AAD admin restored to id-ato-copilot-mcp."
+          fi
+
+          if [ "${{ steps.setup.outputs.reenable_required }}" = "true" ]; then
+            az sql server update \
+              -g "$RG" -n "$SQL_SERVER" \
+              --enable-public-network false --output none 2>/dev/null || true
+            echo "Public network access restored to Disabled."
+          fi

--- a/scripts/bootstrap-csp-and-tenants.sql
+++ b/scripts/bootstrap-csp-and-tenants.sql
@@ -1,0 +1,143 @@
+-- ============================================================================
+--  ATO Copilot — CSP Profile + Default Tenant Bootstrap
+--
+--  PURPOSE: Seeds the minimum data needed for the app to start accepting
+--  requests in MultiTenant mode. Without a CspProfile row in OnboardingState
+--  = Active (2), TenantResolutionMiddleware blocks ALL API calls (including
+--  the /api/csp/onboarding/* paths needed by seed-systems.sh) with 503.
+--
+--  IDEMPOTENT: All inserts are conditional (IF NOT EXISTS). Safe to re-run.
+--
+--  MUST run BEFORE seed-systems.sh or any API-based seed.
+--
+--  Enum values:
+--    OnboardingState: Pending=0, InWizard=1, Active=2
+--    ClassificationLevel: Unclassified=0, CUI=1, Secret=2, TopSecret=3
+-- ============================================================================
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+USE AtoCopilot;
+
+PRINT '── CSP Bootstrap starting ──';
+
+BEGIN TRANSACTION;
+
+-- ── Step 1: Seed CspProfile (singleton row) ────────────────────────────────
+IF NOT EXISTS (SELECT 1 FROM CspProfiles)
+BEGIN
+    PRINT 'Inserting CspProfile (PEO-790 / flankspeed)...';
+    INSERT INTO CspProfiles (
+        Id,
+        LegalEntityName,
+        DisplayName,
+        LogoUrl,
+        PrimarySupportEmail,
+        SupportPhone,
+        DefaultClassificationFloor,
+        OnboardingState,
+        OnboardingCompletedAt,
+        IdentityCompletedAt,
+        SupportCompletedAt,
+        ClassificationCompletedAt,
+        CreatedAt,
+        CreatedBy,
+        UpdatedAt,
+        UpdatedBy,
+        RowVersion
+    )
+    VALUES (
+        NEWID(),
+        N'PEO-790',
+        N'flankspeed',
+        NULL,
+        N'roger.potts@mil.mil',
+        NULL,
+        1,         -- CUI
+        2,         -- Active
+        SYSDATETIMEOFFSET(),
+        SYSDATETIMEOFFSET(),
+        SYSDATETIMEOFFSET(),
+        SYSDATETIMEOFFSET(),
+        SYSDATETIMEOFFSET(),
+        N'system',
+        NULL,
+        NULL,
+        NULL
+    );
+    PRINT '  CspProfile inserted.';
+END
+ELSE
+BEGIN
+    PRINT '  CspProfile already exists — skipping insert.';
+
+    -- Ensure OnboardingState = Active regardless (in case it was left Pending)
+    UPDATE CspProfiles
+    SET OnboardingState = 2,
+        OnboardingCompletedAt = ISNULL(OnboardingCompletedAt, SYSDATETIMEOFFSET()),
+        IdentityCompletedAt   = ISNULL(IdentityCompletedAt,   SYSDATETIMEOFFSET()),
+        SupportCompletedAt    = ISNULL(SupportCompletedAt,    SYSDATETIMEOFFSET()),
+        ClassificationCompletedAt = ISNULL(ClassificationCompletedAt, SYSDATETIMEOFFSET()),
+        UpdatedAt = SYSDATETIMEOFFSET(),
+        UpdatedBy = N'system-bootstrap'
+    WHERE OnboardingState != 2;
+
+    IF @@ROWCOUNT > 0
+        PRINT '  Updated CspProfile OnboardingState → Active.';
+END
+
+-- ── Step 2: Seed default system tenant ─────────────────────────────────────
+-- The app needs at least one Active tenant so the middleware can resolve
+-- a default context for unauthenticated/seed API calls.
+IF NOT EXISTS (SELECT 1 FROM Tenants WHERE OnboardingState = 2)
+BEGIN
+    PRINT 'Inserting default system tenant (FlankSpeed-Demo-Org)...';
+    INSERT INTO Tenants (
+        Id,
+        EntraTenantId,
+        DisplayName,
+        LegalEntityName,
+        DoDComponent,
+        PrimaryPocName,
+        PrimaryPocEmail,
+        PrimaryPocPhone,
+        HqAddressLine1,
+        HqAddressLine2,
+        HqCity,
+        HqStateOrProvince,
+        HqPostalCode,
+        OnboardingState,
+        CreatedAt,
+        CreatedBy
+    )
+    VALUES (
+        NEWID(),
+        NULL,
+        N'FlankSpeed-Demo-Org',
+        N'PEO-790 Demo Organization',
+        N'Navy',
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        2,         -- Active
+        SYSDATETIMEOFFSET(),
+        N'system'
+    );
+    PRINT '  Default tenant inserted.';
+END
+ELSE
+BEGIN
+    PRINT '  Active tenant already exists — skipping insert.';
+END
+
+COMMIT TRANSACTION;
+
+PRINT '';
+PRINT '── Bootstrap summary ──';
+SELECT COUNT(*) AS CspProfileCount, MAX(CAST(OnboardingState AS INT)) AS MaxOnboardingState FROM CspProfiles;
+SELECT COUNT(*) AS TenantCount FROM Tenants;
+PRINT '── Bootstrap complete ──';


### PR DESCRIPTION
## Summary

Companion to #401. Adds a bootstrap SQL script and workflow to recover the DB after a full wipe — required before API-based seed scripts can execute.

## Problem

After `wipe-seed-data.sql`, if `CspProfiles` has no row with `OnboardingState=Active` (2), `TenantResolutionMiddleware` blocks **all** API calls with 503. This makes it impossible to run `seed-systems.sh` via the API — a chicken-and-egg that requires direct SQL to resolve.

## Changes

| File | Purpose |
|------|---------|
| `scripts/bootstrap-csp-and-tenants.sql` | Idempotent CSP profile + default tenant seed. Sets `OnboardingState=Active`. Safe to re-run. |
| `.github/workflows/bootstrap-csp-tenants.yml` | Dispatches the SQL via go-sqlcmd with OIDC auth. Handles firewall open/close + MI admin restore. |

## Runbook

After any wipe that leaves CspProfiles empty:
1. Run **Bootstrap CSP + Tenant Data** workflow
2. Then run **Full Wipe + Reseed** workflow

🚫 **No production schema changes.** SQL-only, fully idempotent.