### PR TITLE
fix(ci): replace AddDbContextFactory with TestDbContextFactory in TenantScopedQueryGuardGlobalReferenceTests to prevent shared SQLite connection close hang

### DIFF
--- a/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Tenancy/TenantScopedQueryGuardGlobalReferenceTests.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
+using Ato.Copilot.Tests.Unit;
 
 namespace Ato.Copilot.Tests.Unit.Tenancy;
 
@@ -60,14 +61,24 @@ public class TenantScopedQueryGuardGlobalReferenceTests : IAsyncLifetime
         services.AddSingleton<ITenantContextAccessor, TenantContextAccessor>();
         services.AddSingleton(_httpContextAccessorMock.Object);
 
-        // Register the factory FIRST so TenantScopedQueryGuardInterceptor (singleton,
-        // resolved lazily) can inject IDbContextFactory<AtoCopilotContext> to eagerly
-        // seed its [GlobalReference] table map at construction time.
-        // NOTE: the factory registration does NOT add the interceptor itself — that
-        // would create a circular dependency (factory → interceptor → factory).
-        // The interceptor is wired via AddDbContext below so EF Core gets it.
-        services.AddDbContextFactory<AtoCopilotContext>(opt =>
-            opt.UseSqlite(_connection));
+        // Register a NON-POOLING IDbContextFactory<AtoCopilotContext> so the
+        // TenantScopedQueryGuardInterceptor constructor can call CreateDbContext()
+        // to read EF model metadata for the [GlobalReference] table map.
+        //
+        // IMPORTANT: Do NOT use AddDbContextFactory here. AddDbContextFactory
+        // registers a PooledDbContextFactory whose Dispose() path resets and CLOSES
+        // the underlying connection object. Since _connection is a shared in-memory
+        // SqliteConnection used by AddDbContext below, closing it in the pool reset
+        // (triggered when the interceptor ctor disposes its seed context) makes
+        // subsequent EnsureCreatedAsync / query calls hang on a closed connection.
+        //
+        // TestDbContextFactory returns the same non-disposing shared context on every
+        // CreateDbContext() call, so the pool never closes _connection.
+        var factoryOptions = new DbContextOptionsBuilder<AtoCopilotContext>()
+            .UseSqlite(_connection)
+            .Options;
+        services.AddSingleton<IDbContextFactory<AtoCopilotContext>>(
+            new TestDbContextFactory(factoryOptions));
 
         // Also register as AddDbContext so test code that resolves AtoCopilotContext
         // directly (via scope) gets the interceptor attached.


### PR DESCRIPTION
## Summary

Fixes a CI hang that blocked all 3 open PRs (#409, #410, #412) since June 12.

## Root Cause

PR #405 changed `TenantScopedQueryGuardInterceptor` to eagerly seed its `[GlobalReference]` table map at construction time via `IDbContextFactory<AtoCopilotContext>.CreateDbContext()`. The updated test (`TenantScopedQueryGuardGlobalReferenceTests`) registered `AddDbContextFactory` to provide that factory.

**Problem:** `AddDbContextFactory` registers a `PooledDbContextFactory<T>`. When the interceptor constructor calls `CreateDbContext()` and immediately disposes the returned context (`using var seedCtx = ...`), `PooledDbContextFactory` resets the context on dispose — which **closes the underlying `SqliteConnection` object**. Since `_connection` is a shared in-memory connection also used by the `AddDbContext` registration, closing it during interceptor construction leaves subsequent `EnsureCreatedAsync` / query calls operating on a closed connection. This caused `xUnit` to hang indefinitely with zero test output — bypassing the 15-minute job timeout on the runner.

**Evidence:**
- June 11 CI: 5,220 tests passed in 73 seconds
- After #405: `dotnet test` starts, prints "Starting test execution, please wait..." and never produces another line
- New test run triggered for diagnosis: hung for 17+ minutes before manual cancel

## Fix

Replace `AddDbContextFactory` in the test with a manually-constructed `TestDbContextFactory` (already present in the test project). `TestDbContextFactory` returns the same non-disposing shared context on every `CreateDbContext()` call — the pool never closes `_connection`, and the interceptor reads EF model metadata successfully without affecting shared connection state.

## Impact

- Only `TenantScopedQueryGuardGlobalReferenceTests.cs` changed
- No production code modified
- All 5 existing tests in that class remain green (interceptor still correctly seeds the `[GlobalReference]` map)
- Unblocks PRs #409, #410, #412

## After Merge

All 3 blocked PRs need to `git rebase main` or `git merge main` to pick up this fix before re-triggering CI.
