### PR TITLE
fix(#408): count null-boundary CSAs in Authorization Boundary Defined gate

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/RmfLifecycleService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/RmfLifecycleService.cs
@@ -377,17 +377,35 @@ public class RmfLifecycleService : IRmfLifecycleService
         // Feature 040 introduced BoundaryComponentAssignments as the source of truth
         // for boundary composition. Keep a legacy fallback count for older rows that
         // still rely on ComponentSystemAssignments.AuthorizationBoundaryDefinitionId.
+        //
+        // Issue #408 fix: also count CSAs where AuthorizationBoundaryDefinitionId IS NULL.
+        // When a component is assigned via the wizard or boundary page without an explicit
+        // boundary ID (null), it is treated as a system-wide / primary-boundary assignment.
+        // This mirrors the logic in GetComponentsByBoundaryAsync (includeNullBoundary = true
+        // for the primary boundary). Without this, a single-component system always fails
+        // the "Authorization Boundary Defined" gate even though the component is visible in
+        // the boundary UI.
         var inScopeBoundaryComponents = await context.BoundaryComponentAssignments
             .CountAsync(bca => bca.AuthorizationBoundaryDefinition!.RegisteredSystemId == system.Id
                             && bca.IsInScope,
                         cancellationToken);
 
-        var legacyInScopeComponents = await context.ComponentSystemAssignments
+        // Count explicit-boundary CSAs (original legacy path)
+        var legacyExplicitBoundaryComponents = await context.ComponentSystemAssignments
             .CountAsync(csa => csa.RegisteredSystemId == system.Id
                             && csa.AuthorizationBoundaryDefinitionId != null,
                         cancellationToken);
 
-        var inScopeComponents = inScopeBoundaryComponents + legacyInScopeComponents;
+        // Count null-boundary CSAs — assigned to the system without a specific boundary,
+        // which maps to the primary / system-wide boundary (same as the display path).
+        var legacyNullBoundaryComponents = await context.ComponentSystemAssignments
+            .CountAsync(csa => csa.RegisteredSystemId == system.Id
+                            && csa.AuthorizationBoundaryDefinitionId == null,
+                        cancellationToken);
+
+        var inScopeComponents = inScopeBoundaryComponents
+                              + legacyExplicitBoundaryComponents
+                              + legacyNullBoundaryComponents;
 
         results.Add(new GateCheckResult
         {

--- a/tests/Ato.Copilot.Tests.Unit/Gates/BoundaryGateTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Gates/BoundaryGateTests.cs
@@ -1,0 +1,273 @@
+using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Gates;
+
+/// <summary>
+/// Unit tests for Gate 2 (Authorization Boundary Defined) in CheckPrepareToCategorize
+/// via RmfLifecycleService.CheckGateConditionsAsync.
+///
+/// Regression tests for Issue #408:
+///   - A component assigned without an explicit AuthorizationBoundaryDefinitionId (null)
+///     must still satisfy the "Authorization Boundary Defined" gate.
+///   - Previously, only CSAs with AuthorizationBoundaryDefinitionId != null were counted,
+///     causing the gate to fail even when a component was visible in the boundary UI.
+/// </summary>
+public class BoundaryGateTests
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly AtoCopilotContext _db;
+    private readonly RmfLifecycleService _service;
+
+    public BoundaryGateTests()
+    {
+        var dbName = $"BoundaryGate_{Guid.NewGuid()}";
+        var services = new ServiceCollection();
+        services.AddDbContext<AtoCopilotContext>(o => o.UseInMemoryDatabase(dbName));
+        services.AddLogging();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _db = _serviceProvider.GetRequiredService<AtoCopilotContext>();
+
+        _service = new RmfLifecycleService(
+            _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Mock.Of<ILogger<RmfLifecycleService>>());
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<RegisteredSystem> SeedSystemWithRole()
+    {
+        var system = new RegisteredSystem
+        {
+            Name = "Boundary Gate Test System",
+            SystemType = SystemType.MajorApplication,
+            MissionCriticality = MissionCriticality.MissionEssential,
+            HostingEnvironment = "Azure Government",
+            CreatedBy = "test-user",
+            CurrentRmfStep = RmfPhase.Prepare
+        };
+        _db.RegisteredSystems.Add(system);
+
+        system.RmfRoleAssignments.Add(new RmfRoleAssignment
+        {
+            RegisteredSystemId = system.Id,
+            RmfRole = RmfRole.Isso,
+            UserId = "isso-user",
+            UserDisplayName = "Test ISSO",
+            IsActive = true,
+            AssignedBy = "test-admin"
+        });
+
+        await _db.SaveChangesAsync();
+        return system;
+    }
+
+    // ─── Gate 2: Authorization Boundary Defined ───────────────────────────────
+
+    /// <summary>
+    /// Issue #408 — A CSA with AuthorizationBoundaryDefinitionId = NULL (assigned via wizard
+    /// or boundary page without an explicit boundary) must satisfy the gate.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_NullBoundaryComponentSystemAssignment_Passes()
+    {
+        var system = await SeedSystemWithRole();
+
+        // Assign a component with no explicit boundary (null) — the pattern produced by
+        // AssignToSystemAsync when no boundaryDefinitionId is supplied by the wizard.
+        _db.ComponentSystemAssignments.Add(new ComponentSystemAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            RegisteredSystemId = system.Id,
+            AuthorizationBoundaryDefinitionId = null,   // ← the failing case
+            CreatedBy = "test-user"
+        });
+        await _db.SaveChangesAsync();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeTrue(
+            "a CSA with null AuthorizationBoundaryDefinitionId represents a system-wide " +
+            "(primary boundary) assignment and must satisfy the gate");
+        gate.Message.Should().Contain("1 component(s) in boundary.");
+    }
+
+    /// <summary>
+    /// A CSA with an explicit AuthorizationBoundaryDefinitionId (the existing path) still passes.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_ExplicitBoundaryComponentSystemAssignment_Passes()
+    {
+        var system = await SeedSystemWithRole();
+
+        var boundaryId = Guid.NewGuid().ToString();
+        _db.AuthorizationBoundaryDefinitions.Add(new AuthorizationBoundaryDefinition
+        {
+            Id = boundaryId,
+            RegisteredSystemId = system.Id,
+            Name = "Production Boundary",
+            BoundaryType = BoundaryDefinitionType.Logical,
+            IsPrimary = true,
+            CreatedBy = "test-user"
+        });
+
+        _db.ComponentSystemAssignments.Add(new ComponentSystemAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            RegisteredSystemId = system.Id,
+            AuthorizationBoundaryDefinitionId = boundaryId,  // ← explicit boundary
+            CreatedBy = "test-user"
+        });
+        await _db.SaveChangesAsync();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeTrue(
+            "a CSA with an explicit AuthorizationBoundaryDefinitionId must satisfy the gate");
+    }
+
+    /// <summary>
+    /// A BoundaryComponentAssignment (Feature 040 path, IsInScope=true) still passes.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_BoundaryComponentAssignmentInScope_Passes()
+    {
+        var system = await SeedSystemWithRole();
+
+        var boundaryId = Guid.NewGuid().ToString();
+        _db.AuthorizationBoundaryDefinitions.Add(new AuthorizationBoundaryDefinition
+        {
+            Id = boundaryId,
+            RegisteredSystemId = system.Id,
+            Name = "Production Boundary",
+            BoundaryType = BoundaryDefinitionType.Logical,
+            IsPrimary = true,
+            CreatedBy = "test-user"
+        });
+
+        _db.BoundaryComponentAssignments.Add(new BoundaryComponentAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            AuthorizationBoundaryDefinitionId = boundaryId,
+            IsInScope = true,
+            CreatedBy = "test-user"
+        });
+        await _db.SaveChangesAsync();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeTrue(
+            "a BoundaryComponentAssignment with IsInScope=true must satisfy the gate");
+    }
+
+    /// <summary>
+    /// A BoundaryComponentAssignment with IsInScope=false must NOT satisfy the gate
+    /// when it is the only assignment.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_BoundaryComponentAssignmentOutOfScope_Fails()
+    {
+        var system = await SeedSystemWithRole();
+
+        var boundaryId = Guid.NewGuid().ToString();
+        _db.AuthorizationBoundaryDefinitions.Add(new AuthorizationBoundaryDefinition
+        {
+            Id = boundaryId,
+            RegisteredSystemId = system.Id,
+            Name = "Production Boundary",
+            BoundaryType = BoundaryDefinitionType.Logical,
+            IsPrimary = true,
+            CreatedBy = "test-user"
+        });
+
+        // Out-of-scope component — should NOT count toward the gate.
+        _db.BoundaryComponentAssignments.Add(new BoundaryComponentAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            AuthorizationBoundaryDefinitionId = boundaryId,
+            IsInScope = false,
+            ExclusionRationale = "Excluded for test",
+            CreatedBy = "test-user"
+        });
+        await _db.SaveChangesAsync();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeFalse(
+            "an out-of-scope BoundaryComponentAssignment must not satisfy the gate");
+    }
+
+    /// <summary>
+    /// No component assignments at all — gate must fail.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_NoComponentAssignments_Fails()
+    {
+        var system = await SeedSystemWithRole();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeFalse(
+            "with no component assignments the gate must not pass");
+        gate.Message.Should().Contain("At least 1 component must be assigned");
+    }
+
+    /// <summary>
+    /// Mixed: one null-boundary CSA + one in-scope BCA → count = 2.
+    /// </summary>
+    [Fact]
+    public async Task Gate2_MixedNullBoundaryAndBCA_CountsBoth()
+    {
+        var system = await SeedSystemWithRole();
+
+        var boundaryId = Guid.NewGuid().ToString();
+        _db.AuthorizationBoundaryDefinitions.Add(new AuthorizationBoundaryDefinition
+        {
+            Id = boundaryId,
+            RegisteredSystemId = system.Id,
+            Name = "Production Boundary",
+            BoundaryType = BoundaryDefinitionType.Logical,
+            IsPrimary = true,
+            CreatedBy = "test-user"
+        });
+
+        // Feature 040 path: one in-scope BCA
+        _db.BoundaryComponentAssignments.Add(new BoundaryComponentAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            AuthorizationBoundaryDefinitionId = boundaryId,
+            IsInScope = true,
+            CreatedBy = "test-user"
+        });
+
+        // Legacy null-boundary CSA (the issue #408 scenario)
+        _db.ComponentSystemAssignments.Add(new ComponentSystemAssignment
+        {
+            SystemComponentId = Guid.NewGuid().ToString(),
+            RegisteredSystemId = system.Id,
+            AuthorizationBoundaryDefinitionId = null,
+            CreatedBy = "test-user"
+        });
+
+        await _db.SaveChangesAsync();
+
+        var results = await _service.CheckGateConditionsAsync(system.Id, RmfPhase.Categorize);
+
+        var gate = results.Single(r => r.GateName == "Authorization Boundary Defined");
+        gate.Passed.Should().BeTrue();
+        gate.Message.Should().Contain("2 component(s) in boundary.");
+    }
+}


### PR DESCRIPTION
Owner: Cyborg
Epic: #408 — Authorization Boundary Defined gate false-FAILED on null-boundary CSAs
Spec: N/A (single-file logic fix)
Wave: Wave 8 — Security & Compliance Hardening

## Problem Statement

`RmfLifecycleService.CheckPrepareToCategorizeAsync` (lines 377–408) counted boundary-assigned components only when `ComponentSystemAssignment.AuthorizationBoundaryDefinitionId != null`. However, `ComponentService.AssignToSystemAsync` intentionally writes `null` into that column when no explicit boundary ID is supplied — which is the standard code path from both the system wizard and the boundary assignment page.

Result: systems that correctly have components assigned via the standard wizard path received **FAILED** on the "Authorization Boundary Defined" gate even though the Boundary page's display count showed ≥1 component. Gate logic and display path were out of sync.

Affected file: `src/Ato.Copilot.Agents/Compliance/Services/RmfLifecycleService.cs:377–408`

## Goal / Desired Outcome

- Gate 2 ("Authorization Boundary Defined") returns PASSED when ≥1 `ComponentSystemAssignment` exists with either a null **or** an explicit `AuthorizationBoundaryDefinitionId` for the system.
- Gate logic mirrors the display path's null-boundary inclusion logic (`ComponentService.GetComponentsByBoundaryAsync:1138–1147`).
- Five regression unit tests covering all valid CSA/BCA combinations land in `BoundaryGateTests.cs`.

## Scope

**In Scope:**
- `RmfLifecycleService.cs` — replace two-way count with three-way `CountAsync` (lines 377–408)
- `tests/Ato.Copilot.Tests.Unit/Gates/BoundaryGateTests.cs` — new test file (5 tests)

**Out of Scope:**
- `ComponentService.AssignToSystemAsync` — do NOT change; null boundary ID is intentional
- `ComponentService.GetComponentsByBoundaryAsync` — display path already handles null; no change
- Any EF migration
- Any frontend change

## User Experience Flow

1. User navigates to the RMF wizard and assigns one or more components to a system (no explicit boundary selected — standard path).
2. `ComponentService.AssignToSystemAsync` writes a `ComponentSystemAssignment` row with `AuthorizationBoundaryDefinitionId = null`.
3. User opens the Phase Readiness panel and expands "Prepare → Categorize".
4. Gate 2 "Authorization Boundary Defined" shows **PASSED** (≥1 component found via three-way count).
5. User proceeds to Categorize step without manual workaround.

## Functional Requirements

- **FR-001** — The gate must count `ComponentSystemAssignment` rows where `AuthorizationBoundaryDefinitionId IS NULL` as valid boundary assignments.
- **FR-002** — The gate must still count `ComponentSystemAssignment` rows where `AuthorizationBoundaryDefinitionId IS NOT NULL` as valid.
- **FR-003** — The gate must still count `BoundaryComponentAssignment` rows where `IsInScope = true` as valid.
- **FR-004** — A `BoundaryComponentAssignment` row where `IsInScope = false` must NOT satisfy the gate alone.
- **FR-005** — The total `inScopeComponents` count is the sum of all three `CountAsync` results.

## Technical Design Notes

**Root cause:** `ComponentService.AssignToSystemAsync` (lines 1198–1206) sets `AuthorizationBoundaryDefinitionId = boundaryDefinitionId` where that parameter defaults to `null` from both the wizard and boundary page. This is architecturally intentional — a null boundary ID means "primary / system-wide boundary". The gate was never updated to honour this semantic.

**Fix — three-way CountAsync:**

```csharp
// 1. Feature 040 path: BoundaryComponentAssignment.IsInScope = true
var inScopeBoundaryComponents = await context.BoundaryComponentAssignments
    .CountAsync(bca =>
        bca.AuthorizationBoundaryDefinition!.RegisteredSystemId == system.Id
        && bca.IsInScope, cancellationToken);

// 2. Legacy explicit-boundary CSA
var legacyExplicitBoundaryComponents = await context.ComponentSystemAssignments
    .CountAsync(csa =>
        csa.RegisteredSystemId == system.Id
        && csa.AuthorizationBoundaryDefinitionId != null, cancellationToken);

// 3. Null-boundary CSA = primary/system-wide boundary assignment (Issue #408 fix)
var legacyNullBoundaryComponents = await context.ComponentSystemAssignments
    .CountAsync(csa =>
        csa.RegisteredSystemId == system.Id
        && csa.AuthorizationBoundaryDefinitionId == null, cancellationToken);

var inScopeComponents = inScopeBoundaryComponents
                      + legacyExplicitBoundaryComponents
                      + legacyNullBoundaryComponents;
```

**Display path alignment:** `ComponentService.GetComponentsByBoundaryAsync` (lines 1138–1147) already uses `includeNullBoundary` to include null-boundary CSAs in the display count. The gate now matches this logic exactly.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Three `CountAsync` calls instead of one combined `||` predicate | Clarity and reviewability; each count maps to a distinct data path (Feature 040 BCA, explicit-boundary CSA, null-boundary CSA). EF will generate efficient individual queries. |
| No migration / no backfill of null `AuthorizationBoundaryDefinitionId` | Null is intentional semantics ("primary boundary"). Backfilling would break the display path and alter existing data. |
| New `BoundaryGateTests.cs` mirrors `PrivacyGateTests.cs` structure | Consistency with existing gate test pattern; allows CI to detect regressions on any gate change. |

## Acceptance Criteria

```gherkin
Scenario: Null-boundary CSA satisfies the Authorization Boundary Defined gate
  Given a RegisteredSystem with no BoundaryComponentAssignments
  And one ComponentSystemAssignment with AuthorizationBoundaryDefinitionId = null
  When CheckPrepareToCategorizeAsync is called
  Then Gate 2 result is PASSED

Scenario: Explicit-boundary CSA satisfies the gate
  Given a RegisteredSystem with a ComponentSystemAssignment with a non-null AuthorizationBoundaryDefinitionId
  When CheckPrepareToCategorizeAsync is called
  Then Gate 2 result is PASSED

Scenario: BCA with IsInScope=true satisfies the gate
  Given a RegisteredSystem with a BoundaryComponentAssignment where IsInScope = true
  When CheckPrepareToCategorizeAsync is called
  Then Gate 2 result is PASSED

Scenario: BCA with IsInScope=false does not satisfy the gate alone
  Given a RegisteredSystem with only a BoundaryComponentAssignment where IsInScope = false
  When CheckPrepareToCategorizeAsync is called
  Then Gate 2 result is FAILED

Scenario: Mixed null-boundary CSA and in-scope BCA both counted
  Given a RegisteredSystem with one null-boundary CSA and one in-scope BCA
  When CheckPrepareToCategorizeAsync is called
  Then Gate 2 result is PASSED and inScopeComponents = 2
```

## Non-Functional Requirements

- **NFR-001** — No additional EF migration required; this is a query-layer change only.
- **NFR-002** — All three `CountAsync` calls target indexed columns (`RegisteredSystemId`, `AuthorizationBoundaryDefinitionId`); no full-table scan introduced.
- **NFR-003** — Unit tests run in <200 ms using `InMemoryDatabase`.

## Test Plan

**Manual:**
- Assign a component to a system via the wizard (no explicit boundary) → verify Gate 2 shows PASSED in Phase Readiness panel.
- Create a system with no components → verify Gate 2 shows FAILED.

**Unit tests (new — `BoundaryGateTests.cs`):**
- `Gate2_NullBoundaryComponentSystemAssignment_Passes`
- `Gate2_ExplicitBoundaryComponentSystemAssignment_Passes`
- `Gate2_BoundaryComponentAssignmentInScope_Passes`
- `Gate2_BoundaryComponentAssignmentOutOfScope_Fails`
- `Gate2_MixedNullBoundaryAndBCA_CountsBoth`

**Existing suite must pass:**
- All existing CI checks (dotnet-build-test, dashboard bundle audit, integration tests)

## Definition of Done

- [x] Three-way `CountAsync` logic in `RmfLifecycleService.cs:377–408`
- [x] Five unit tests in `BoundaryGateTests.cs` — all green
- [ ] All existing CI jobs still pass
- [x] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT modify `ComponentService.AssignToSystemAsync` — null boundary ID is intentional architecture.
- DO NOT backfill `AuthorizationBoundaryDefinitionId` via migration.
- DO NOT merge if any existing CI check regresses.

## Anti-patterns

- Combining all three predicates into a single `||` LINQ expression — produces a Cartesian-risk query that EF may not optimize cleanly; three explicit `CountAsync` calls are clearer.
- Adding a fourth `CountAsync` for "both null AND explicit" — double-counts assignments; the three cases are mutually exclusive by definition.

## Existing File References

- `src/Ato.Copilot.Agents/Compliance/Services/RmfLifecycleService.cs:377–408` — gate check, three-way count fix
- `src/Ato.Copilot.Core/Services/ComponentService.cs:1198–1206` — `AssignToSystemAsync`, writes null boundary (do NOT change)
- `src/Ato.Copilot.Core/Services/ComponentService.cs:1138–1147` — `GetComponentsByBoundaryAsync`, display path (correct, mirrors gate fix)
- `tests/Ato.Copilot.Tests.Unit/Gates/BoundaryGateTests.cs` — new, 5 regression tests

Closes #408
