### PR TITLE
fix(#403): eager-init GlobalReference table set prevents cold-start HTTP 500 on CspProfile query

### DIFF
--- a/src/Ato.Copilot.Core/Data/Interceptors/TenantScopedQueryGuardInterceptor.cs
+++ b/src/Ato.Copilot.Core/Data/Interceptors/TenantScopedQueryGuardInterceptor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Reflection;
+using Ato.Copilot.Core.Data.Context;
 using Ato.Copilot.Core.Interfaces.Tenancy;
 using Ato.Copilot.Core.Models.Tenancy.Attributes;
 using Microsoft.AspNetCore.Http;
@@ -32,7 +33,14 @@ namespace Ato.Copilot.Core.Data.Interceptors;
 /// types touched by a command are <c>[GlobalReference]</c>, the guard is skipped.
 /// This is required for <c>TenantResolutionMiddleware</c> Stage A0, which reads
 /// <c>CspProfile</c> (a <c>[GlobalReference]</c> entity) before
-/// <c>accessor.Push(ctx)</c> runs at Stage E. See issue #396.</para>
+/// <c>accessor.Push(ctx)</c> runs at Stage E. See issues #396 and #403.</para>
+///
+/// <para>The <c>[GlobalReference]</c> table set is populated <em>eagerly</em> at
+/// construction time via <see cref="IDbContextFactory{TContext}"/>. This prevents
+/// a cold-start race where the first request to hit the guard fires before
+/// <c>eventData.Context</c> has been used to seed the cache, causing all
+/// <c>[GlobalReference]</c> table names to be missing from the set and the guard
+/// to fire incorrectly on the <c>CspProfiles</c> read in Stage A0.</para>
 ///
 /// <para>Registration: added alongside <see cref="TenantStampingSaveChangesInterceptor"/>
 /// in <c>CoreServiceExtensions.AddAtoCopilotCore()</c>.</para>
@@ -46,26 +54,35 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<TenantScopedQueryGuardInterceptor> _logger;
 
-    // Lazy-initialized set of table names (lower-case) that belong exclusively to
-    // [GlobalReference] entities. Built once from the EF model on the first request
-    // that hits the guard (i.e. first time the context is available). Thread-safe
-    // via ConcurrentDictionary<string, byte> used as a set.
+    // Set of table names that belong exclusively to [GlobalReference] entities.
+    // Populated EAGERLY at construction time from the EF model via IDbContextFactory
+    // so it is never empty on the first request. Thread-safe via ConcurrentDictionary
+    // used as a set (value byte is unused; TryAdd is the membership operation).
     //
-    // Key: lower-cased table name. Value: 1 = [GlobalReference], 0 = [TenantScoped] / unknown.
-    // The map is populated lazily from eventData.Context the first time the guard trips
-    // (HttpContext != null AND accessor.Current == null), so it has zero overhead on the
-    // happy path (accessor already populated).
+    // Eager initialisation is critical: CspProfileService.GetAsync() is called from
+    // TenantResolutionMiddleware Stage A0 — before accessor.Push() at Stage E — using
+    // a factory-created DbContext that is separate from the interceptor's lazy-loaded
+    // eventData.Context. On cold boot, if the map is empty when that query fires, the
+    // guard incorrectly treats CspProfiles as [TenantScoped] and throws, blocking
+    // every first request with a 500. (issue #403 / pitfall #15)
     private readonly ConcurrentDictionary<string, byte> _globalRefTableNames = new(StringComparer.OrdinalIgnoreCase);
-    private volatile bool _modelLoaded;
 
     public TenantScopedQueryGuardInterceptor(
         ITenantContextAccessor accessor,
         IHttpContextAccessor httpContextAccessor,
+        IDbContextFactory<AtoCopilotContext> dbContextFactory,
         ILogger<TenantScopedQueryGuardInterceptor> logger)
     {
         _accessor = accessor;
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
+
+        // Eagerly seed the [GlobalReference] table map from the EF model.
+        // CreateDbContext() is synchronous, cheap (no DB connection), and
+        // safe to call during DI construction because it only reads the in-memory
+        // model. We immediately dispose the context — we only need the model metadata.
+        using var seedCtx = dbContextFactory.CreateDbContext();
+        PopulateGlobalRefTableNames(seedCtx);
     }
 
     /// <inheritdoc/>
@@ -166,11 +183,10 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
     /// </remarks>
     private bool IsGlobalReferenceOnlyQuery(DbCommand command, CommandEventData eventData)
     {
-        // Populate the model cache on first invocation.
-        if (!_modelLoaded && eventData.Context is { } ctx)
-        {
-            PopulateGlobalRefTableNames(ctx);
-        }
+        // The [GlobalReference] table map is seeded eagerly at construction time,
+        // so no lazy-init check is needed here. If somehow the map is empty
+        // (e.g. a unit test that doesn't wire the factory), be conservative and
+        // let the guard proceed (return false = possible tenant-scoped query).
 
         // Extract table names from the SQL text. If we can't find any recognizable
         // table references → be conservative and let the guard proceed (return false).
@@ -215,8 +231,6 @@ public sealed class TenantScopedQueryGuardInterceptor : DbCommandInterceptor
             // Value byte: 1 = confirmed [GlobalReference]. The dictionary acts as a set.
             _globalRefTableNames.TryAdd(tableName, 1);
         }
-
-        _modelLoaded = true;
     }
 
     /// <summary>

--- a/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
@@ -59,12 +59,25 @@ public class TenantScopedQueryGuardGlobalReferenceTests : IAsyncLifetime
         services.AddLogging();
         services.AddSingleton<ITenantContextAccessor, TenantContextAccessor>();
         services.AddSingleton(_httpContextAccessorMock.Object);
-        services.AddSingleton<TenantScopedQueryGuardInterceptor>();
+
+        // Register the factory FIRST so TenantScopedQueryGuardInterceptor (singleton,
+        // resolved lazily) can inject IDbContextFactory<AtoCopilotContext> to eagerly
+        // seed its [GlobalReference] table map at construction time.
+        // NOTE: the factory registration does NOT add the interceptor itself — that
+        // would create a circular dependency (factory → interceptor → factory).
+        // The interceptor is wired via AddDbContext below so EF Core gets it.
+        services.AddDbContextFactory<AtoCopilotContext>(opt =>
+            opt.UseSqlite(_connection));
+
+        // Also register as AddDbContext so test code that resolves AtoCopilotContext
+        // directly (via scope) gets the interceptor attached.
         services.AddDbContext<AtoCopilotContext>((sp, opt) =>
         {
             opt.UseSqlite(_connection);
             opt.AddInterceptors(sp.GetRequiredService<TenantScopedQueryGuardInterceptor>());
         });
+
+        services.AddSingleton<TenantScopedQueryGuardInterceptor>();
 
         _sp = services.BuildServiceProvider();
         _accessor = (TenantContextAccessor)_sp.GetRequiredService<ITenantContextAccessor>();


### PR DESCRIPTION
## Root Cause (Pitfall #15)

`TenantScopedQueryGuardInterceptor` populated its `[GlobalReference]` table name set **lazily** from `eventData.Context` on the first guard trip.

`TenantResolutionMiddleware` Stage A0 calls `CspProfileService.GetAsync()` **before** `accessor.Push(ctx)` (Stage E). `CspProfileService` creates its own `DbContext` via `IDbContextFactory` — a **separate instance** from the one that would have seeded the lazy map.

On cold boot, the map is **empty** when that `CspProfiles` query fires:
- `ContainsKey("CspProfiles")` → `false`
- Guard incorrectly treats it as `[TenantScoped]`
- Throws `InvalidOperationException`
- **HTTP 500 on every first request after deploy** ❌

## Fix

| Change | File |
|--------|------|
| Inject `IDbContextFactory<AtoCopilotContext>` into constructor | `TenantScopedQueryGuardInterceptor.cs` |
| Call `PopulateGlobalRefTableNames(seedCtx)` **eagerly at construction** (model-only read, no DB connection) | `TenantScopedQueryGuardInterceptor.cs` |
| Remove `_modelLoaded` volatile flag (no longer needed) | `TenantScopedQueryGuardInterceptor.cs` |
| Register `AddDbContextFactory` before singleton interceptor in test setup | `TenantScopedQueryGuardGlobalReferenceTests.cs` |

## Sequence after fix

```
Cold boot:
  1. DI constructs TenantScopedQueryGuardInterceptor
  2. Constructor calls CreateDbContext() — reads EF model, NO DB connection
  3. _globalRefTableNames seeded: {CspProfiles, Tenants, NistControls, ...}
  4. Context disposed immediately

First request (Stage A0):
  5. CspProfileService.GetAsync() fires CspProfiles query
  6. Guard checks: HttpContext != null, accessor.Current == null
  7. IsGlobalReferenceOnlyQuery → ContainsKey("CspProfiles") → TRUE ✅
  8. Guard returns — query proceeds
  9. Stage E: accessor.Push(ctx) — all [TenantScoped] queries now guarded
```

## Testing
- Existing `TenantScopedQueryGuardGlobalReferenceTests` covers all three properties
- Test setup updated to register `AddDbContextFactory` + `AddDbContext` separately to avoid circular dependency during construction

Closes #403