### PR TITLE
fix(#406): wizard step 2 — dual-source capability fetch (CSP first, Org second)

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx
@@ -3,12 +3,37 @@ import apiClient from '../../../api/client';
 import { linkCapabilities, getCapabilityLinks, removeCapabilityLink } from '../../../api/capabilityLinks';
 import type { SystemCapabilityLink } from '../../../types/dashboard';
 
-interface Capability {
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+/** CSP-inherited capability from /api/dashboard/capability-library */
+interface CspCapability {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+  componentName: string;
+  controlCount: number;
+  mappedControls: string[];
+  isSubscribed: boolean;
+}
+
+/** Org-owned capability from /api/dashboard/capabilities */
+interface OrgCapability {
   id: string;
   name: string;
   provider: string;
   category: string;
   implementationStatus: string;
+}
+
+/** Unified row rendered in the picker list */
+interface CapabilityRow {
+  id: string;
+  name: string;
+  subtitle: string;      // "provider · componentName" or "provider"
+  badge: string;         // category / implementationStatus / control count
+  source: 'csp' | 'org';
+  alreadyLinked: boolean;
 }
 
 interface SecurityCapabilitiesProps {
@@ -17,42 +42,89 @@ interface SecurityCapabilitiesProps {
   onErrors: (errors: Record<string, string[]>) => void;
 }
 
+// ─── Component ─────────────────────────────────────────────────────────────────
+
 export default function SecurityCapabilities({ systemId, onNext, onErrors }: SecurityCapabilitiesProps) {
   const [search, setSearch] = useState('');
-  const [capabilities, setCapabilities] = useState<Capability[]>([]);
+  const [cspCapabilities, setCspCapabilities] = useState<CspCapability[]>([]);
+  const [orgCapabilities, setOrgCapabilities] = useState<OrgCapability[]>([]);
   const [linkedItems, setLinkedItems] = useState<SystemCapabilityLink[]>([]);
+  const [cspSubscribedIds, setCspSubscribedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Load existing links on mount
-  useEffect(() => {
-    getCapabilityLinks(systemId).then((res) => setLinkedItems(res.items)).catch(() => onErrors({ _form: ['Failed to load capability links'] }));
-  }, [systemId]);
+  // ─── Initial load: existing org-links + CSP subscriptions ──────────────────
 
-  // Debounced search
-  const fetchCapabilities = useCallback(async (query: string) => {
-    setLoading(true);
-    try {
-      const { data } = await apiClient.get('/capabilities', {
-        params: { search: query, pageSize: 50 },
-      });
-      setCapabilities(data.items ?? []);
-    } catch {
-      setCapabilities([]);
-    } finally {
-      setLoading(false);
+  useEffect(() => {
+    let cancelled = false;
+    async function loadInitial() {
+      try {
+        const [linksRes, subsRes] = await Promise.all([
+          getCapabilityLinks(systemId),
+          apiClient
+            .get<{ items: { capabilityId: string }[]; totalCount: number }>(
+              `/systems/${systemId}/capability-subscriptions`,
+            )
+            .catch(() => ({ data: { items: [], totalCount: 0 } })),
+        ]);
+        if (!cancelled) {
+          setLinkedItems(linksRes.items);
+          setCspSubscribedIds(new Set(subsRes.data.items.map((s) => s.capabilityId)));
+        }
+      } catch {
+        if (!cancelled) onErrors({ _form: ['Failed to load capability links'] });
+      }
     }
-  }, []);
+    void loadInitial();
+    return () => { cancelled = true; };
+  }, [systemId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ─── Parallel fetch: CSP library FIRST, then Org capabilities ──────────────
+
+  const fetchCapabilities = useCallback(
+    async (query: string) => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const [cspRes, orgRes] = await Promise.all([
+          // CSP capability library — Mapped capabilities published by the CSP provider
+          apiClient
+            .get<{ items: CspCapability[]; totalCount: number }>('/capability-library', {
+              params: { search: query || undefined, systemId, pageSize: 50 },
+            })
+            .catch(() => ({ data: { items: [], totalCount: 0 } })),
+          // Org-owned capabilities — this organisation's own capability catalog
+          apiClient
+            .get<{ items: OrgCapability[] }>('/capabilities', {
+              params: { search: query || undefined, pageSize: 50 },
+            })
+            .catch(() => ({ data: { items: [] } })),
+        ]);
+        setCspCapabilities(cspRes.data.items ?? []);
+        setOrgCapabilities(orgRes.data.items ?? []);
+      } catch {
+        setLoadError('Failed to load capabilities. Please try again.');
+        setCspCapabilities([]);
+        setOrgCapabilities([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [systemId],
+  );
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      fetchCapabilities(search);
+      void fetchCapabilities(search);
     }, 300);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
   }, [search, fetchCapabilities]);
+
+  // ─── Selection ─────────────────────────────────────────────────────────────
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
@@ -63,12 +135,40 @@ export default function SecurityCapabilities({ systemId, onNext, onErrors }: Sec
     });
   };
 
+  // ─── Link / subscribe action ────────────────────────────────────────────────
+  //
+  // CSP capabilities  → POST /systems/{id}/capability-subscriptions (CapabilitySubscriptionEndpoints)
+  // Org capabilities  → POST /systems/{id}/capability-links         (via linkCapabilities())
+
+  const linkSelected = async (ids: Set<string>): Promise<void> => {
+    if (ids.size === 0) return;
+
+    const cspIds = [...ids].filter((id) => cspCapabilities.some((c) => c.id === id));
+    const orgIds = [...ids].filter((id) => orgCapabilities.some((c) => c.id === id));
+
+    const cspJobs = cspIds.map((capabilityId) =>
+      apiClient
+        .post(`/systems/${systemId}/capability-subscriptions`, { capabilityId })
+        .then(() => {
+          setCspSubscribedIds((prev) => new Set([...prev, capabilityId]));
+        }),
+    );
+
+    const orgJob =
+      orgIds.length > 0
+        ? linkCapabilities(systemId, orgIds).then((result) => {
+            setLinkedItems((prev) => [...prev, ...(result.items ?? [])]);
+          })
+        : Promise.resolve();
+
+    await Promise.all([...cspJobs, orgJob]);
+  };
+
   const handleLink = async () => {
     if (selectedIds.size === 0) return;
     setSaving(true);
     try {
-      const result = await linkCapabilities(systemId, Array.from(selectedIds));
-      setLinkedItems((prev) => [...prev, ...(result.items ?? [])]);
+      await linkSelected(selectedIds);
       setSelectedIds(new Set());
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to link capabilities';
@@ -83,8 +183,7 @@ export default function SecurityCapabilities({ systemId, onNext, onErrors }: Sec
     if (selectedIds.size > 0) {
       setSaving(true);
       try {
-        const result = await linkCapabilities(systemId, Array.from(selectedIds));
-        setLinkedItems((prev) => [...prev, ...(result.items ?? [])]);
+        await linkSelected(selectedIds);
         setSelectedIds(new Set());
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : 'Failed to link capabilities';
@@ -107,95 +206,211 @@ export default function SecurityCapabilities({ systemId, onNext, onErrors }: Sec
     }
   };
 
+  // ─── Unified row lists ──────────────────────────────────────────────────────
+
   const linkedCapIds = new Set(linkedItems.map((l) => l.capabilityId));
+
+  const cspRows: CapabilityRow[] = cspCapabilities.map((c) => ({
+    id: c.id,
+    name: c.name,
+    subtitle: `${c.provider} · ${c.componentName}`,
+    badge: `${c.controlCount} controls`,
+    source: 'csp',
+    alreadyLinked: cspSubscribedIds.has(c.id) || c.isSubscribed,
+  }));
+
+  const orgRows: CapabilityRow[] = orgCapabilities.map((c) => ({
+    id: c.id,
+    name: c.name,
+    subtitle: c.provider,
+    badge: c.category,
+    source: 'org',
+    alreadyLinked: linkedCapIds.has(c.id),
+  }));
+
+  const totalRows = cspRows.length + orgRows.length;
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
 
   return (
     <div>
       <h2 className="text-xl font-semibold text-gray-900 mb-1">Step 2: Security Capabilities</h2>
-      <p className="text-sm text-gray-500 mb-6">Search and link existing security capabilities to this system.</p>
+      <p className="text-sm text-gray-500 mb-6">
+        Link security capabilities to this system. CSP-inherited capabilities are shown first,
+        followed by your organisation&apos;s own capabilities.
+      </p>
 
-      {/* Linked items */}
+      {/* ── Linked items ─────────────────────────────────────────────────────── */}
       {linkedItems.length > 0 && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-2">Linked Capabilities ({linkedItems.length})</h3>
+          <h3 className="text-sm font-medium text-gray-700 mb-2">
+            Linked Capabilities ({linkedItems.length})
+          </h3>
           <div className="space-y-1">
             {linkedItems.map((item) => (
-              <div key={item.id} className="flex items-center justify-between rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm">
+              <div
+                key={item.id}
+                className="flex items-center justify-between rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm"
+              >
                 <div>
                   <span className="font-medium text-gray-900">{item.capabilityName}</span>
-                  {item.category && <span className="ml-2 text-xs text-gray-500">{item.category}</span>}
+                  {item.category && (
+                    <span className="ml-2 text-xs text-gray-500">{item.category}</span>
+                  )}
                 </div>
-                <button onClick={() => handleRemove(item.id)} className="text-red-500 hover:text-red-700 text-xs">Remove</button>
+                <button
+                  onClick={() => void handleRemove(item.id)}
+                  className="text-red-500 hover:text-red-700 text-xs"
+                >
+                  Remove
+                </button>
               </div>
             ))}
           </div>
         </div>
       )}
 
-      {/* Search */}
+      {/* ── Search ───────────────────────────────────────────────────────────── */}
       <div className="mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          placeholder="Search capabilities by name or category..."
+          placeholder="Search CSP and org capabilities by name, provider, or category…"
         />
       </div>
 
-      {/* Results */}
-      <div className="border border-gray-200 rounded-md max-h-64 overflow-y-auto">
+      {/* ── Source legend ─────────────────────────────────────────────────────── */}
+      <div className="mb-3 flex items-center gap-4 text-xs text-gray-500">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-3 rounded-full border-2 border-indigo-400 bg-indigo-50" />
+          CSP-inherited
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-3 rounded-full border-2 border-gray-300 bg-white" />
+          Org capability
+        </span>
+      </div>
+
+      {/* ── Results list ──────────────────────────────────────────────────────── */}
+      <div className="border border-gray-200 rounded-md max-h-72 overflow-y-auto">
         {loading ? (
-          <p className="p-4 text-sm text-gray-500">Searching...</p>
-        ) : capabilities.length === 0 ? (
+          <p className="p-4 text-sm text-gray-500">Searching…</p>
+        ) : loadError ? (
+          <p className="p-4 text-sm text-red-500">{loadError}</p>
+        ) : totalRows === 0 ? (
           <p className="p-4 text-sm text-gray-400">No capabilities found</p>
         ) : (
-          capabilities.map((cap) => {
-            const alreadyLinked = linkedCapIds.has(cap.id);
-            return (
-              <label
-                key={cap.id}
-                className={`flex items-center gap-3 px-3 py-2 border-b border-gray-100 hover:bg-gray-50 text-sm ${alreadyLinked ? 'opacity-50' : 'cursor-pointer'}`}
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedIds.has(cap.id)}
-                  onChange={() => !alreadyLinked && toggleSelect(cap.id)}
-                  disabled={alreadyLinked}
-                  className="rounded"
-                />
-                <div className="flex-1">
-                  <span className="font-medium text-gray-900">{cap.name}</span>
-                  <span className="ml-2 text-xs text-gray-500">{cap.provider}</span>
+          <>
+            {/* CSP group — rendered first */}
+            {cspRows.length > 0 && (
+              <>
+                <div className="sticky top-0 z-10 bg-indigo-50 px-3 py-1.5 border-b border-indigo-100">
+                  <span className="text-xs font-semibold text-indigo-700 uppercase tracking-wide">
+                    CSP-Inherited ({cspRows.length})
+                  </span>
                 </div>
-                <span className="text-xs text-gray-400">{cap.category}</span>
-                <span className={`text-xs px-1.5 py-0.5 rounded ${cap.implementationStatus === 'Implemented' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
-                  {cap.implementationStatus}
-                </span>
-              </label>
-            );
-          })
+                {cspRows.map((row) => (
+                  <CapabilityRowItem
+                    key={row.id}
+                    row={row}
+                    checked={selectedIds.has(row.id)}
+                    onToggle={() => !row.alreadyLinked && toggleSelect(row.id)}
+                  />
+                ))}
+              </>
+            )}
+
+            {/* Org group — rendered second */}
+            {orgRows.length > 0 && (
+              <>
+                <div className="sticky top-0 z-10 bg-gray-50 px-3 py-1.5 border-b border-gray-100">
+                  <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
+                    Org Capabilities ({orgRows.length})
+                  </span>
+                </div>
+                {orgRows.map((row) => (
+                  <CapabilityRowItem
+                    key={row.id}
+                    row={row}
+                    checked={selectedIds.has(row.id)}
+                    onToggle={() => !row.alreadyLinked && toggleSelect(row.id)}
+                  />
+                ))}
+              </>
+            )}
+          </>
         )}
       </div>
 
+      {/* ── Link button ───────────────────────────────────────────────────────── */}
       {selectedIds.size > 0 && (
         <button
-          onClick={handleLink}
+          onClick={() => void handleLink()}
           disabled={saving}
           className="mt-3 rounded-md bg-green-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
         >
-          {saving ? 'Linking...' : `Link ${selectedIds.size} Selected`}
+          {saving ? 'Linking…' : `Link ${selectedIds.size} Selected`}
         </button>
       )}
 
       <div className="mt-6 flex justify-end">
         <button
-          onClick={handleNext}
+          onClick={() => void handleNext()}
           disabled={saving}
           className="rounded-md bg-indigo-600 px-6 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
         >
-          {saving ? 'Saving...' : 'Next'}
+          {saving ? 'Saving…' : 'Next'}
         </button>
       </div>
     </div>
+  );
+}
+
+// ─── Row sub-component ──────────────────────────────────────────────────────────
+
+function CapabilityRowItem({
+  row,
+  checked,
+  onToggle,
+}: {
+  row: CapabilityRow;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  const isCsp = row.source === 'csp';
+  const borderClass = isCsp ? 'border-b border-indigo-50' : 'border-b border-gray-100';
+  const hoverClass = row.alreadyLinked ? 'opacity-50' : 'hover:bg-gray-50 cursor-pointer';
+  const leftAccentClass = isCsp ? 'border-l-2 border-l-indigo-400 pl-2' : 'pl-3';
+
+  return (
+    <label className={`flex items-center gap-3 px-3 py-2 text-sm ${borderClass} ${hoverClass}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        disabled={row.alreadyLinked}
+        className="rounded"
+      />
+      <div className={`flex flex-1 items-center justify-between gap-2 ${leftAccentClass}`}>
+        <div className="min-w-0">
+          <span className="font-medium text-gray-900 truncate">{row.name}</span>
+          <span className="ml-2 text-xs text-gray-500">{row.subtitle}</span>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {row.alreadyLinked && (
+            <span className="text-xs font-medium text-green-700 bg-green-50 rounded px-1.5 py-0.5">
+              ✓ Linked
+            </span>
+          )}
+          <span className="text-xs text-gray-400">{row.badge}</span>
+          {isCsp && (
+            <span className="text-xs font-medium text-indigo-600 bg-indigo-50 rounded px-1.5 py-0.5">
+              CSP
+            </span>
+          )}
+        </div>
+      </div>
+    </label>
   );
 }


### PR DESCRIPTION
Owner: Mr. Terrific
Issues: #406
Reporter: Batman (Discord task)
Triage: Mr. Terrific

## 1. Problem Statement

`src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx`

- `fetchCapabilities()` called only `GET /api/dashboard/capabilities` (Org-level, line 42 pre-fix).
- `GET /api/dashboard/capability-library` (CSP-inherited capabilities) was never queried in the wizard.
- Result: wizard Step 2 shows "No capabilities found" for any tenant whose Org catalog is empty but whose CSP provider has published capabilities.

## 2. Goal / Desired Outcome

Wizard Step 2 fetches from both sources in parallel, renders CSP capabilities first (clearly labelled), Org capabilities second. Search filters both simultaneously.

## 3. Scope

**In Scope**
- `SecurityCapabilities.tsx` — fetch, display, link logic
- CSP capabilities linked via `POST .../capability-subscriptions`
- Org capabilities linked via `POST .../capability-links` (unchanged)

**Out of Scope**
- Backend endpoint changes
- Other wizard steps
- `OrgCapabilityLibraryPage.tsx` (standalone page, unaffected)

## 4. User Experience Flow

1. User enters wizard Step 2.
2. Component fetches `/capability-library?systemId=...` and `/capabilities` in parallel.
3. CSP-inherited group renders first (indigo header + left accent stripe + CSP badge).
4. Org capabilities render second (gray header).
5. User types in search — both groups filter simultaneously, 300ms debounce.
6. Already-subscribed CSP rows show "✓ Linked", disabled.
7. Already-linked Org rows show "✓ Linked", disabled.
8. User selects rows across both groups and clicks "Link N Selected".
9. CSP selections → `POST .../capability-subscriptions` (one per item, parallel).
10. Org selections → `POST .../capability-links` (batch).
11. Legend below the search box explains indigo = CSP-inherited, gray = Org.

## 5. Functional Requirements

- FR-001: Component MUST fetch `/capability-library` and `/capabilities` in parallel on mount and on search change.
- FR-002: CSP capabilities MUST render before Org capabilities in the list.
- FR-003: CSP and Org groups MUST be visually distinct (sticky group header + left accent for CSP).
- FR-004: Search MUST filter both sources simultaneously.
- FR-005: Existing CSP subscriptions MUST be loaded on mount and reflected as "✓ Linked".
- FR-006: CSP capability link action MUST call `POST .../capability-subscriptions`.
- FR-007: Org capability link action MUST call `POST .../capability-links` (unchanged).
- FR-008: If both endpoints fail for a query, an inline error message MUST be shown (not silent empty state).

## 6. Technical Design Notes

**Root cause:** `fetchCapabilities()` called `apiClient.get('/capabilities', ...)` only. The CSP endpoint `/capability-library` (served by `CapabilitySubscriptionEndpoints.cs`) was not wired into the wizard.

**Fix approach:**
- `fetchCapabilities` now calls both endpoints via `Promise.all(...)`.
- Individual CSP fetch failure is swallowed (`.catch(() => ...)`) so an empty CSP catalog does not block Org results and vice versa.
- Initial load now also fetches `GET .../capability-subscriptions` to seed `cspSubscribedIds` — avoids showing already-subscribed CSP caps as selectable.
- `linkSelected()` partitions the selection set by source and dispatches to the correct endpoint.
- `CapabilityRowItem` sub-component handles per-row rendering; `source: 'csp' | 'org'` drives the indigo vs. gray visual treatment.

## 7. Architecture Decisions

| Decision | Reason |
|---|---|
| Parallel `Promise.all` for both fetches | Keeps p95 latency at max(csp, org) not sum(csp+org) |
| Per-endpoint `.catch(() => empty)` | Prevents CSP 404/503 (SingleTenant/incomplete onboarding) from breaking Org results |
| CSP → subscriptions, Org → capability-links | Each endpoint is the correct write surface per spec-070 |
| Load existing subscriptions on mount | Avoids a second round-trip after user selects; `isSubscribed` from `/capability-library` is also checked as fallback |
| `CapabilityRowItem` extracted | Avoids duplicated JSX for two groups; single `source` prop controls visual variant |

## 8. Acceptance Criteria

```gherkin
Given the tenant has CSP capabilities published
When the user reaches wizard Step 2
Then CSP capabilities appear in the list before Org capabilities

Given the user types a search term
When 300ms have elapsed
Then both CSP and Org groups are filtered simultaneously

Given the user selects one CSP and one Org capability
When they click "Link 2 Selected"
Then the CSP capability is POSTed to /systems/{id}/capability-subscriptions
And the Org capability is POSTed to /systems/{id}/capability-links

Given the CSP endpoint returns 404 (SingleTenant mode)
When the component loads
Then Org capabilities still render normally
And no error banner is shown

Given both endpoints fail
When the component loads
Then an inline error message is shown instead of "No capabilities found"

Given a capability is already subscribed (CSP) or linked (Org)
When the list renders
Then that row shows "✓ Linked" and its checkbox is disabled
```

## 9. Non-Functional Requirements

- Fetch latency: both requests fire in parallel; no sequential waterfall.
- No new external deps introduced.
- `tsc --noEmit`: 0 errors (verified locally).

## 10. Test Plan

**Manual:**
- Open wizard on a tenant with CSP capabilities → confirm CSP group appears first.
- Open wizard on a SingleTenant deployment → confirm Org capabilities render; no error banner.
- Search "access" → both groups filter.
- Select and link mixed CSP+Org selection → verify correct endpoints called via network tab.

**Existing suite:** `npm run test` in `src/Ato.Copilot.Dashboard` must pass.

## 11. Definition of Done

- [x] `SecurityCapabilities.tsx` updated with dual-source fetch + grouped display
- [x] CSP link action targets `capability-subscriptions`
- [x] Org link action targets `capability-links` (unchanged)
- [x] Search filters both sources simultaneously
- [x] Visual distinction: CSP indigo group, Org gray group
- [x] Existing subscription state loaded on mount
- [x] `tsc --noEmit` passes locally
- [x] Branch pushed and PR open
- [ ] CI green

## 12. Explicit Constraints

- DO NOT change backend endpoints.
- DO NOT break existing `capability-links` flow for Org capabilities.

## 13. Anti-patterns

- DO NOT call the two fetches sequentially.
- DO NOT let a CSP 404 (SingleTenant) propagate to an error state when Org capabilities exist.
- DO NOT use `onErrors()` for data-fetch failures inside the list — use inline `loadError` state (see pitfall in csharp-aspnet-development skill).

## 14. Existing File References

- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SecurityCapabilities.tsx` — file under fix
- `src/Ato.Copilot.Mcp/Endpoints/CapabilitySubscriptionEndpoints.cs:38` — `GET /capability-library`
- `src/Ato.Copilot.Dashboard/src/api/capabilityLinks.ts` — `linkCapabilities`, `getCapabilityLinks`, `removeCapabilityLink`
- `src/Ato.Copilot.Dashboard/src/pages/OrgCapabilityLibraryPage.tsx:164` — reference implementation for `/capability-library` query shape
