### PR TITLE
feat(#411): non-CSP dashboard deployment via runtime env var override

### DIFF
--- a/.github/workflows/cd-azure-containerapp.yml
+++ b/.github/workflows/cd-azure-containerapp.yml
@@ -225,3 +225,27 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  # Feature 411: Org-only (non-CSP) dashboard — same image, same MCP backend,
+  # FORCE_SINGLE_TENANT=true forces SingleTenant mode at runtime via nginx
+  # sub_filter injection of window.__FORCE_SINGLE_TENANT__. This eliminates
+  # the CSP portfolio view, TenantPicker, and ImpersonationBanner for tenants
+  # that do not need CSP features.
+  deploy-production-dashboard-org:
+    needs: [deploy-production-dashboard, build-image]
+    uses: ./.github/workflows/deploy-containerapp-stage.yml
+    with:
+      environment_name: production
+      workload: dashboard
+      containerapp_name: ca-ato-copilot-dashboard-org-v2
+      image: ${{ needs.build-image.outputs.dashboard_image }}
+      target_port: "8080"
+      health_path: /
+      include_mcp_env_vars: false
+      assign_managed_identity: false
+      inject_runtime_secrets: false
+      extra_env_vars: "FORCE_SINGLE_TENANT=true"
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -56,6 +56,15 @@ on:
         required: false
         default: false
         type: boolean
+      extra_env_vars:
+        description: |
+          Additional space-separated env var KEY=VALUE pairs to append to the container
+          app's env vars. Used to pass deployment-specific flags such as
+          FORCE_SINGLE_TENANT=true for org-only dashboard instances (Feature 411).
+          Values must not contain spaces. Example: "FORCE_SINGLE_TENANT=true FOO=bar"
+        required: false
+        default: ""
+        type: string
       min_replicas:
         description: "Minimum replica count. Set to 1+ to disable cold-start (scale-to-zero)."
         required: false
@@ -286,6 +295,12 @@ jobs:
           fi
 
           ENV_ARGS_WITH_SECRETS="${ENV_ARGS_BASE}${SECRETREF_ARGS}"
+          # Feature 411: append caller-supplied extra vars (e.g. FORCE_SINGLE_TENANT=true).
+          EXTRA="${{ inputs.extra_env_vars }}"
+          if [ -n "${EXTRA}" ]; then
+            ENV_ARGS_BASE="${ENV_ARGS_BASE} ${EXTRA}"
+            ENV_ARGS_WITH_SECRETS="${ENV_ARGS_WITH_SECRETS} ${EXTRA}"
+          fi
           echo "base=${ENV_ARGS_BASE}" >> "$GITHUB_OUTPUT"
           echo "with_secrets=${ENV_ARGS_WITH_SECRETS}" >> "$GITHUB_OUTPUT"
 

--- a/src/Ato.Copilot.Dashboard/nginx.conf
+++ b/src/Ato.Copilot.Dashboard/nginx.conf
@@ -184,11 +184,23 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Never cache index.html so new deploys are picked up immediately
+    # Never cache index.html so new deploys are picked up immediately.
+    # Feature 411: inject window.__FORCE_SINGLE_TENANT__ at runtime via envsubst.
+    # FORCE_SINGLE_TENANT is set to "true" for org-only deployments and "" (empty)
+    # for CSP deployments. envsubst rewrites this template when the container starts.
     location = /index.html {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+
+        # Runtime mode injection (Feature 411): replaces the closing </head> tag
+        # with an inline script that sets window.__FORCE_SINGLE_TENANT__ before
+        # React hydrates. envsubst substitutes ${FORCE_SINGLE_TENANT} at container
+        # start time (nginx:stable-alpine processes /etc/nginx/templates/*.template).
+        # The sub_filter directive requires ngx_http_sub_module (included in
+        # nginx:stable-alpine). sub_filter_types is not needed — text/html is default.
+        sub_filter "</head>" "<script>window.__FORCE_SINGLE_TENANT__=\"${FORCE_SINGLE_TENANT}\";</script></head>";
+        sub_filter_once on;
     }
 
     # Cache static assets (hashed filenames make this safe)

--- a/src/Ato.Copilot.Dashboard/src/features/tenancy/api.ts
+++ b/src/Ato.Copilot.Dashboard/src/features/tenancy/api.ts
@@ -161,8 +161,20 @@ function unwrap<T>(envelope: Envelope<T>): T {
  * Returns deployment mode. Falls back to `SingleTenant` if the endpoint is
  * unreachable (e.g. T084 has not yet been deployed) so callers can render
  * defensively without a try/catch.
+ *
+ * Feature 411: If nginx injected `window.__FORCE_SINGLE_TENANT__ === "true"`
+ * at container start time (org-only deployment), short-circuit immediately
+ * without hitting the network. This lets a single image serve both CSP and
+ * org-only deployments purely via env var, with no extra backend round-trip.
  */
 export async function getDeploymentMode(): Promise<DeploymentModeResponse> {
+  // Runtime override — set by nginx sub_filter for org-only (non-CSP) Container App
+  // instances (Feature 411). "true" is the only truthy value; empty string or absent
+  // means the normal network probe runs.
+  if (typeof window !== 'undefined' && window.__FORCE_SINGLE_TENANT__ === 'true') {
+    return { mode: 'SingleTenant' };
+  }
+
   try {
     const { data } = await tenancyClient.get<Envelope<DeploymentModeResponse>>(
       '/deployment/mode',

--- a/src/Ato.Copilot.Dashboard/src/vite-env.d.ts
+++ b/src/Ato.Copilot.Dashboard/src/vite-env.d.ts
@@ -8,3 +8,10 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Feature 411: runtime mode override injected by nginx sub_filter.
+// nginx sets window.__FORCE_SINGLE_TENANT__ = "true" for org-only deployments;
+// it is empty string or absent for CSP/MultiTenant deployments.
+interface Window {
+  __FORCE_SINGLE_TENANT__?: string;
+}


### PR DESCRIPTION
## Summary

Single image, two deployments. `FORCE_SINGLE_TENANT=true` env var forces the dashboard into SingleTenant (org-only) mode at container start — no second build, no code fork.

---

## How it works

```
Container start
  └─ nginx envsubst processes nginx.conf.template
       └─ ${FORCE_SINGLE_TENANT} substituted into sub_filter string
            └─ Every /index.html response has injected:
                 <script>window.__FORCE_SINGLE_TENANT__="true";</script>

React bootstrap (main.tsx)
  └─ TenantPicker mounts → calls getDeploymentMode()
       └─ window.__FORCE_SINGLE_TENANT__ === 'true'?
            YES → return { mode: 'SingleTenant' } immediately (no network call)
            NO  → GET /api/deployment/mode (existing path, unchanged)
```

---

## Files changed

### `nginx.conf`
Adds `sub_filter` + `sub_filter_once` to the `location = /index.html` block:
```nginx
sub_filter "</head>" "<script>window.__FORCE_SINGLE_TENANT__=\"\";</script></head>";
sub_filter_once on;
```
- `ngx_http_sub_module` is included in `nginx:stable-alpine` — no Dockerfile change needed.
- `envsubst` runs at container start (nginx Docker image auto-processes `*.template` files).
- CSP deployment: `FORCE_SINGLE_TENANT` is unset → empty string injected → override check is false → existing probe runs unchanged.

### `src/features/tenancy/api.ts`
Adds a short-circuit at the top of `getDeploymentMode()`:
```ts
if (typeof window !== 'undefined' && window.__FORCE_SINGLE_TENANT__ === 'true') {
  return { mode: 'SingleTenant' };
}
```
Zero network cost. No impact on the CSP deployment path.

### `src/vite-env.d.ts`
Extends `Window` interface with `__FORCE_SINGLE_TENANT__?: string` — type-safe, no `(as any)`.

### `deploy-containerapp-stage.yml` (reusable workflow)
Adds `extra_env_vars` input (default `""`), appended to the env var args block after secret refs. Generic — not org-specific.

### `cd-azure-containerapp.yml` (CD pipeline)
Adds `deploy-production-dashboard-org` job:
- Runs after `deploy-production-dashboard` (CSP dashboard) succeeds
- `containerapp_name: ca-ato-copilot-dashboard-org-v2`
- Same image as CSP dashboard
- `extra_env_vars: "FORCE_SINGLE_TENANT=true"`

---

## Deployment topology

| Container App | Mode | FORCE_SINGLE_TENANT |
|---|---|---|
| `ca-ato-copilot-dashboard-v2` | MultiTenant (CSP) | unset |
| `ca-ato-copilot-dashboard-org-v2` | SingleTenant (Org) | `true` |

Both point to the same MCP backend (`ca-ato-copilot-mcp-v2`).

---

## Design trade-offs

**Why sub_filter and not a separate build?**
One image means one build, one push, one vulnerability surface, one deployment artifact to audit. Runtime configuration is the right separation point for deployment topology — it's infrastructure, not code.

**Why check `=== 'true'` not just truthy?**
Empty string (when `FORCE_SINGLE_TENANT` is unset) injected as `window.__FORCE_SINGLE_TENANT__=""` is falsy in JS but is still a string. Strict equality prevents accidental triggering on any injected value other than the exact string `"true"`.

**Why not `VITE_FORCE_SINGLE_TENANT`?**
Vite env vars are baked in at build time. We explicitly want runtime configuration so the same image can be promoted through dev → test → production for both deployment types without rebuilding.

---

## Acceptance Criteria

- [ ] `ca-ato-copilot-dashboard-v2`: TenantPicker visible for CSP-Admin, `PortfolioRiskProfile` renders
- [ ] `ca-ato-copilot-dashboard-org-v2`: TenantPicker hidden, ImpersonationBanner hidden, `getDeploymentMode()` returns `SingleTenant` with no network call
- [ ] Both point to same MCP backend, both serve the same asset bundle
- [ ] CD pipeline deploys org dashboard after CSP dashboard succeeds (waterfall, not parallel, to gate on CSP smoke test first)