### PR TITLE
fix(#407,#408): harden Step 3 component load error handling; fix null-boundary gate false-fail

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx
@@ -30,6 +30,7 @@ export default function SystemComponents({ systemId, onNext, onErrors }: SystemC
   const [orgSearch, setOrgSearch] = useState('');
   const [orgComponents, setOrgComponents] = useState<OrgComponentDto[]>([]);
   const [orgLoading, setOrgLoading] = useState(false);
+  const [orgError, setOrgError] = useState<string | null>(null);
   const [assigning, setAssigning] = useState<string | null>(null);
 
   useEffect(() => {
@@ -40,9 +41,19 @@ export default function SystemComponents({ systemId, onNext, onErrors }: SystemC
   useEffect(() => {
     if (activeTab !== 'org') return;
     setOrgLoading(true);
+    setOrgError(null);
     listComponents({ search: orgSearch || undefined, pageSize: 50 })
-      .then((res) => setOrgComponents(res.items))
-      .catch(() => onErrors({ _form: ['Failed to load organization components'] }))
+      .then((res) => {
+        // Guard against unexpected shape — backend returns { items, totalCount, page, pageSize }
+        const items = res?.items ?? [];
+        setOrgComponents(items);
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[SystemComponents] Failed to load org components:', err);
+        setOrgError(msg || 'Failed to load organization components.');
+        setOrgComponents([]);
+      })
       .finally(() => setOrgLoading(false));
   }, [activeTab, orgSearch]);
 
@@ -137,6 +148,11 @@ export default function SystemComponents({ systemId, onNext, onErrors }: SystemC
           />
           {orgLoading ? (
             <p className="text-sm text-gray-400">Loading...</p>
+          ) : orgError ? (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              <span className="font-medium">Failed to load organization components.</span>
+              {' '}{orgError}
+            </div>
           ) : orgComponents.length === 0 ? (
             <p className="text-sm text-gray-400">No organization components found.</p>
           ) : (


### PR DESCRIPTION
## Summary

Fixes two bugs blocking the System Registration Wizard workflow.

---

### Bug #407 — Wizard Step 3 shows 'No organization components found'

**Root cause:** The `listComponents()` call in `SystemComponents.tsx` (line 43) was throwing (auth/network/tenant error), but the `.catch()` block silently swallowed it: it called `onErrors()` (a form-level handler, invisible in the list panel) and reset `orgComponents` to `[]`, which rendered the misleading 'No organization components found' message instead of an error.

**Fix:**
- Added `orgError` state: renders an inline red error banner in the list panel when `listComponents()` rejects
- Added `console.error` so the actual exception is visible in browser DevTools
- Added `res?.items ?? []` defensive guard against unexpected response shapes
- Removed the `onErrors()` call from the list-load path (reserved for form-level errors, not library API errors)

**Files:** `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemComponents.tsx`

---

### Bug #408 — Phase Readiness check fails for 'Authorization Boundary Defined' despite components being assigned

**Root cause:** `RmfLifecycleService.CheckPrepareToCategorizeAsync` (lines 385–388) counted only `ComponentSystemAssignment` rows where `AuthorizationBoundaryDefinitionId != null`. But `AssignToSystemAsync` (the wizard path) creates CSA rows with `AuthorizationBoundaryDefinitionId = null` when no explicit boundary is selected — representing a system-wide / primary-boundary assignment. `GetComponentsByBoundaryAsync` (the display function) correctly includes null-boundary rows via its `includeNullBoundary` logic. The gate check did not.

**Net effect:** UI showed 1 component assigned to boundary, phase-readiness showed 0 → gate failed.

**Fix:** Removed `&& csa.AuthorizationBoundaryDefinitionId != null` from the legacy CSA count. All CSAs for the system now count toward the gate, matching display logic.

**Files:** `src/Ato.Copilot.Agents/Compliance/Services/RmfLifecycleService.cs`

---

### Tests

Added `BoundaryGateTests.cs` — 5 regression tests for Gate 2:
- `NullBoundaryCSA_Passes` — the issue #408 exact scenario
- `ExplicitBoundaryCSA_Passes` — existing explicit-FK path still works
- `BCA_InScope_Passes` — Feature 040 `BoundaryComponentAssignment` path still works
- `BCA_OutOfScope_Fails` — out-of-scope exclusion correctly rejected
- `NoAssignments_Fails` — empty system correctly blocked
- `Mixed_CountsBoth` — both paths summed correctly (count = 2)

---

## Spec Compliance

No spec changes — both are regression fixes to existing behaviour in the System Registration Wizard (spec-047) and RMF gate logic (spec-040 / spec-033).

## Acceptance Criteria

- [ ] Wizard Step 3 shows 15 org components (or inline error if API fails, not misleading empty state)
- [ ] Phase Readiness 'Authorization Boundary Defined' gate passes for systems with wizard-assigned components
- [ ] All 5 new `BoundaryGateTests` green in CI
- [ ] No regressions in existing gate tests (`PrivacyGateTests`, `SimulationGateTests`)