### PR TITLE
feat(spec-068): upgrade from STUB to SDK-complete — Epic #222 Org Templates & Narrative Seed Admin

### DIFF
--- a/docs/adr/ADR-068-OSCAL-Support-Strategy.md
+++ b/docs/adr/ADR-068-OSCAL-Support-Strategy.md
@@ -1,0 +1,258 @@
+# ADR-068 — OSCAL Support Strategy for SPIN Agent
+
+**Status:** PROPOSED  
+**Date:** 2026-06-18  
+**Author:** Oracle (Intelligence & Knowledge Management Lead)  
+**Requested by:** Batman (Strategic Assessment, W10 Dispatch Queue)  
+**Decision Required by:** W10 Scoping Lock  
+**Spec cross-reference:** Gap #1 from Batman W10 Strategic Assessment; spec `022-ssp-full-oscal`
+
+---
+
+## Context
+
+SPIN Agent is an AI-powered compliance copilot for DoD teams navigating the NIST Risk Management Framework. The platform generates SSP narratives, control implementations, SAP/SAR artifacts, and POA&M entries — all currently exported as Word/Excel documents for eMASS submission.
+
+OSCAL (Open Security Controls Assessment Language) is NIST's machine-readable standard for expressing security controls, system implementations, assessment plans, results, and POA&M data in structured JSON, XML, or YAML formats.
+
+### Regulatory Mandate — Source of Urgency
+
+**OMB M-24-15** (Modernizing the Federal Risk and Authorization Management Program), issued July 25, 2024, contains hard compliance deadlines:
+
+| Deadline | Requirement |
+|----------|-------------|
+| **180 days** (Jan 2025) | Federal agencies must update policy to align with the memo |
+| **24 months** (July 2026) | All GRC and system-inventory tools must be capable of ingesting and producing machine-readable OSCAL artifacts |
+
+Direct quote from M-24-15:
+> *"Agencies must have the necessary procedures in place to produce, accept, and submit materials in machine-readable formats… FedRAMP should receive all authorization artifacts — SSP, SAP, SAR, and POA&M — as machine-readable data through APIs."*
+
+**This is a legal compliance deadline, not a trend.** Any DoD compliance copilot serving federal agencies or FedRAMP-scoped customers that cannot produce OSCAL by July 2026 is non-compliant with federal acquisition requirements. 400+ CSPs are already converting.
+
+### Competitive Landscape (Intelligence Summary)
+
+| Competitor | OSCAL posture |
+|------------|--------------|
+| RegScale | OSCAL-native since 2023 — top differentiator in enterprise sales |
+| GovRAMP | OSCAL adapter implemented; native pipeline roadmapped |
+| Telos Xacta | OSCAL import/export, marketed as FedRAMP automation tool |
+| SPIN Agent (current) | No OSCAL support — gap vs. all named competitors |
+
+Batman's gap assessment: "OSCAL is the compliance automation language of the federal government. Not supporting it means we can't interoperate with the emerging ecosystem and can't claim to be a true ATO copilot."
+
+### W10 Scoping Context
+
+W10 is a bounded sprint window. Engineering capacity is allocated. The OSCAL decision is architecturally significant because:
+
+1. **Option A** (native generation) requires OSCAL data model knowledge built into the compliance engine at the record level — not addable post-hoc without significant refactoring of `ControlImplementation`, `AssessmentRecord`, `PoamItem`, and `AuthorizationDecision` entities.
+2. **Option B** (export adapter) can be implemented as a projection layer over existing entities without touching the core data model.
+3. **Option C** (defer) risks:
+   - Falling outside the July 2026 OMB M-24-15 deadline during W11 planning
+   - Losing enterprise deals where OSCAL is now an RFP line item
+   - Allowing RegScale's OSCAL-native positioning to harden in the market
+
+---
+
+## Decision
+
+**Recommended Option: B — OSCAL Export Adapter for W10, with Option A as W12+ Strategic Initiative.**
+
+This matches Batman's recommendation. The analysis below provides the evidence foundation for John's approval.
+
+---
+
+## Options Considered
+
+### Option A: Native OSCAL Generation (High Effort, High Value)
+
+**What it means:**  
+Refactor the SPIN Agent data model and compliance engine to treat OSCAL as the authoritative internal format. All compliance artifacts (SSP, SAP, SAR, POA&M) are generated and stored as OSCAL-native structures. Word/Excel export becomes a rendering concern on top of OSCAL-native records.
+
+**Architecture implications:**
+- `ControlImplementation` narratives stored as OSCAL `implemented-requirement` elements
+- `AssessmentRecord` maps to OSCAL `assessment-results` layer
+- `PoamItem` maps to OSCAL `finding` / `risk` / `observation` model
+- `AuthorizationDecision` maps to OSCAL `authorization` component
+- New database schema for OSCAL component registry (catalogs, profiles)
+- OSCAL catalog ingestion pipeline for NIST SP 800-53 Rev 5 + DoD overlays
+
+**Pros:**
+- True competitive differentiation vs. RegScale ("OSCAL-native" is a genuine enterprise differentiator)
+- Machine-readable output enables FedRAMP automation workflows
+- Future-proof: OMB M-24-15 compliance without structural debt
+- Enables control catalog crosswalks (SP 800-53 ↔ CMMC ↔ IL5) natively
+- Positions for DoD's long-term move toward "ATO-as-code"
+
+**Cons:**
+- High engineering effort: 8–12 weeks minimum for a correct OSCAL-native implementation
+- W10 cannot absorb this without dropping 3–4 other P1 roadmap items (CMMC overlays, Tanium integration, P1 Marketplace, cATO Dashboard)
+- Risk of incomplete implementation shipping with schema debt
+- OSCAL schemas are complex — FedRAMP extensions add additional specificity beyond base NIST schemas
+- Wrong time in product lifecycle: data model must be stable before OSCAL-native can be implemented cleanly
+
+**Effort:** ~8–12 weeks | **Risk:** High | **W10 fit:** No
+
+---
+
+### Option B: OSCAL Export Adapter (Medium Effort, Satisfies Mandate) ✅ RECOMMENDED
+
+**What it means:**  
+Build a projection/export layer that transforms SPIN Agent's existing compliance record model into OSCAL-compliant JSON/XML outputs. The internal data model does not change. OSCAL is generated on-demand from `ControlImplementation`, `AssessmentRecord`, `PoamItem`, and `AuthorizationDecision` records at export time.
+
+**Architecture:**
+```
+SPIN Agent Records (existing)
+        ↓
+OSCAL Projection Service
+        ↓
+OSCAL JSON/XML (SSP, SAP, SAR, POA&M)
+        ↓
+Export endpoint + eMASS / FedRAMP upload
+```
+
+**Projection scope (W10):**
+- **SSP export:** `RegisteredSystem` + `SecurityCategorization` + `ControlImplementation` records → OSCAL System Security Plan (JSON)
+- **POA&M export:** `PoamItem` + `PoamMilestone` records → OSCAL POA&M component
+- **Control catalog mapping:** SP 800-53 Rev 5 control IDs → OSCAL catalog reference URIs
+- **Phase 2 (W11 candidate):** SAP → OSCAL Assessment Plan; SAR → OSCAL Assessment Results
+
+**What adapter does NOT require:**
+- Schema changes to existing entities
+- Disruption to current SSP narrative generation pipeline
+- Changes to the eMASS Word/Excel export workflow (both coexist)
+- Task #314 resolution (seed pipeline is independent)
+
+**Pros:**
+- W10-deliverable: 3–4 weeks for SSP + POA&M projection (two most critical artifacts per M-24-15)
+- Satisfies the July 2026 OMB M-24-15 24-month mandate on schedule
+- Zero regression risk on existing export workflows
+- Gives enterprise customers an OSCAL checkbox before W12
+- Establishes the projection pattern that W12 native migration can adopt selectively
+- Unblocks higher-classification IL5 deals where OSCAL is now an RFP requirement
+
+**Cons:**
+- Not architecturally "pure" — OSCAL is a rendering concern, not a source of truth
+- Projection layer will need maintenance as OSCAL schemas evolve (FedRAMP extensions update annually)
+- Cannot advertise "OSCAL-native" — only "OSCAL-compatible" or "OSCAL export"
+- Some fidelity loss: OSCAL structural richness is not fully captured by projection from flat records
+
+**Effort:** ~3–4 weeks (SSP + POA&M scope) | **Risk:** Low | **W10 fit:** Yes
+
+---
+
+### Option C: Defer to W11+ (Low Risk Near-Term, High Risk Long-Term)
+
+**What it means:**  
+No OSCAL work in W10. Revisit in W11 scoping once market demand is clearer.
+
+**Pros:**
+- Preserves W10 capacity for P1–P5 items (CMMC overlays, Tanium, Marketplace, cATO, IL5 roadmap)
+- No architectural commitment before data model is stable
+
+**Cons:**
+- **OMB M-24-15 risk:** The 24-month clock from July 2024 expires in July 2026. If W11 begins Q3 2026, Option C puts the platform at or past the compliance deadline — non-negotiable for federal customers.
+- **Deal risk:** Enterprise RFPs increasingly include OSCAL as a line item. Competitors (RegScale, Telos) will capture deals where OSCAL is required.
+- **Positioning risk:** Batman assessment explicitly flags OSCAL as "architecturally significant." Deferring signals the team underestimates the structural complexity — the later it starts, the more it will conflict with a maturing data model.
+- **Compounding cost:** Every W10 entity added without OSCAL awareness increases the cost of native migration (W12+). Option B adapter in W10 actually *reduces* W12 native migration effort by force-validating the mapping.
+
+**Effort:** 0 now | **Risk:** High (mandate timeline) | **W10 fit:** Yes (but inadvisable)
+
+---
+
+## Recommendation Rationale
+
+The choice between B and C is not a trade-off of effort vs. features. It is a trade-off of **compliance deadline vs. capacity allocation**.
+
+The OMB M-24-15 24-month deadline is July 2026. If W10 is the last sprint window before that deadline (or close to it), Option C is not a real option — it is a compliance gap masquerading as a prioritization call.
+
+The choice between A and B in W10 is straightforward: Option A's 8–12 week scope crowds out the entire P1–P5 roadmap that Batman identified. The correct sequencing is:
+
+```
+W10: Option B (adapter) → closes mandate gap, earns OSCAL-compatible positioning
+W12: Option A (native)  → when data model is stable, retire adapter, claim OSCAL-native
+```
+
+Option B is not a permanent compromise. It is the correct first move that:
+1. Satisfies the compliance mandate on time
+2. Preserves W10 roadmap capacity for CMMC, Tanium, Marketplace, cATO, and IL5 — all of which open near-term deals
+3. Generates the control-to-OSCAL mapping work that makes W12 native migration faster and lower-risk
+4. Immediately answers "do you support OSCAL?" with "yes, with export" rather than "not yet"
+
+---
+
+## Decision Record
+
+| Dimension | Option A | **Option B ✅** | Option C |
+|-----------|----------|-----------------|----------|
+| W10 feasibility | ❌ Too large | ✅ 3–4 weeks | ✅ 0 weeks |
+| OMB M-24-15 compliance | ✅ Exceeds | ✅ Satisfies | ⚠️ Risk if W11 is Q3 2026 |
+| Data model impact | High refactor | None | None |
+| Competitive positioning | OSCAL-native | OSCAL-compatible | No OSCAL |
+| Roadmap cost (P1–P5) | 3–4 items dropped | Minor capacity | Unaffected |
+| W12 native migration cost | N/A | Reduced | Increased |
+| Enterprise deal risk | Low | Low | High |
+
+---
+
+## Implementation Scope (Option B — W10)
+
+If approved, W10 OSCAL adapter scope:
+
+### Phase 1 — SSP OSCAL Export (Required)
+- New spec: `spec/022-ssp-full-oscal` review and gap-close
+- `IOscalProjectionService` interface + `OscalSspProjector` implementation
+- Maps: `RegisteredSystem` → `system-characteristics`; `SecurityCategorization` → `security-impact-level`; `ControlImplementation` → `implemented-requirement`; `AuthorizationBoundary` → `system-component`
+- Export endpoint: `GET /api/dashboard/systems/{id}/oscal/ssp.json`
+- NIST SP 800-53 Rev 5 catalog reference constants
+
+### Phase 2 — POA&M OSCAL Export (Required)
+- `PoamItem` + `PoamMilestone` → OSCAL POA&M model
+- Export endpoint: `GET /api/dashboard/systems/{id}/oscal/poam.json`
+
+### Phase 3 — Frontend Export Action (Required)
+- "Download OSCAL" button on system detail → downloads SSP JSON + POA&M JSON
+- Co-located with existing "Export to eMASS" action
+
+### Out of Scope for W10 (W11 candidates):
+- SAP → OSCAL Assessment Plan
+- SAR → OSCAL Assessment Results
+- OSCAL import / ingest
+- OSCAL validation against FedRAMP schema extensions
+- Native OSCAL internal storage (Option A — W12+)
+
+---
+
+## W12+ Strategic Initiative Note
+
+Option A (native OSCAL generation) should be roadmapped explicitly for W12+ with the following prerequisites:
+1. OSCAL schema stability for FedRAMP extensions (updated annually — target the stable Rev 5 FedRAMP profile)
+2. SPIN Agent data model stability (post W10 CMMC overlays, post Tanium integration)
+3. Option B adapter shipping and validated in production (real customer SSP exports confirm the mapping)
+4. ADR update: retire adapter, adopt OSCAL-native with internal format migration
+
+The path from B to A is: validate mapping in production (W10–W11) → freeze the mapping → migrate internal storage to OSCAL schema (W12).
+
+---
+
+## Approval Required
+
+- [ ] **John** — W10 scoping lock: confirm Option B in scope, confirm W10 capacity allocation (~3–4 weeks engineering)
+- [ ] **Batman** — Strategic alignment: confirm W12+ Option A roadmap slot
+- [ ] **Cyborg** — Technical validation: confirm adapter approach does not conflict with eMASS export architecture (spec `041-emass-package`)
+
+---
+
+## Sources
+
+| Source | Date | Relevance |
+|--------|------|-----------|
+| OMB M-24-15: Modernizing FedRAMP | July 25, 2024 | Hard 24-month OSCAL mandate for all federal GRC tools |
+| DRTConfidence OSCAL Analysis | July 29, 2024 | M-24-15 compliance timeline breakdown; 400+ CSPs converting |
+| Batman W10 Strategic Assessment | 2026-06-18 | Gap identification; Option A/B/C framing; W10 dispatch |
+| NIST OSCAL Implementer's Guide (Workshop 32) | Feb 19, 2025 | Implementation best practices; common challenges |
+| RegScale competitive positioning | Field intelligence | OSCAL-native as enterprise differentiator |
+
+---
+
+*ADR authored by Oracle — source-grounded, timestamped, citable.*  
+*Decision authority: John Spinella (Product). Approval needed before W10 scoping lock.*

--- a/specs/068-org-template-admin/checklists/requirements.md
+++ b/specs/068-org-template-admin/checklists/requirements.md
@@ -1,0 +1,188 @@
+# SDK Completeness Checklist — Spec 068: Org Templates & Narrative Seed Admin UI
+
+> Epic: #222 | Use this checklist to verify that the spec SDK is complete and ready for implementation.
+> Reviewer: fill in ✅ / ❌ / ⚠️ for each item. All items must be ✅ before implementation begins.
+
+---
+
+## Section A — `spec.md` (stub file)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| A1 | `spec.md` exists in `specs/068-org-template-admin/` | ✅ | Stub already present |
+| A2 | Spec has a title and epic reference (#222) | ✅ | Confirm in file |
+| A3 | Spec describes the problem statement / user need | ⚠️ | Verify stub has adequate description |
+| A4 | Spec lists the two entity types covered (`OrganizationDocumentTemplate`, `NarrativeSeedDocument`) | ✅ | Confirmed in context |
+| A5 | Spec references the correct backend feature migration (`Feature047_OnboardingWizard`) | ✅ | — |
+| A6 | Spec is linked from the spec registry / index | ⚠️ | Verify `specs/registry.md` or equivalent has entry for 068 |
+
+---
+
+## Section B — `tasks.md` (stub file)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| B1 | `tasks.md` exists in `specs/068-org-template-admin/` | ✅ | Stub already present |
+| B2 | Tasks reference backend endpoints for templates (all 9) | ⚠️ | Verify coverage of: GET /, POST /upload, GET /{id}, PATCH /{id}, DELETE /{id}, GET /{id}/download, POST /{id}/replace, POST /{id}/default, DELETE /{id}/default/clear |
+| B3 | Tasks reference backend endpoints for seeds (all 3) | ⚠️ | Verify coverage of: GET /, POST /, DELETE /{id} |
+| B4 | Tasks reference frontend route registration | ⚠️ | Verify `TemplatesAdminPage.tsx` route task is present |
+| B5 | Tasks reference `feat222_NarrativeSeedIndexingFields` migration as a prerequisite task | ⚠️ | High-priority item; blocks all seed-column work |
+| B6 | Tasks are assigned to epics/stories in the project tracker | ⚠️ | Verify GitHub issues or equivalent are linked |
+
+---
+
+## Section C — `data-model.md` (this SDK, newly written)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| C1 | `data-model.md` exists in `specs/068-org-template-admin/` | ✅ | Written as part of this SDK |
+| C2 | `OrganizationDocumentTemplate` entity table is present with all 20 properties | ✅ | All properties documented |
+| C3 | `NarrativeSeedDocument` entity table is present with all 19 properties | ✅ | All properties documented including the 3 pending-migration columns |
+| C4 | All 4 enums for `OrganizationDocumentTemplate` are defined with integer values | ✅ | `TemplateType`, `TemplateFileFormat`, `TemplateValidationStatus`, `TemplateStatus` |
+| C5 | All 2 enums for `NarrativeSeedDocument` are defined with integer values | ✅ | `NarrativeSeedIndexingStatus`, `NarrativeSeedStatus` |
+| C6 | EF `OnModelCreating` configuration block is present and complete | ✅ | Includes query filters, indexes, FK relationships, string lengths |
+| C7 | Filtered unique index `UX_OrgDocTemplate_TenantType_Default` is documented in EF config | ✅ | Critical invariant |
+| C8 | Migration SQL for `Feature047_OnboardingWizard` (UP only) is present | ✅ | Both tables included |
+| C9 | Migration SQL for `feat222_NarrativeSeedIndexingFields` (UP only) is present | ✅ | 3-column ALTER TABLE |
+| C10 | Pending migration warning is prominently marked in the document | ✅ | ⚠️ callout present |
+| C11 | Invariants table lists at least 10 business rules with enforcement mechanism | ✅ | INV-1 through INV-10 |
+| C12 | Storage blob key pattern (`wizard/templates/{tenantId}/{Id}/{filename}`) is documented | ✅ | §5 Storage Layout |
+| C13 | Global query filter behaviour (`DeletedAt == null`) is documented | ✅ | Noted in EF config and INV-9 |
+| C14 | `NarrativeSeedDocument.Tags` default (`"[]"`) and JSON format documented | ✅ | INV-7 |
+| C15 | `ContentChecksumSha256` server-generation constraint documented | ✅ | INV-8 |
+
+---
+
+## Section D — `research.md` (this SDK, newly written)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| D1 | `research.md` exists in `specs/068-org-template-admin/` | ✅ | Written as part of this SDK |
+| D2 | At least 8 numbered research decisions (R1–Rn) are present | ✅ | R1–R10 documented |
+| D3 | Each decision has: chosen option, alternatives considered, rationale | ✅ | Consistent format throughout |
+| D4 | Single-page vs. split-route decision (R1) is documented | ✅ | — |
+| D5 | Upload strategy (multipart vs. presigned URL) decision (R2) is documented | ✅ | — |
+| D6 | Default-template invariant enforcement strategy (R3) is documented | ✅ | DB layer vs. app layer |
+| D7 | Soft-delete vs. hard-delete decision (R4) is documented | ✅ | — |
+| D8 | Async indexing rationale (R5) is documented | ✅ | Includes stub-handler caveat |
+| D9 | Citation-safe deletion decision (R6) is documented | ✅ | `?confirmCitations` pattern |
+| D10 | Validation warnings (non-blocking) decision (R7) is documented | ✅ | — |
+| D11 | Route registration decision (R8) is documented | ✅ | Pre-existing page component |
+| D12 | API client consolidation decision (R9) is documented | ✅ | Extend existing `onboardingApi.ts` |
+| D13 | Pending migration gate decision (R10) is documented | ✅ | — |
+| D14 | Each decision references the entity/invariant it affects | ✅ | Cross-references to data-model.md |
+
+---
+
+## Section E — `plan.md` (this SDK, newly written)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| E1 | `plan.md` exists in `specs/068-org-template-admin/` | ✅ | Written as part of this SDK |
+| E2 | Prerequisites table (P1–P5) is present | ✅ | Status and owner columns |
+| E3 | Phase 0 (migration gate) steps are present | ✅ | 5 steps + gate criteria |
+| E4 | Phase 1 (backend templates) steps are present | ✅ | 8 steps + gate criteria |
+| E5 | Phase 2 (backend seeds) steps are present | ✅ | 7 steps + gate criteria |
+| E6 | Phase 3 (frontend route + API client) steps are present | ✅ | 6 steps + gate criteria |
+| E7 | Phase 4 (frontend UI) steps are present | ✅ | 11 steps covering both tabs + gate criteria |
+| E8 | Phase 5 (E2E + regression) steps are present | ✅ | 6 steps + gate criteria |
+| E9 | Phase 6 (docs + SDK) steps are present | ✅ | 4 steps |
+| E10 | Each phase has explicit gate criteria (not just a step list) | ✅ | — |
+| E11 | Dependency graph is present and accurate | ✅ | ASCII diagram |
+| E12 | Risk register is present with likelihood/impact/mitigation | ✅ | 5 risks documented |
+| E13 | `NarrativeSeedIndexJobHandler` stub caveat is called out in Phase 2 | ✅ | Step 2.4 |
+| E14 | All 9 template endpoints have corresponding plan steps | ✅ | Steps 1.1–1.6 cover endpoints; 1.7 covers tests |
+| E15 | All 3 seed endpoints have corresponding plan steps | ✅ | Steps 2.1–2.3 |
+
+---
+
+## Section F — `quickstart.md` (this SDK, newly written)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| F1 | `quickstart.md` exists in `specs/068-org-template-admin/` | ✅ | Written as part of this SDK |
+| F2 | Prerequisites table with minimum versions is present | ✅ | .NET, Node, SQL, Azurite |
+| F3 | Clone + branch instructions are present | ✅ | §2.1 |
+| F4 | Backend dependency restore command is present | ✅ | `dotnet restore` |
+| F5 | Frontend dependency restore command is present | ✅ | `npm install` |
+| F6 | Local secrets / `appsettings.Development.json` setup is documented | ✅ | §2.4 |
+| F7 | Azurite (blob emulator) start instructions are present | ✅ | §2.5 with container creation command |
+| F8 | Both EF migrations are covered in DB setup | ✅ | §3 including `feat222` migration |
+| F9 | Schema verification SQL queries are provided | ✅ | `INFORMATION_SCHEMA.COLUMNS` + index check |
+| F10 | Backend start command + URL are documented | ✅ | §4.1 |
+| F11 | Frontend start command + URL are documented | ✅ | §5.1 |
+| F12 | `curl` verification commands for template list endpoint are present | ✅ | §4.2 |
+| F13 | `curl` verification commands for seed list endpoint are present | ✅ | §4.3 |
+| F14 | Template upload `curl` command with all required fields is present | ✅ | §6.1 |
+| F15 | Set-default + default-protection verification commands are present | ✅ | §6.2 + §6.3 |
+| F16 | Clear-default + delete sequence commands are present | ✅ | §6.4 |
+| F17 | Narrative seed upload `curl` command is present | ✅ | §6.5 |
+| F18 | Blob storage verification command (Azurite) is present | ✅ | §6.6 |
+| F19 | Access control / 403 verification command is present | ✅ | §6.7 |
+| F20 | Test run commands (backend + frontend + E2E) are present | ✅ | §7 |
+| F21 | Common issues table (at least 8 rows) is present | ✅ | §8 — 8 rows |
+| F22 | Dev shortcuts section is present | ✅ | §9 |
+| F23 | Vite proxy configuration is documented | ✅ | §5.3 |
+
+---
+
+## Section G — `checklists/requirements.md` (this file)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| G1 | `checklists/requirements.md` exists in `specs/068-org-template-admin/checklists/` | ✅ | This file |
+| G2 | Sections A–F covering all other SDK files are present | ✅ | Sections A–F above |
+| G3 | Each section has ≥ 5 checklist items | ✅ | All sections have ≥ 6 items |
+| G4 | Status column uses ✅ / ❌ / ⚠️ notation | ✅ | — |
+| G5 | Notes column is present for actionable follow-ups | ✅ | — |
+
+---
+
+## Section H — API Contract Completeness
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| H1 | All 9 template endpoints documented: `GET /`, `POST /upload`, `GET /{id}`, `PATCH /{id}`, `DELETE /{id}`, `GET /{id}/download`, `POST /{id}/replace`, `POST /{id}/default`, `DELETE /{id}/default/clear` | ✅ | Documented in verified source facts |
+| H2 | All 3 seed endpoints documented: `GET /`, `POST /`, `DELETE /{id}` | ✅ | — |
+| H3 | All 5 error codes documented: `TEMPLATE_WRONG_FORMAT` (415), `TEMPLATE_TOO_LARGE` (413), `TEMPLATE_DEFAULT_PROTECTED` (409), `WIZARD_NARRATIVE_SEED_HAS_CITATIONS` (409), `AUTH_FORBIDDEN` (403) | ✅ | — |
+| H4 | Authorization policy (`OnboardingAdministratorRequirement`) documented | ✅ | data-model.md INV-10 |
+| H5 | Route group base paths documented: `/api/onboarding/templates` and `/api/onboarding/narrative-seeds` | ✅ | — |
+| H6 | `POST /upload` returns `{ template, warnings }` shape documented | ✅ | quickstart.md §6.1 |
+| H7 | `POST /` (seed) returns `202 Accepted` with `{ document, jobId }` documented | ✅ | quickstart.md §6.5 |
+| H8 | `POST /{id}/replace` returns `{ template, dependentsFlagged }` documented | ✅ | plan.md Phase 1, Step 1.3 |
+| H9 | `DELETE /{id}` (seed) `?confirmCitations` query parameter documented | ✅ | research.md R6 |
+| H10 | Frontend API client location documented (`onboardingApi.ts`) | ✅ | research.md R9 |
+
+---
+
+## Section I — Architecture & Integration Completeness
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| I1 | Dependency on `EvidenceArtifact` (Feature 038) is documented | ✅ | data-model.md NarrativeSeedDocument.EvidenceArtifactId |
+| I2 | Dependency on `WizardJobStatus` is documented | ✅ | data-model.md NarrativeSeedDocument.IndexJobId |
+| I3 | Base migration (`Feature047_OnboardingWizard`) dependency is documented | ✅ | Multiple files |
+| I4 | Pending migration (`feat222_NarrativeSeedIndexingFields`) status is documented with warning | ✅ | data-model.md §3.2, quickstart.md §3.1 |
+| I5 | `NarrativeSeedIndexJobHandler.cs` stub status documented | ✅ | research.md R5, plan.md Phase 2 |
+| I6 | `TemplatesAdminPage.tsx` untracked-file status documented | ✅ | research.md R8, plan.md Phase 3 |
+| I7 | Azure Blob Storage container (`wizard-artifacts`) documented | ✅ | data-model.md §5, quickstart.md §2.5 |
+| I8 | Tenant-scoped entities (`[TenantScoped]`) behaviour documented | ✅ | data-model.md §1 entity tables |
+| I9 | EF global query filter (`HasQueryFilter`) behaviour documented | ✅ | data-model.md §2 + INV-9 |
+
+---
+
+## Final Sign-Off
+
+| Reviewer | Role | Date | Sign-off |
+|---|---|---|---|
+| | Backend Lead | | ☐ |
+| | Frontend Lead | | ☐ |
+| | Tech Lead / Architect | | ☐ |
+| | PM / Epic Owner (#222) | | ☐ |
+
+> **Definition of Ready:** All items in Sections A–I must be ✅ before implementation sprint begins.
+> Items marked ⚠️ are pending verification against the actual repository files and must be resolved by the reviewer.
+
+---
+
+*Last updated: 2026-06-18 | Spec: 068-org-template-admin | Epic: #222*

--- a/specs/068-org-template-admin/contracts/frontend-types.md
+++ b/specs/068-org-template-admin/contracts/frontend-types.md
@@ -1,0 +1,995 @@
+# Frontend Types Contract — Spec 068: Org Templates & Narrative Seed Admin
+
+**Epic:** #222 — Org Templates & Narrative Seed Admin UI
+**Language:** TypeScript
+**API client file:** `onboardingApi.ts`
+
+---
+
+## Table of Contents
+
+1. [Shared Utility Types](#1-shared-utility-types)
+2. [Enum Types](#2-enum-types)
+3. [Entity Interfaces](#3-entity-interfaces)
+   - [OrganizationDocumentTemplate](#31-organizationdocumenttemplate)
+   - [NarrativeSeedDocument](#32-narrativeseeддocument)
+4. [API Request & Response Types](#4-api-request--response-types)
+   - [Templates](#41-template-api-types)
+   - [Narrative Seeds](#42-narrative-seed-api-types)
+5. [API Client Function Signatures](#5-api-client-function-signatures)
+   - [Template Methods](#51-template-methods)
+   - [Narrative Seed Methods](#52-narrative-seed-methods)
+6. [React Component Prop Interfaces](#6-react-component-prop-interfaces)
+   - [Template Admin Components](#61-template-admin-components)
+   - [Narrative Seed Admin Components](#62-narrative-seed-admin-components)
+   - [Shared Admin Components](#63-shared-admin-components)
+7. [Derived / Display Types](#7-derived--display-types)
+8. [Type Guards & Utilities](#8-type-guards--utilities)
+
+---
+
+## 1. Shared Utility Types
+
+```typescript
+// ─── Standard API Envelope ───────────────────────────────────────────────────
+
+/** Successful API response wrapper. */
+export interface ApiSuccess<T> {
+  ok: true;
+  data: T;
+}
+
+/** Failed API response wrapper. */
+export interface ApiError {
+  ok: false;
+  errorCode: string;
+  message: string;
+  suggestion?: string | null;
+}
+
+/** Union of success and error envelopes. */
+export type ApiResult<T> = ApiSuccess<T> | ApiError;
+
+// ─── Common Scalar Aliases ────────────────────────────────────────────────────
+
+/** ISO 8601 date-time string, e.g. "2025-06-01T12:00:00Z". */
+export type ISODateString = string;
+
+/** UUID v4 string, e.g. "3fa85f64-5717-4562-b3fc-2c963f66afa6". */
+export type GuidString = string;
+```
+
+---
+
+## 2. Enum Types
+
+```typescript
+// ─── Template Types ───────────────────────────────────────────────────────────
+
+export type TemplateType =
+  | 'Ssp'
+  | 'Sar'
+  | 'Sap'
+  | 'Crm'
+  | 'HwSwInventory';
+
+export const TEMPLATE_TYPE_LABELS: Record<TemplateType, string> = {
+  Ssp: 'System Security Plan',
+  Sar: 'Security Assessment Report',
+  Sap: 'Security Assessment Plan',
+  Crm: 'Customer Responsibility Matrix',
+  HwSwInventory: 'Hardware/Software Inventory',
+};
+
+// ─── File Formats ─────────────────────────────────────────────────────────────
+
+export type FileFormat = 'Docx' | 'Xlsx';
+
+export const FILE_FORMAT_LABELS: Record<FileFormat, string> = {
+  Docx: 'Word Document (.docx)',
+  Xlsx: 'Excel Spreadsheet (.xlsx)',
+};
+
+// ─── Template Validation Status ───────────────────────────────────────────────
+
+export type ValidationStatus =
+  | 'Pending'
+  | 'Compliant'
+  | 'FlaggedNonCompliant';
+
+// ─── Template Lifecycle Status ────────────────────────────────────────────────
+
+export type TemplateStatus = 'Active' | 'Superseded' | 'Deleted';
+
+// ─── Seed Indexing Status ─────────────────────────────────────────────────────
+
+export type IndexingStatus = 'Pending' | 'Indexed' | 'Failed';
+
+// ─── Seed Lifecycle Status ────────────────────────────────────────────────────
+
+export type SeedStatus = 'Active' | 'Deleted';
+```
+
+---
+
+## 3. Entity Interfaces
+
+### 3.1 OrganizationDocumentTemplate
+
+```typescript
+/**
+ * A document template file (DOCX or XLSX) used to generate SSP/SAR/SAP/CRM/HwSw artifacts.
+ *
+ * Wire shape received from GET /api/onboarding/templates and related endpoints.
+ *
+ * ⚠️  `storageBlobKey` is NEVER present — it is a backend-only field and is
+ *     stripped before serialization. Do not declare or reference it on this type.
+ *
+ * ⚠️  `validationWarnings` is a raw JSON string when non-null. Call
+ *     `parseValidationWarnings(template)` to get a `string[]`.
+ */
+export interface OrganizationDocumentTemplate {
+  /** Primary key GUID. */
+  id: GuidString;
+  /** Owning tenant GUID. */
+  tenantId: GuidString;
+  /** Classification of the template's intended use. */
+  templateType: TemplateType;
+  /** Human-readable display name. */
+  label: string;
+  /** Version string set by the uploader (e.g., "2024-Q4"). */
+  version: string;
+  /** Original filename as supplied during upload; used in Content-Disposition on download. */
+  originalFileName: string;
+  /** Detected file format. */
+  fileFormat: FileFormat;
+  /** File size in bytes. */
+  fileSizeBytes: number;
+  /** SHA-256 hex digest of the file content. */
+  contentChecksumSha256: string;
+  /** Whether this is the default template for its `templateType`. */
+  isDefault: boolean;
+  /** Validation state set by the background content-inspection job. */
+  validationStatus: ValidationStatus;
+  /**
+   * Raw JSON string array of warning messages, or `null` if no warnings.
+   * Parse with `JSON.parse()` before display.
+   * Example: `"[\"Missing cover page\",\"Outdated footer macro\"]"`
+   */
+  validationWarnings: string | null;
+  /** Lifecycle state. */
+  status: TemplateStatus;
+  /** ISO 8601 creation timestamp. */
+  createdAt: ISODateString;
+  /** GUID of the user who created this template. */
+  createdBy: GuidString;
+  /** ISO 8601 last-updated timestamp. */
+  updatedAt: ISODateString;
+  /** GUID of the user who last updated this template. */
+  updatedBy: GuidString;
+  /** ISO 8601 deletion timestamp, or `null` if not deleted. */
+  deletedAt: ISODateString | null;
+}
+```
+
+---
+
+### 3.2 NarrativeSeedDocument
+
+```typescript
+/**
+ * A PDF document used to seed AI-assisted wizard narrative generation.
+ *
+ * Wire shape received from GET /api/onboarding/narrative-seeds and related endpoints.
+ *
+ * ⚠️  `tags` is a raw JSON string on the wire (e.g., `"[\"policy\",\"ac\"]"`).
+ *     Call `parseSeedTags(seed)` to get a `string[]` for display/filtering.
+ */
+export interface NarrativeSeedDocument {
+  /** Primary key GUID. */
+  id: GuidString;
+  /** Owning tenant GUID. */
+  tenantId: GuidString;
+  /** Human-readable display name. */
+  label: string;
+  /**
+   * Raw JSON string containing an array of classification tags.
+   * Parse with `JSON.parse()` before use.
+   * Example: `"[\"policy\",\"ac\",\"ia\"]"`
+   */
+  tags: string;
+  /** GUID of the linked evidence artifact record. */
+  evidenceArtifactId: GuidString;
+  /** Current state of the async AI indexing pipeline for this document. */
+  indexingStatus: IndexingStatus;
+  /** GUID of the background indexing job, or `null` if not queued. */
+  indexJobId: GuidString | null;
+  /** ISO 8601 timestamp when indexing completed, or `null`. */
+  indexedAt: ISODateString | null;
+  /** Number of content chunks indexed, or `null` if not yet indexed. */
+  indexedChunkCount: number | null;
+  /** Human-readable error message if indexing failed, or `null`. */
+  indexingError: string | null;
+  /** Lifecycle state. */
+  status: SeedStatus;
+  /** ISO 8601 creation timestamp. */
+  createdAt: ISODateString;
+  /** GUID of the user who created this seed. */
+  createdBy: GuidString;
+  /** ISO 8601 last-updated timestamp. */
+  updatedAt: ISODateString;
+  /** GUID of the user who last updated this seed. */
+  updatedBy: GuidString;
+  /** ISO 8601 deletion timestamp, or `null` if not deleted. */
+  deletedAt: ISODateString | null;
+}
+```
+
+---
+
+## 4. API Request & Response Types
+
+### 4.1 Template API Types
+
+```typescript
+// ─── List Templates ───────────────────────────────────────────────────────────
+
+export interface ListTemplatesParams {
+  /** Filter by template type. Omit to return all types. */
+  templateType?: TemplateType;
+  /** Include soft-deleted templates. Defaults to false. */
+  includeDeleted?: boolean;
+}
+
+export type ListTemplatesResponse = ApiSuccess<OrganizationDocumentTemplate[]>;
+
+// ─── Upload Template ──────────────────────────────────────────────────────────
+
+/** Fields supplied via FormData for POST /api/onboarding/templates/upload */
+export interface UploadTemplateFields {
+  templateType: TemplateType;
+  label: string;
+  version: string;
+  file: File;
+  /** Defaults to false if omitted. */
+  isDefault?: boolean;
+}
+
+export interface UploadTemplateData {
+  template: OrganizationDocumentTemplate;
+  /** Validation warnings discovered during content inspection. May be empty. */
+  warnings: string[];
+}
+
+export type UploadTemplateResponse = ApiSuccess<UploadTemplateData>;
+
+// ─── Get Template ─────────────────────────────────────────────────────────────
+
+export type GetTemplateResponse = ApiSuccess<OrganizationDocumentTemplate>;
+
+// ─── Patch Template Metadata ──────────────────────────────────────────────────
+
+/** At least one field must be provided. */
+export interface PatchTemplateBody {
+  /** Updated label. Omit to leave unchanged. */
+  label?: string;
+  /** Updated version string. Omit to leave unchanged. */
+  version?: string;
+}
+
+export type PatchTemplateResponse = ApiSuccess<OrganizationDocumentTemplate>;
+
+// ─── Delete Template ──────────────────────────────────────────────────────────
+
+/** DELETE returns 204 No Content — no response body. */
+export type DeleteTemplateResponse = void;
+
+// ─── Replace Template File ────────────────────────────────────────────────────
+
+/** Fields supplied via FormData for POST /api/onboarding/templates/{id}/replace */
+export interface ReplaceTemplateFileFields {
+  file: File;
+  /** New version string. Omit to retain existing version. */
+  version?: string;
+}
+
+export interface ReplaceTemplateFileData {
+  template: OrganizationDocumentTemplate;
+  /** Count of dependent draft artifacts flagged for re-generation review. */
+  dependentsFlagged: number;
+}
+
+export type ReplaceTemplateFileResponse = ApiSuccess<ReplaceTemplateFileData>;
+
+// ─── Mark Template Default ────────────────────────────────────────────────────
+
+export type MarkTemplateDefaultResponse = ApiSuccess<OrganizationDocumentTemplate>;
+
+// ─── Clear Template Default ───────────────────────────────────────────────────
+
+/** DELETE returns 204 No Content — no response body. */
+export type ClearTemplateDefaultResponse = void;
+```
+
+---
+
+### 4.2 Narrative Seed API Types
+
+```typescript
+// ─── List Narrative Seeds ─────────────────────────────────────────────────────
+
+export type ListNarrativeSeedsResponse = ApiSuccess<NarrativeSeedDocument[]>;
+
+// ─── Upload Narrative Seed ────────────────────────────────────────────────────
+
+/** Fields supplied via FormData for POST /api/onboarding/narrative-seeds */
+export interface UploadNarrativeSeedFields {
+  label: string;
+  /** Submitted as repeated form fields: tags=policy&tags=ac */
+  tags?: string[];
+  file: File;
+}
+
+export interface UploadNarrativeSeedData {
+  document: NarrativeSeedDocument;
+  /** Async indexing job ID, or null if indexing is not applicable. */
+  jobId: GuidString | null;
+}
+
+export type UploadNarrativeSeedResponse = ApiSuccess<UploadNarrativeSeedData>;
+
+// ─── Delete Narrative Seed ────────────────────────────────────────────────────
+
+export interface DeleteNarrativeSeedParams {
+  /**
+   * Pass `true` to acknowledge and force-remove active citations.
+   * Defaults to false; a 409 WIZARD_NARRATIVE_SEED_HAS_CITATIONS is returned
+   * if omitted and citations exist.
+   */
+  confirmCitations?: boolean;
+}
+
+/** DELETE returns 204 No Content — no response body. */
+export type DeleteNarrativeSeedResponse = void;
+```
+
+---
+
+## 5. API Client Function Signatures
+
+All functions are async and throw (or reject) on non-2xx responses using the `ApiError` shape.
+File-upload methods accept `FormData` built from the typed field interfaces.
+
+```typescript
+// File: onboardingApi.ts
+
+import type {
+  ListTemplatesParams,
+  ListTemplatesResponse,
+  UploadTemplateFields,
+  UploadTemplateResponse,
+  GetTemplateResponse,
+  PatchTemplateBody,
+  PatchTemplateResponse,
+  ReplaceTemplateFileFields,
+  ReplaceTemplateFileResponse,
+  MarkTemplateDefaultResponse,
+  ListNarrativeSeedsResponse,
+  UploadNarrativeSeedFields,
+  UploadNarrativeSeedResponse,
+  DeleteNarrativeSeedParams,
+  GuidString,
+} from './types';
+
+// ─── Template Methods ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches the list of organization document templates.
+ * @param params - Optional filters: templateType, includeDeleted.
+ * @returns Envelope with `OrganizationDocumentTemplate[]`.
+ */
+export function listTemplates(
+  params?: ListTemplatesParams,
+): Promise<ListTemplatesResponse>;
+
+/**
+ * Uploads a new template file with metadata.
+ * Builds a FormData from `fields` and POSTs to /upload.
+ * @returns Envelope with `{ template, warnings }`.
+ */
+export function uploadTemplate(
+  fields: UploadTemplateFields,
+): Promise<UploadTemplateResponse>;
+
+/**
+ * Fetches a single template by ID.
+ * @param id - Template GUID.
+ * @returns Envelope with the `OrganizationDocumentTemplate`.
+ */
+export function getTemplate(
+  id: GuidString,
+): Promise<GetTemplateResponse>;
+
+/**
+ * Updates label and/or version of an existing template.
+ * @param id   - Template GUID.
+ * @param body - Partial metadata update (at least one field required).
+ * @returns Envelope with the updated `OrganizationDocumentTemplate`.
+ */
+export function patchTemplate(
+  id: GuidString,
+  body: PatchTemplateBody,
+): Promise<PatchTemplateResponse>;
+
+/**
+ * Soft-deletes a template.
+ * Resolves with `void` on 204. Rejects with `ApiError` on 404 or 409.
+ * @param id - Template GUID.
+ */
+export function deleteTemplate(
+  id: GuidString,
+): Promise<void>;
+
+/**
+ * Downloads a template file as a Blob.
+ * Callers should create an object URL for download:
+ *   `URL.createObjectURL(blob)`
+ * @param id - Template GUID.
+ * @returns Raw file Blob with the appropriate MIME type.
+ */
+export function downloadTemplate(
+  id: GuidString,
+): Promise<Blob>;
+
+/**
+ * Replaces the binary file content of an existing template.
+ * Optionally updates the version string.
+ * @returns Envelope with `{ template, dependentsFlagged }`.
+ */
+export function replaceTemplateFile(
+  id: GuidString,
+  fields: ReplaceTemplateFileFields,
+): Promise<ReplaceTemplateFileResponse>;
+
+/**
+ * Marks a template as the default for its templateType.
+ * Any prior default of the same type is automatically demoted server-side.
+ * @returns Envelope with the updated `OrganizationDocumentTemplate`.
+ */
+export function markTemplateDefault(
+  id: GuidString,
+): Promise<MarkTemplateDefaultResponse>;
+
+/**
+ * Removes the default designation from a template.
+ * Resolves with `void` on 204.
+ * @param id - Template GUID.
+ */
+export function clearTemplateDefault(
+  id: GuidString,
+): Promise<void>;
+
+// ─── Narrative Seed Methods ───────────────────────────────────────────────────
+
+/**
+ * Fetches all narrative seed documents for the tenant.
+ * @returns Envelope with `NarrativeSeedDocument[]`.
+ */
+export function listNarrativeSeeds(): Promise<ListNarrativeSeedsResponse>;
+
+/**
+ * Uploads a new narrative seed PDF.
+ * Tags are submitted as repeated form fields.
+ * @returns Envelope with `{ document, jobId }` (202 Accepted).
+ */
+export function uploadNarrativeSeed(
+  fields: UploadNarrativeSeedFields,
+): Promise<UploadNarrativeSeedResponse>;
+
+/**
+ * Soft-deletes a narrative seed.
+ * Pass `{ confirmCitations: true }` to force-delete even when citations exist.
+ * Resolves with `void` on 204. Rejects with 409 `WIZARD_NARRATIVE_SEED_HAS_CITATIONS`
+ * if citations exist and `confirmCitations` was not set.
+ * @param id     - Seed document GUID.
+ * @param params - Optional: `{ confirmCitations }`.
+ */
+export function deleteNarrativeSeed(
+  id: GuidString,
+  params?: DeleteNarrativeSeedParams,
+): Promise<void>;
+```
+
+---
+
+## 6. React Component Prop Interfaces
+
+### 6.1 Template Admin Components
+
+```typescript
+import type { OrganizationDocumentTemplate, TemplateType } from './types';
+
+// ─── TemplateAdminPage ────────────────────────────────────────────────────────
+
+/** Top-level route component — no required props (fetches its own data). */
+export interface TemplateAdminPageProps {}
+
+// ─── TemplateListPanel ────────────────────────────────────────────────────────
+
+export interface TemplateListPanelProps {
+  /** Templates to render. Already filtered/sorted by parent. */
+  templates: OrganizationDocumentTemplate[];
+  /** Loading state — show skeleton rows when true. */
+  isLoading: boolean;
+  /** Active type filter, or undefined to show all. */
+  filterType?: TemplateType;
+  /** Whether soft-deleted templates are included in `templates`. */
+  showDeleted: boolean;
+  /** Fires when user changes the type filter. */
+  onFilterTypeChange: (type: TemplateType | undefined) => void;
+  /** Fires when user toggles the "show deleted" switch. */
+  onShowDeletedChange: (show: boolean) => void;
+  /** Fires when user requests upload of a new template. */
+  onUploadClick: () => void;
+  /** Fires when user selects a template row for detail/action. */
+  onTemplateSelect: (template: OrganizationDocumentTemplate) => void;
+}
+
+// ─── TemplateRow ──────────────────────────────────────────────────────────────
+
+export interface TemplateRowProps {
+  template: OrganizationDocumentTemplate;
+  /** Fires when user clicks the row or a detail action. */
+  onSelect: (template: OrganizationDocumentTemplate) => void;
+  /** Fires when user clicks "Set as Default". */
+  onMarkDefault: (id: string) => void;
+  /** Fires when user clicks "Clear Default". */
+  onClearDefault: (id: string) => void;
+  /** Fires when user clicks "Download". */
+  onDownload: (id: string) => void;
+  /** Fires when user clicks "Delete". */
+  onDelete: (id: string) => void;
+  /** Whether any async action on this row is in progress. */
+  isBusy?: boolean;
+}
+
+// ─── TemplateUploadModal ──────────────────────────────────────────────────────
+
+export interface TemplateUploadModalProps {
+  /** Controls modal visibility. */
+  isOpen: boolean;
+  /** Called when the modal is closed (cancel or after successful upload). */
+  onClose: () => void;
+  /**
+   * Called after a successful upload.
+   * @param template  - Newly created template.
+   * @param warnings  - Any content warnings returned by the server.
+   */
+  onSuccess: (template: OrganizationDocumentTemplate, warnings: string[]) => void;
+  /** Pre-select a template type in the form (e.g., from active filter). */
+  initialTemplateType?: TemplateType;
+}
+
+// ─── TemplatePatchModal ───────────────────────────────────────────────────────
+
+export interface TemplatePatchModalProps {
+  /** Controls modal visibility. */
+  isOpen: boolean;
+  /** The template being edited. */
+  template: OrganizationDocumentTemplate;
+  /** Called when the modal is closed without saving. */
+  onClose: () => void;
+  /** Called after a successful PATCH with the updated template. */
+  onSuccess: (updated: OrganizationDocumentTemplate) => void;
+}
+
+// ─── TemplateReplaceFileModal ─────────────────────────────────────────────────
+
+export interface TemplateReplaceFileModalProps {
+  isOpen: boolean;
+  template: OrganizationDocumentTemplate;
+  onClose: () => void;
+  /**
+   * Called after a successful file replacement.
+   * @param updated           - Updated template entity.
+   * @param dependentsFlagged - Count of dependent artifacts flagged.
+   */
+  onSuccess: (updated: OrganizationDocumentTemplate, dependentsFlagged: number) => void;
+}
+
+// ─── TemplateDeleteConfirmDialog ──────────────────────────────────────────────
+
+export interface TemplateDeleteConfirmDialogProps {
+  isOpen: boolean;
+  template: OrganizationDocumentTemplate;
+  onClose: () => void;
+  /** Called after the template is successfully deleted. */
+  onSuccess: (deletedId: string) => void;
+}
+
+// ─── TemplateValidationWarningsBanner ────────────────────────────────────────
+
+export interface TemplateValidationWarningsBannerProps {
+  /**
+   * Parsed validation warnings array. Render the banner only when length > 0.
+   */
+  warnings: string[];
+  /** If true, renders a compact/inline variant. */
+  compact?: boolean;
+}
+
+// ─── TemplateStatusBadge ──────────────────────────────────────────────────────
+
+export interface TemplateStatusBadgeProps {
+  status: ValidationStatus | TemplateStatus;
+}
+```
+
+---
+
+### 6.2 Narrative Seed Admin Components
+
+```typescript
+import type { NarrativeSeedDocument } from './types';
+
+// ─── NarrativeSeedAdminPage ───────────────────────────────────────────────────
+
+/** Top-level route component — no required props (fetches its own data). */
+export interface NarrativeSeedAdminPageProps {}
+
+// ─── NarrativeSeedListPanel ───────────────────────────────────────────────────
+
+export interface NarrativeSeedListPanelProps {
+  seeds: NarrativeSeedDocument[];
+  isLoading: boolean;
+  /** Fires when user requests upload of a new seed. */
+  onUploadClick: () => void;
+  /** Fires when user selects a seed row for detail or action. */
+  onSeedSelect: (seed: NarrativeSeedDocument) => void;
+}
+
+// ─── NarrativeSeedRow ─────────────────────────────────────────────────────────
+
+export interface NarrativeSeedRowProps {
+  seed: NarrativeSeedDocument;
+  /** Tags parsed from `seed.tags` JSON string — pass pre-parsed value. */
+  parsedTags: string[];
+  onSelect: (seed: NarrativeSeedDocument) => void;
+  /** Fires when user clicks "Delete". */
+  onDelete: (id: string) => void;
+  isBusy?: boolean;
+}
+
+// ─── NarrativeSeedUploadModal ─────────────────────────────────────────────────
+
+export interface NarrativeSeedUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Called after a successful upload.
+   * @param document - The newly created seed document.
+   * @param jobId    - The async indexing job ID, or null.
+   */
+  onSuccess: (document: NarrativeSeedDocument, jobId: string | null) => void;
+}
+
+// ─── NarrativeSeedDeleteConfirmDialog ────────────────────────────────────────
+
+export interface NarrativeSeedDeleteConfirmDialogProps {
+  isOpen: boolean;
+  seed: NarrativeSeedDocument;
+  onClose: () => void;
+  /**
+   * Called after successful deletion.
+   * @param deletedId - The GUID of the deleted seed.
+   */
+  onSuccess: (deletedId: string) => void;
+}
+
+/**
+ * Shown as a second confirmation step when the server responds with
+ * 409 WIZARD_NARRATIVE_SEED_HAS_CITATIONS.
+ */
+export interface NarrativeSeedCitationConfirmDialogProps {
+  isOpen: boolean;
+  seed: NarrativeSeedDocument;
+  onClose: () => void;
+  /** Called when the user confirms force-deletion despite citations. */
+  onConfirm: () => void;
+}
+
+// ─── NarrativeSeedIndexingStatusIndicator ────────────────────────────────────
+
+export interface NarrativeSeedIndexingStatusIndicatorProps {
+  status: IndexingStatus;
+  /** Chunk count — shown when status is "Indexed". */
+  chunkCount?: number | null;
+  /** Error detail — shown when status is "Failed". */
+  errorMessage?: string | null;
+}
+
+// ─── NarrativeSeedTagList ─────────────────────────────────────────────────────
+
+export interface NarrativeSeedTagListProps {
+  /** Pre-parsed tag array (already JSON.parsed from `seed.tags`). */
+  tags: string[];
+  /** Maximum tags to show before a "+N more" overflow indicator. */
+  maxVisible?: number;
+}
+```
+
+---
+
+### 6.3 Shared Admin Components
+
+```typescript
+// ─── FileDropZone ─────────────────────────────────────────────────────────────
+
+export interface FileDropZoneProps {
+  /** MIME types and/or file extensions to accept (HTML accept string). */
+  accept: string;
+  /** Maximum file size in bytes. Triggers client-side validation. */
+  maxSizeBytes?: number;
+  /** Called when a valid file is selected or dropped. */
+  onFileSelect: (file: File) => void;
+  /** Called when a file fails client-side validation. */
+  onValidationError?: (message: string) => void;
+  /** Whether any upload action is currently pending. */
+  isUploading?: boolean;
+  /** Label text shown inside the drop area. */
+  label?: string;
+}
+
+// ─── AdminActionMenu ──────────────────────────────────────────────────────────
+
+export interface AdminActionMenuItem {
+  label: string;
+  onClick: () => void;
+  /** When true, renders the item in a destructive/danger style. */
+  isDangerous?: boolean;
+  /** Tooltip shown when the item is disabled. */
+  disabledReason?: string;
+  disabled?: boolean;
+}
+
+export interface AdminActionMenuProps {
+  items: AdminActionMenuItem[];
+  /** Accessible label for the trigger button. */
+  triggerAriaLabel?: string;
+}
+
+// ─── BlobDownloadButton ───────────────────────────────────────────────────────
+
+export interface BlobDownloadButtonProps {
+  /** Async function that fetches the Blob. */
+  fetchBlob: () => Promise<Blob>;
+  /** Suggested file name for the download. */
+  fileName: string;
+  /** Button label text. */
+  label?: string;
+  disabled?: boolean;
+}
+```
+
+---
+
+## 7. Derived / Display Types
+
+Helper types for UI state that are not directly from the API wire format:
+
+```typescript
+/**
+ * OrganizationDocumentTemplate with `validationWarnings` pre-parsed into
+ * a string array for display convenience.
+ */
+export interface OrganizationDocumentTemplateView
+  extends Omit<OrganizationDocumentTemplate, 'validationWarnings'> {
+  /** Pre-parsed warnings — empty array when the raw field was null. */
+  validationWarningsParsed: string[];
+}
+
+/**
+ * NarrativeSeedDocument with `tags` pre-parsed into a string array.
+ */
+export interface NarrativeSeedDocumentView
+  extends Omit<NarrativeSeedDocument, 'tags'> {
+  /** Pre-parsed tags array. */
+  tagsParsed: string[];
+}
+
+/** Local form state for the template upload form. */
+export interface TemplateUploadFormState {
+  templateType: TemplateType | '';
+  label: string;
+  version: string;
+  file: File | null;
+  isDefault: boolean;
+}
+
+/** Local form state for the template metadata patch form. */
+export interface TemplatePatchFormState {
+  label: string;
+  version: string;
+}
+
+/** Local form state for the narrative seed upload form. */
+export interface NarrativeSeedUploadFormState {
+  label: string;
+  /** Comma or newline-separated string that the user types; split before submit. */
+  tagsInput: string;
+  file: File | null;
+}
+
+/** Used to surface inline upload-progress feedback. */
+export interface UploadProgressState {
+  isUploading: boolean;
+  progressPercent?: number;
+  error: ApiError | null;
+}
+```
+
+---
+
+## 8. Type Guards & Utilities
+
+```typescript
+// ─── Type Guards ──────────────────────────────────────────────────────────────
+
+/** Narrows an ApiResult to the success branch. */
+export function isApiSuccess<T>(result: ApiResult<T>): result is ApiSuccess<T> {
+  return result.ok === true;
+}
+
+/** Narrows an ApiResult to the error branch. */
+export function isApiError<T>(result: ApiResult<T>): result is ApiError {
+  return result.ok === false;
+}
+
+// ─── Parsing Utilities ────────────────────────────────────────────────────────
+
+/**
+ * Safely parses `template.validationWarnings` from a raw JSON string to string[].
+ * Returns `[]` when the field is null or when JSON.parse fails.
+ */
+export function parseValidationWarnings(
+  template: OrganizationDocumentTemplate,
+): string[] {
+  if (!template.validationWarnings) return [];
+  try {
+    const parsed = JSON.parse(template.validationWarnings);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Safely parses `seed.tags` from a raw JSON string to string[].
+ * Returns `[]` when the field is empty or when JSON.parse fails.
+ */
+export function parseSeedTags(seed: NarrativeSeedDocument): string[] {
+  if (!seed.tags) return [];
+  try {
+    const parsed = JSON.parse(seed.tags);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Converts an `OrganizationDocumentTemplate` to a display-friendly
+ * `OrganizationDocumentTemplateView` with pre-parsed warnings.
+ */
+export function toTemplateView(
+  template: OrganizationDocumentTemplate,
+): OrganizationDocumentTemplateView {
+  return {
+    ...template,
+    validationWarningsParsed: parseValidationWarnings(template),
+  };
+}
+
+/**
+ * Converts a `NarrativeSeedDocument` to a display-friendly
+ * `NarrativeSeedDocumentView` with pre-parsed tags.
+ */
+export function toSeedView(
+  seed: NarrativeSeedDocument,
+): NarrativeSeedDocumentView {
+  return {
+    ...seed,
+    tagsParsed: parseSeedTags(seed),
+  };
+}
+
+/**
+ * Formats `fileSizeBytes` into a human-readable string.
+ * e.g., 204800 → "200 KB"
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ─── FormData Builders ────────────────────────────────────────────────────────
+
+/**
+ * Builds a `FormData` object for the template upload endpoint.
+ * Handles the optional `isDefault` boolean serialization.
+ */
+export function buildUploadTemplateFormData(
+  fields: UploadTemplateFields,
+): FormData {
+  const fd = new FormData();
+  fd.append('templateType', fields.templateType);
+  fd.append('label', fields.label);
+  fd.append('version', fields.version);
+  fd.append('file', fields.file);
+  if (fields.isDefault !== undefined) {
+    fd.append('isDefault', String(fields.isDefault));
+  }
+  return fd;
+}
+
+/**
+ * Builds a `FormData` object for the template file-replace endpoint.
+ */
+export function buildReplaceTemplateFormData(
+  fields: ReplaceTemplateFileFields,
+): FormData {
+  const fd = new FormData();
+  fd.append('file', fields.file);
+  if (fields.version !== undefined) {
+    fd.append('version', fields.version);
+  }
+  return fd;
+}
+
+/**
+ * Builds a `FormData` object for the narrative seed upload endpoint.
+ * Tags are appended as repeated form fields (`tags=policy&tags=ac`).
+ */
+export function buildUploadSeedFormData(
+  fields: UploadNarrativeSeedFields,
+): FormData {
+  const fd = new FormData();
+  fd.append('label', fields.label);
+  fd.append('file', fields.file);
+  (fields.tags ?? []).forEach((tag) => fd.append('tags', tag));
+  return fd;
+}
+```
+
+---
+
+## Implementation Notes
+
+### JSON String Fields
+Both `OrganizationDocumentTemplate.validationWarnings` and `NarrativeSeedDocument.tags` arrive from the API as raw JSON strings rather than parsed arrays. Always use the provided utility functions (`parseValidationWarnings`, `parseSeedTags`) or the view converters (`toTemplateView`, `toSeedView`) before rendering.
+
+### File Downloads
+The `downloadTemplate` API client method returns a `Blob`. To trigger a browser download:
+```typescript
+const blob = await downloadTemplate(id);
+const url = URL.createObjectURL(blob);
+const anchor = document.createElement('a');
+anchor.href = url;
+anchor.download = template.originalFileName;
+anchor.click();
+URL.revokeObjectURL(url);
+```
+Use the `BlobDownloadButton` component for a standardized UX wrapper.
+
+### Optimistic UI Updates
+When marking/clearing defaults or deleting templates, apply optimistic updates locally before the API call resolves, then reconcile with the server response on success or revert on error.
+
+### Citation Confirmation Flow
+For seed deletion, implement a two-step dialog pattern:
+1. Fire `deleteNarrativeSeed(id)` — if it resolves, done.
+2. If it rejects with `WIZARD_NARRATIVE_SEED_HAS_CITATIONS`, show `NarrativeSeedCitationConfirmDialogProps`.
+3. On user confirmation, retry with `deleteNarrativeSeed(id, { confirmCitations: true })`.
+
+### Indexing Status Polling
+After a successful seed upload, the `indexingStatus` begins as `Pending`. Poll `listNarrativeSeeds()` (or a single-seed GET if added in future) at a reasonable interval (e.g., 5s) until `status` transitions to `Indexed` or `Failed`.

--- a/specs/068-org-template-admin/contracts/http-api.md
+++ b/specs/068-org-template-admin/contracts/http-api.md
@@ -1,0 +1,657 @@
+# HTTP API Contract — Spec 068: Org Templates & Narrative Seed Admin
+
+**Epic:** #222 — Org Templates & Narrative Seed Admin UI
+**Base path group:** `/api/onboarding`
+**Auth policy:** `OnboardingAdministratorRequirement.PolicyName` (required on all endpoints)
+**Anti-forgery:** Disabled on this group (`.DisableAntiforgery()`)
+**Envelope format:** All JSON responses share a standard envelope (see § Error Envelope).
+
+---
+
+## Table of Contents
+
+1. [Common Types](#1-common-types)
+2. [Error Envelope](#2-error-envelope)
+3. [Organization Document Templates](#3-organization-document-templates)
+   - [GET /api/onboarding/templates](#31-list-templates)
+   - [POST /api/onboarding/templates/upload](#32-upload-template)
+   - [GET /api/onboarding/templates/{id}](#33-get-template)
+   - [PATCH /api/onboarding/templates/{id}](#34-patch-template-metadata)
+   - [DELETE /api/onboarding/templates/{id}](#35-delete-template)
+   - [GET /api/onboarding/templates/{id}/download](#36-download-template-file)
+   - [POST /api/onboarding/templates/{id}/replace](#37-replace-template-file)
+   - [POST /api/onboarding/templates/{id}/default](#38-mark-template-as-default)
+   - [DELETE /api/onboarding/templates/{id}/default/clear](#39-clear-template-default)
+4. [Narrative Seed Documents](#4-narrative-seed-documents)
+   - [GET /api/onboarding/narrative-seeds](#41-list-narrative-seeds)
+   - [POST /api/onboarding/narrative-seeds](#42-upload-narrative-seed)
+   - [DELETE /api/onboarding/narrative-seeds/{id}](#43-delete-narrative-seed)
+
+---
+
+## 1. Common Types
+
+### TemplateType (string enum)
+| Value | Description |
+|-------|-------------|
+| `Ssp` | System Security Plan |
+| `Sar` | Security Assessment Report |
+| `Sap` | Security Assessment Plan |
+| `Crm` | Customer Responsibility Matrix |
+| `HwSwInventory` | Hardware/Software Inventory |
+
+### FileFormat (string enum)
+| Value |
+|-------|
+| `Docx` |
+| `Xlsx` |
+
+### ValidationStatus (string enum)
+| Value |
+|-------|
+| `Pending` |
+| `Compliant` |
+| `FlaggedNonCompliant` |
+
+### TemplateStatus (string enum)
+| Value |
+|-------|
+| `Active` |
+| `Superseded` |
+| `Deleted` |
+
+### IndexingStatus (string enum)
+| Value |
+|-------|
+| `Pending` |
+| `Indexed` |
+| `Failed` |
+
+### SeedStatus (string enum)
+| Value |
+|-------|
+| `Active` |
+| `Deleted` |
+
+---
+
+### OrganizationDocumentTemplate (response shape)
+
+```jsonc
+{
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",       // GUID string
+  "tenantId": "3fa85f64-5717-4562-b3fc-2c963f66afa6", // GUID string
+  "templateType": "Ssp",                               // TemplateType
+  "label": "FedRAMP SSP Master Template",
+  "version": "2024-Q4",
+  "originalFileName": "fedramp-ssp-master-v2024Q4.docx",
+  // storageBlobKey is NEVER included in API responses — backend only
+  "fileFormat": "Docx",                                // FileFormat
+  "fileSizeBytes": 204800,
+  "contentChecksumSha256": "e3b0c44298fc1c149afb...",
+  "isDefault": true,
+  "validationStatus": "Compliant",                     // ValidationStatus
+  "validationWarnings": null,                          // null | JSON string (array of warning strings)
+  "status": "Active",                                  // TemplateStatus
+  "createdAt": "2025-01-15T10:00:00Z",
+  "createdBy": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "updatedAt": "2025-06-01T12:00:00Z",
+  "updatedBy": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "deletedAt": null                                    // null | ISO 8601 string
+}
+```
+
+> **Note:** `validationWarnings` is stored and returned as a raw JSON string (e.g., `"[\"Missing cover page\",\"Outdated header\"]"`). Clients should `JSON.parse()` this field before display.
+
+---
+
+### NarrativeSeedDocument (response shape)
+
+```jsonc
+{
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "tenantId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "label": "AC Policy Narrative",
+  "tags": "[\"policy\",\"ac\"]",                       // JSON string — clients must JSON.parse()
+  "evidenceArtifactId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "indexingStatus": "Indexed",                         // IndexingStatus
+  "indexJobId": null,                                  // null | GUID string
+  "indexedAt": "2025-06-01T08:00:00Z",                 // null | ISO 8601 string
+  "indexedChunkCount": 42,                             // null | number
+  "indexingError": null,                               // null | string
+  "status": "Active",                                  // SeedStatus
+  "createdAt": "2025-01-15T10:00:00Z",
+  "createdBy": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "updatedAt": "2025-06-01T12:00:00Z",
+  "updatedBy": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "deletedAt": null
+}
+```
+
+> **Note:** `tags` is a raw JSON string in the DB and returned as-is on the wire. Clients should `JSON.parse()` for display.
+
+---
+
+## 2. Error Envelope
+
+All error responses use the following JSON shape:
+
+```jsonc
+{
+  "ok": false,
+  "errorCode": "TEMPLATE_WRONG_FORMAT",     // machine-readable code (see tables below)
+  "message": "Human-readable description.", // always present
+  "suggestion": "Optional fix hint."        // may be null or absent
+}
+```
+
+Success responses always include `"ok": true` plus a `"data"` key.
+
+---
+
+## 3. Organization Document Templates
+
+Route group: `MapGroup("/api/onboarding/templates")`
+Auth: `RequireAuthorization(OnboardingAdministratorRequirement.PolicyName)`
+
+---
+
+### 3.1 List Templates
+
+```
+GET /api/onboarding/templates
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** N/A (no body)
+
+#### Query Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `templateType` | `TemplateType` string | No | — | Filter by template type. Omit to return all types. |
+| `includeDeleted` | `boolean` | No | `false` | When `true`, includes templates with `status == "Deleted"`. |
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": [
+    { /* OrganizationDocumentTemplate */ },
+    { /* OrganizationDocumentTemplate */ }
+  ]
+}
+```
+
+Returns an empty array `[]` when no templates match.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Authenticated user lacks `OnboardingAdministrator` role |
+
+---
+
+### 3.2 Upload Template
+
+```
+POST /api/onboarding/templates/upload
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** `multipart/form-data`
+
+#### Request Parts
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `templateType` | string (`TemplateType`) | **Yes** | Type of the template. |
+| `label` | string | **Yes** | Human-readable label for the template. |
+| `version` | string | **Yes** | Version string (e.g., `"2024-Q4"`). |
+| `file` | binary file | **Yes** | The template file (.docx or .xlsx). |
+| `isDefault` | boolean | No | If `true`, marks this template as the default for its type. Defaults to `false`. |
+
+#### Success Response — `201 Created`
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "template": { /* OrganizationDocumentTemplate */ },
+    "warnings": ["Missing cover page field", "Outdated footer macro"] // string[], may be empty
+  }
+}
+```
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `413` | `TEMPLATE_TOO_LARGE` | File exceeds maximum allowed size |
+| `415` | `TEMPLATE_WRONG_FORMAT` | File format not supported (not .docx or .xlsx) |
+| `400` | — | Missing required fields (`templateType`, `label`, `version`, `file`) |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.3 Get Template
+
+```
+GET /api/onboarding/templates/{id}
+```
+
+**Authentication:** Onboarding Administrator
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": { /* OrganizationDocumentTemplate */ }
+}
+```
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `404` | — | No template with this ID exists in the tenant |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.4 Patch Template Metadata
+
+```
+PATCH /api/onboarding/templates/{id}
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** `application/json`
+
+> Updates only metadata fields (`label`, `version`). To update file content, use [Replace Template File](#37-replace-template-file). `templateType` cannot be changed after creation.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Request Body
+
+```jsonc
+{
+  "label": "Updated Label",   // optional string — omit to leave unchanged
+  "version": "2025-Q1"       // optional string — omit to leave unchanged
+}
+```
+
+At least one field must be present (both may be included simultaneously).
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": { /* OrganizationDocumentTemplate with updated fields */ }
+}
+```
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `404` | — | Template not found |
+| `400` | — | Request body is empty or malformed |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.5 Delete Template
+
+```
+DELETE /api/onboarding/templates/{id}
+```
+
+**Authentication:** Onboarding Administrator
+
+> Soft-deletes the template (sets `status = "Deleted"`, records `deletedAt`). Templates marked as default are protected from deletion.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Success Response — `204 No Content`
+
+No body.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `409` | `TEMPLATE_DEFAULT_PROTECTED` | Cannot delete a template that is currently the default; clear its default status first |
+| `404` | — | Template not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.6 Download Template File
+
+```
+GET /api/onboarding/templates/{id}/download
+```
+
+**Authentication:** Onboarding Administrator
+
+> Returns the raw template file. Clients **must** use the blob URL pattern — do **not** link to blob storage directly.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Success Response — `200 OK`
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/octet-stream` |
+| `Content-Disposition` | `attachment; filename="<OriginalFileName>"` |
+
+Body: raw binary file stream.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `404` | — | Template not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.7 Replace Template File
+
+```
+POST /api/onboarding/templates/{id}/replace
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** `multipart/form-data`
+
+> Replaces the binary content of an existing template. All dependent artifacts (e.g., draft SSPs using this template) are flagged.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Request Parts
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | binary file | **Yes** | The replacement file (.docx or .xlsx). |
+| `version` | string | No | New version string; if omitted the existing version is retained. |
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "template": { /* OrganizationDocumentTemplate with new file metadata */ },
+    "dependentsFlagged": 3  // number of dependent artifacts flagged for review
+  }
+}
+```
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `413` | `TEMPLATE_TOO_LARGE` | Replacement file exceeds maximum size |
+| `404` | — | Template not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.8 Mark Template as Default
+
+```
+POST /api/onboarding/templates/{id}/default
+```
+
+**Authentication:** Onboarding Administrator
+
+> Sets this template as the default for its `templateType`. Any previously default template of the same type is automatically demoted.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Request Body
+
+None.
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": { /* OrganizationDocumentTemplate with isDefault: true */ }
+}
+```
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `404` | — | Template not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 3.9 Clear Template Default
+
+```
+DELETE /api/onboarding/templates/{id}/default/clear
+```
+
+**Authentication:** Onboarding Administrator
+
+> Removes the default designation from this template. After this call `isDefault` will be `false`. No other template is automatically promoted.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Template ID. |
+
+#### Success Response — `204 No Content`
+
+No body.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `404` | — | Template not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+## 4. Narrative Seed Documents
+
+Route group: `MapGroup("/api/onboarding/narrative-seeds")`
+Auth: `RequireAuthorization(OnboardingAdministratorRequirement.PolicyName)`
+
+---
+
+### 4.1 List Narrative Seeds
+
+```
+GET /api/onboarding/narrative-seeds
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** N/A (no body)
+
+#### Query Parameters
+
+None. Returns all seeds for the tenant (active only by default; deleted seeds are excluded unless an admin-level flag is added in a future iteration).
+
+#### Success Response — `200 OK`
+
+```jsonc
+{
+  "ok": true,
+  "data": [
+    { /* NarrativeSeedDocument */ },
+    { /* NarrativeSeedDocument */ }
+  ]
+}
+```
+
+Returns an empty array `[]` when no seeds exist.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 4.2 Upload Narrative Seed
+
+```
+POST /api/onboarding/narrative-seeds
+```
+
+**Authentication:** Onboarding Administrator
+**Content-Type:** `multipart/form-data`
+
+> File is uploaded, stored, and an async indexing job is queued. The response returns immediately with a `jobId` that can be used to track indexing progress.
+
+#### Request Parts
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | string | **Yes** | Human-readable label for the seed document. |
+| `tags` | string[] | No | Array of tag strings submitted as repeated form fields (e.g., `tags=policy&tags=ac`). |
+| `file` | binary file | **Yes** | The PDF seed document. |
+
+#### Success Response — `202 Accepted`
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "document": { /* NarrativeSeedDocument with indexingStatus: "Pending" */ },
+    "jobId": "3fa85f64-5717-4562-b3fc-2c963f66afa6" // GUID string | null — async indexing job ID
+  }
+}
+```
+
+> `jobId` may be `null` if the indexing queue is not applicable (e.g., feature-flagged off).
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `413` | `SspPdfUnreadable` | File too large or PDF could not be parsed |
+| `400` | — | Missing required fields (`label`, `file`) |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+### 4.3 Delete Narrative Seed
+
+```
+DELETE /api/onboarding/narrative-seeds/{id}
+```
+
+**Authentication:** Onboarding Administrator
+
+> Soft-deletes the seed document. If the seed has active citations in any wizard, deletion is blocked unless `confirmCitations=true` is passed to acknowledge the forced removal.
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | GUID | **Yes** | Seed document ID. |
+
+#### Query Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `confirmCitations` | boolean | No | `false` | Pass `true` to confirm deletion even when active citations exist. |
+
+#### Success Response — `204 No Content`
+
+No body.
+
+#### Error Responses
+
+| HTTP | `errorCode` | Condition |
+|------|------------|-----------|
+| `409` | `WIZARD_NARRATIVE_SEED_HAS_CITATIONS` | Seed has active citations and `confirmCitations` was not `true` |
+| `404` | — | Seed not found |
+| `401` | — | Missing or invalid auth token |
+| `403` | — | Insufficient permissions |
+
+---
+
+## 5. Error Code Reference
+
+| `errorCode` | HTTP | Endpoint(s) | Description |
+|-------------|------|-------------|-------------|
+| `TEMPLATE_WRONG_FORMAT` | `415` | Upload Template | File is not a supported format (.docx / .xlsx) |
+| `TEMPLATE_TOO_LARGE` | `413` | Upload Template, Replace Template File | File exceeds the maximum allowed size |
+| `TEMPLATE_DEFAULT_PROTECTED` | `409` | Delete Template | Cannot delete a template currently marked as default |
+| `SspPdfUnreadable` | `413` | Upload Narrative Seed | Seed PDF is too large or could not be parsed |
+| `WIZARD_NARRATIVE_SEED_HAS_CITATIONS` | `409` | Delete Narrative Seed | Seed has active citations; pass `confirmCitations=true` to force |
+
+---
+
+## 6. Implementation Notes
+
+### Security
+- All endpoints are protected by `OnboardingAdministratorRequirement.PolicyName`. There is no public or read-only access variant.
+- Anti-forgery tokens are disabled on this group (file upload compatibility).
+
+### File Handling
+- The download endpoint streams from internal blob storage. **Clients must consume the `Content-Disposition` filename and use blob URLs** — do not construct direct blob-storage URLs.
+- `storageBlobKey` is a backend-only field and is **never serialized** to API responses.
+
+### Tags Encoding
+- `NarrativeSeedDocument.tags` is stored and returned as a raw JSON string (e.g., `"[\"policy\",\"ac\"]"`). Frontend clients are responsible for `JSON.parse()` before display.
+
+### Validation Warnings
+- `OrganizationDocumentTemplate.validationWarnings` is similarly a raw JSON string when non-null. Parse before rendering.
+
+### Async Indexing
+- Uploading a narrative seed returns `202 Accepted`. The `indexingStatus` field begins as `Pending` and transitions to `Indexed` or `Failed` asynchronously. Poll or use a push channel to track completion.

--- a/specs/068-org-template-admin/contracts/internal-services.md
+++ b/specs/068-org-template-admin/contracts/internal-services.md
@@ -1,0 +1,620 @@
+# Internal Services Contract — Spec 068: Org Templates & Narrative Seed Admin
+
+**Epic:** #222 — Org Templates & Narrative Seed Admin UI
+**Layer:** Application / Domain Services (C# interfaces + implementation outline)
+
+---
+
+## Table of Contents
+
+1. [Result Types](#1-result-types)
+2. [IOrganizationTemplateService](#2-iorganizationtemplateservice)
+   - [Interface Definition](#21-interface-definition)
+   - [Method Implementation Outlines](#22-method-implementation-outlines)
+3. [INarrativeSeedDocumentService](#3-inarrativeseeддocumentservice)
+   - [Interface Definition](#31-interface-definition)
+   - [Method Implementation Outlines](#32-method-implementation-outlines)
+4. [Shared Exceptions & Error Codes](#4-shared-exceptions--error-codes)
+5. [Architecture Notes](#5-architecture-notes)
+
+---
+
+## 1. Result Types
+
+These result DTOs are returned by service methods where a simple entity is not sufficient.
+
+```csharp
+namespace Org.Onboarding.Templates;
+
+/// <summary>
+/// Result returned by <see cref="IOrganizationTemplateService.UploadAsync"/>.
+/// </summary>
+public sealed record UploadTemplateResult
+{
+    /// <summary>The persisted template entity after upload.</summary>
+    public required OrganizationDocumentTemplate Template { get; init; }
+
+    /// <summary>
+    /// Human-readable validation warnings discovered during content inspection.
+    /// Empty if no warnings were raised.
+    /// </summary>
+    public required IReadOnlyList<string> Warnings { get; init; }
+}
+
+/// <summary>
+/// Result returned by <see cref="IOrganizationTemplateService.ReplaceFileAsync"/>.
+/// </summary>
+public sealed record ReplaceTemplateResult
+{
+    /// <summary>The updated template entity after file replacement.</summary>
+    public required OrganizationDocumentTemplate Template { get; init; }
+
+    /// <summary>
+    /// Number of dependent draft artifacts (e.g., SSPs) flagged for review
+    /// because their bound template file changed.
+    /// </summary>
+    public required int DependentsFlagged { get; init; }
+}
+
+/// <summary>
+/// Result returned by <see cref="INarrativeSeedDocumentService.UploadAsync"/>.
+/// </summary>
+public sealed record UploadSeedResult
+{
+    /// <summary>The persisted seed document entity.</summary>
+    public required NarrativeSeedDocument Document { get; init; }
+
+    /// <summary>
+    /// The async indexing job ID, or <c>null</c> if no indexing job was queued
+    /// (e.g., feature-flagged off or synchronous path taken).
+    /// </summary>
+    public Guid? JobId { get; init; }
+}
+```
+
+---
+
+## 2. IOrganizationTemplateService
+
+### 2.1 Interface Definition
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Org.Onboarding.Templates;
+
+/// <summary>
+/// Manages the lifecycle of organization document templates (SSP, SAR, SAP, CRM,
+/// HW/SW Inventory). All operations are scoped to a tenant; callers must supply
+/// the resolved <paramref name="tenantId"/> from the authenticated HTTP context.
+/// </summary>
+public interface IOrganizationTemplateService
+{
+    /// <summary>
+    /// Returns all document templates for a tenant, optionally filtered by type
+    /// and/or including soft-deleted records.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="type">
+    ///     When non-null, restricts results to templates of this type.
+    ///     Pass <c>null</c> to return all types.
+    /// </param>
+    /// <param name="includeDeleted">
+    ///     When <c>true</c>, includes templates with
+    ///     <see cref="TemplateStatus.Deleted"/>. Defaults to <c>false</c>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Read-only ordered list of matching templates.</returns>
+    Task<IReadOnlyList<OrganizationDocumentTemplate>> ListAsync(
+        Guid tenantId,
+        TemplateType? type,
+        bool includeDeleted,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves a single template by ID, scoped to the tenant.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    ///     The matching template, or <c>null</c> if not found or belonging to
+    ///     a different tenant.
+    /// </returns>
+    Task<OrganizationDocumentTemplate?> GetAsync(
+        Guid tenantId,
+        Guid id,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Validates, stores, and registers a new document template.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="type">Template type (<see cref="TemplateType"/>).</param>
+    /// <param name="label">Human-readable label.</param>
+    /// <param name="version">Version string (e.g., "2024-Q4").</param>
+    /// <param name="fileName">Original client-supplied file name, stored for download.</param>
+    /// <param name="content">Seekable stream of the file contents.</param>
+    /// <param name="sizeBytes">File size in bytes; used for pre-validation before streaming.</param>
+    /// <param name="isDefault">
+    ///     If <c>true</c>, this template is marked as default for its type;
+    ///     any prior default of the same type is demoted atomically.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><see cref="UploadTemplateResult"/> containing the saved entity and warnings.</returns>
+    /// <exception cref="TemplateFileTooLargeException">
+    ///     Thrown when <paramref name="sizeBytes"/> exceeds the configured maximum.
+    /// </exception>
+    /// <exception cref="TemplateWrongFormatException">
+    ///     Thrown when <paramref name="fileName"/> extension is not .docx or .xlsx,
+    ///     or when content inspection fails.
+    /// </exception>
+    Task<UploadTemplateResult> UploadAsync(
+        Guid tenantId,
+        Guid actorId,
+        TemplateType type,
+        string label,
+        string version,
+        string fileName,
+        Stream content,
+        long sizeBytes,
+        bool isDefault,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Updates the metadata fields (<paramref name="label"/> and/or
+    /// <paramref name="version"/>) of an existing template.
+    /// File content and <c>templateType</c> cannot be changed via this method.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="label">New label, or <c>null</c> to leave unchanged.</param>
+    /// <param name="version">New version string, or <c>null</c> to leave unchanged.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The updated template entity.</returns>
+    /// <exception cref="TemplateNotFoundException">
+    ///     Thrown when no template with <paramref name="id"/> exists for the tenant.
+    /// </exception>
+    Task<OrganizationDocumentTemplate> PatchMetadataAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        string? label,
+        string? version,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Soft-deletes a template by setting its status to
+    /// <see cref="TemplateStatus.Deleted"/> and recording <c>deletedAt</c>.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="TemplateNotFoundException">
+    ///     Thrown when no template with <paramref name="id"/> exists for the tenant.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown with error code <c>TEMPLATE_DEFAULT_PROTECTED</c> when the template
+    ///     is currently marked as default. Call
+    ///     <see cref="ClearDefaultAsync"/> first.
+    /// </exception>
+    Task DeleteAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Opens a readable stream for the raw template file from blob storage.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    ///     A readable <see cref="Stream"/> positioned at offset 0, or <c>null</c>
+    ///     if the template does not exist for this tenant.
+    /// </returns>
+    /// <remarks>
+    ///     Caller is responsible for disposing the returned stream.
+    ///     The blob key is resolved internally; it is never surfaced to callers.
+    /// </remarks>
+    Task<Stream?> DownloadAsync(
+        Guid tenantId,
+        Guid id,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Replaces the binary content of an existing template with a new file,
+    /// then flags all dependent draft artifacts for re-generation review.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="fileName">Original client-supplied file name for the replacement.</param>
+    /// <param name="content">Seekable stream of the replacement file contents.</param>
+    /// <param name="sizeBytes">File size in bytes.</param>
+    /// <param name="version">
+    ///     New version string, or <c>null</c> to retain the existing version.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><see cref="ReplaceTemplateResult"/> with updated entity and dependent count.</returns>
+    /// <exception cref="TemplateFileTooLargeException">File exceeds maximum size.</exception>
+    /// <exception cref="TemplateNotFoundException">Template not found for tenant.</exception>
+    Task<ReplaceTemplateResult> ReplaceFileAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        string fileName,
+        Stream content,
+        long sizeBytes,
+        string? version,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Marks a template as the default for its <see cref="TemplateType"/>.
+    /// Any previously default template of the same type is atomically demoted
+    /// (<c>isDefault = false</c>) within the same transaction.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The updated template entity with <c>IsDefault = true</c>.</returns>
+    /// <exception cref="TemplateNotFoundException">Template not found for tenant.</exception>
+    Task<OrganizationDocumentTemplate> MarkDefaultAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Removes the default designation from a template.
+    /// After this call, <c>isDefault</c> is <c>false</c>. No other template
+    /// is automatically promoted to default.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Template GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="TemplateNotFoundException">Template not found for tenant.</exception>
+    Task ClearDefaultAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        CancellationToken ct);
+}
+```
+
+---
+
+### 2.2 Method Implementation Outlines
+
+#### `ListAsync`
+1. Query the `OrganizationDocumentTemplates` table filtered by `TenantId = tenantId`.
+2. If `type != null`, add `WHERE TemplateType = @type`.
+3. If `includeDeleted == false`, add `WHERE Status != 'Deleted'`.
+4. Order by `CreatedAt DESC` (most recent first).
+5. Map to domain entities and return.
+
+#### `GetAsync`
+1. Query by `Id = id AND TenantId = tenantId`.
+2. Return `null` on no match (caller maps to 404).
+
+#### `UploadAsync`
+1. **Pre-validate size:** if `sizeBytes > configuredMaxBytes`, throw `TemplateFileTooLargeException`.
+2. **Validate extension:** derive `FileFormat` from `fileName` extension (`.docx` → `Docx`, `.xlsx` → `Xlsx`); throw `TemplateWrongFormatException` for any other extension.
+3. **Content inspection:** open stream, run format-specific content check (e.g., valid OOXML structure); collect `warnings`.
+4. **Blob storage:** write stream to blob store; record returned `storageBlobKey` (internal only — never returned to callers).
+5. **Compute checksum:** SHA-256 over stream content.
+6. **Persist entity:** insert `OrganizationDocumentTemplate` row with `ValidationStatus = Pending`, `Status = Active`.
+7. **Mark default (optional):** within the same DB transaction, if `isDefault == true`, set `IsDefault = false` on any existing default of same type, then set `IsDefault = true` on new template.
+8. Return `UploadTemplateResult { Template, Warnings }`.
+
+#### `PatchMetadataAsync`
+1. Load entity by `Id + TenantId`; throw `TemplateNotFoundException` on miss.
+2. Apply non-null fields: `label`, `version`.
+3. Update `UpdatedAt = now`, `UpdatedBy = actorId`.
+4. Persist and return updated entity.
+
+#### `DeleteAsync`
+1. Load entity by `Id + TenantId`; throw `TemplateNotFoundException` on miss.
+2. If `entity.IsDefault == true`, throw `InvalidOperationException("TEMPLATE_DEFAULT_PROTECTED")`.
+3. Set `Status = Deleted`, `DeletedAt = now`, `UpdatedAt = now`, `UpdatedBy = actorId`.
+4. Persist.
+5. **Do NOT remove blob** — blob is retained for audit / recovery purposes.
+
+#### `DownloadAsync`
+1. Load entity by `Id + TenantId`; return `null` on miss.
+2. Resolve blob using `entity.StorageBlobKey` (internal field; never passed through public API).
+3. Open and return blob read stream; caller is responsible for disposal and streaming to HTTP response with `Content-Disposition: attachment; filename="<entity.OriginalFileName>"`.
+
+#### `ReplaceFileAsync`
+1. Load entity; throw `TemplateNotFoundException` on miss.
+2. Validate size (throw `TemplateFileTooLargeException` if exceeded).
+3. Write new blob to storage; record new `StorageBlobKey`.
+4. Compute new SHA-256 checksum.
+5. Update entity: `StorageBlobKey`, `OriginalFileName`, `FileSizeBytes`, `ContentChecksumSha256`, `FileFormat`, optionally `Version`, reset `ValidationStatus = Pending`, `UpdatedAt`, `UpdatedBy`.
+6. **Flag dependents:** query all draft artifacts bound to this template ID; set a `TemplateStale = true` flag on each. Return count as `DependentsFlagged`.
+7. Persist all changes in a single transaction.
+8. Return `ReplaceTemplateResult`.
+
+#### `MarkDefaultAsync`
+1. Load entity; throw `TemplateNotFoundException` on miss.
+2. In a single DB transaction:
+   a. `UPDATE ... SET IsDefault = false WHERE TenantId = @tenantId AND TemplateType = @type AND IsDefault = true AND Id != @id`
+   b. `UPDATE ... SET IsDefault = true WHERE Id = @id`
+3. Update `UpdatedAt`, `UpdatedBy`.
+4. Return refreshed entity.
+
+#### `ClearDefaultAsync`
+1. Load entity; throw `TemplateNotFoundException` on miss.
+2. Set `IsDefault = false`, `UpdatedAt = now`, `UpdatedBy = actorId`.
+3. Persist.
+
+---
+
+## 3. INarrativeSeedDocumentService
+
+### 3.1 Interface Definition
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Org.Onboarding.NarrativeSeeds;
+
+/// <summary>
+/// Manages narrative seed PDF documents used to prime AI-assisted wizard narratives.
+/// All operations are scoped to a tenant.
+/// </summary>
+public interface INarrativeSeedDocumentService
+{
+    /// <summary>
+    /// Returns all narrative seed documents for the tenant.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="includeDeleted">
+    ///     When <c>true</c>, includes seeds with <see cref="SeedStatus.Deleted"/>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Ordered list of seed documents.</returns>
+    Task<IReadOnlyList<NarrativeSeedDocument>> ListAsync(
+        Guid tenantId,
+        bool includeDeleted,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Uploads a PDF seed document, stores it, and enqueues an async indexing job.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="label">Human-readable label for this seed.</param>
+    /// <param name="tags">
+    ///     Zero or more classification tags (e.g., "policy", "ac").
+    ///     Stored internally as a JSON string.
+    /// </param>
+    /// <param name="fileName">Original client-supplied file name.</param>
+    /// <param name="contentType">MIME type of the uploaded file.</param>
+    /// <param name="content">Readable stream of PDF file bytes.</param>
+    /// <param name="sizeBytes">File size; used for pre-validation.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    ///     <see cref="UploadSeedResult"/> containing the persisted document and
+    ///     optional async <c>JobId</c>.
+    /// </returns>
+    /// <exception cref="SeedPdfUnreadableException">
+    ///     Thrown when the file is too large or cannot be parsed as a PDF.
+    ///     Maps to HTTP 413 with error code <c>SspPdfUnreadable</c>.
+    /// </exception>
+    Task<UploadSeedResult> UploadAsync(
+        Guid tenantId,
+        Guid actorId,
+        string label,
+        IList<string> tags,
+        string fileName,
+        string contentType,
+        Stream content,
+        long sizeBytes,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Soft-deletes a narrative seed document.
+    /// </summary>
+    /// <param name="tenantId">Resolved tenant ID from auth context.</param>
+    /// <param name="id">Seed document GUID.</param>
+    /// <param name="actorId">ID of the authenticated user performing the action.</param>
+    /// <param name="confirmCitations">
+    ///     When <c>false</c> (default), deletion is blocked if active citations
+    ///     reference this seed and <see cref="SeedHasCitationsException"/> is thrown.
+    ///     When <c>true</c>, citations are force-removed and deletion proceeds.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="SeedNotFoundException">
+    ///     Thrown when no seed with <paramref name="id"/> exists for the tenant.
+    /// </exception>
+    /// <exception cref="SeedHasCitationsException">
+    ///     Thrown when the seed has active wizard citations and
+    ///     <paramref name="confirmCitations"/> is <c>false</c>.
+    ///     Maps to HTTP 409 with error code <c>WIZARD_NARRATIVE_SEED_HAS_CITATIONS</c>.
+    /// </exception>
+    Task DeleteAsync(
+        Guid tenantId,
+        Guid id,
+        Guid actorId,
+        bool confirmCitations,
+        CancellationToken ct);
+}
+```
+
+---
+
+### 3.2 Method Implementation Outlines
+
+#### `ListAsync`
+1. Query `NarrativeSeedDocuments` filtered by `TenantId = tenantId`.
+2. If `includeDeleted == false`, add `WHERE Status != 'Deleted'`.
+3. Order by `CreatedAt DESC`.
+4. Return mapped domain list.
+
+#### `UploadAsync`
+1. **Pre-validate size:** if `sizeBytes > configuredMaxBytes`, throw `SeedPdfUnreadableException`.
+2. **Validate PDF:** attempt to open stream as a PDF (e.g., using a PDF library); throw `SeedPdfUnreadableException` if parsing fails.
+3. **Persist to blob storage:** write bytes; record blob key internally.
+4. **Create EvidenceArtifact:** insert a linked evidence artifact record; capture `evidenceArtifactId`.
+5. **Serialize tags:** `JsonSerializer.Serialize(tags)` → store as JSON string.
+6. **Persist `NarrativeSeedDocument`:** insert row with `IndexingStatus = Pending`, `Status = Active`.
+7. **Enqueue indexing job:** dispatch background job (e.g., via message bus). Capture `jobId` if returned; may be `null` when feature-flagged off.
+8. Update `IndexJobId` field on the persisted entity with `jobId` (if non-null).
+9. Return `UploadSeedResult { Document, JobId }`.
+
+#### `DeleteAsync`
+1. Load entity by `Id + TenantId`; throw `SeedNotFoundException` on miss.
+2. If `confirmCitations == false`:
+   a. Count active citations referencing this seed.
+   b. If count > 0, throw `SeedHasCitationsException`.
+3. If `confirmCitations == true` and citations exist:
+   a. Remove or nullify citation references in a cascading update.
+4. Set `Status = Deleted`, `DeletedAt = now`, `UpdatedAt = now`, `UpdatedBy = actorId`.
+5. Persist (single transaction covering citation cleanup + status update).
+
+---
+
+## 4. Shared Exceptions & Error Codes
+
+```csharp
+namespace Org.Onboarding.Exceptions;
+
+/// <summary>Base class for domain exceptions that map to specific HTTP error codes.</summary>
+public abstract class OnboardingDomainException : Exception
+{
+    public string ErrorCode { get; }
+    protected OnboardingDomainException(string errorCode, string message)
+        : base(message) => ErrorCode = errorCode;
+}
+
+/// <summary>
+/// Thrown when a template file exceeds the maximum allowed size.
+/// Maps to HTTP 413 / <c>TEMPLATE_TOO_LARGE</c>.
+/// </summary>
+public sealed class TemplateFileTooLargeException : OnboardingDomainException
+{
+    public TemplateFileTooLargeException()
+        : base("TEMPLATE_TOO_LARGE", "The uploaded template file exceeds the maximum allowed size.") { }
+}
+
+/// <summary>
+/// Thrown when a template file has an unsupported format or fails content inspection.
+/// Maps to HTTP 415 / <c>TEMPLATE_WRONG_FORMAT</c>.
+/// </summary>
+public sealed class TemplateWrongFormatException : OnboardingDomainException
+{
+    public TemplateWrongFormatException(string detail)
+        : base("TEMPLATE_WRONG_FORMAT", $"The template file format is not supported: {detail}") { }
+}
+
+/// <summary>
+/// Thrown when a template cannot be found for the given tenant.
+/// Maps to HTTP 404.
+/// </summary>
+public sealed class TemplateNotFoundException : OnboardingDomainException
+{
+    public TemplateNotFoundException(Guid id)
+        : base("TEMPLATE_NOT_FOUND", $"Template '{id}' was not found.") { }
+}
+
+/// <summary>
+/// Thrown when attempting to delete a template currently marked as default.
+/// Maps to HTTP 409 / <c>TEMPLATE_DEFAULT_PROTECTED</c>.
+/// </summary>
+public sealed class TemplateDefaultProtectedException : OnboardingDomainException
+{
+    public TemplateDefaultProtectedException(Guid id)
+        : base("TEMPLATE_DEFAULT_PROTECTED",
+               $"Template '{id}' is the default template and cannot be deleted. Clear its default status first.") { }
+}
+
+/// <summary>
+/// Thrown when a seed PDF file is too large or cannot be parsed.
+/// Maps to HTTP 413 / <c>SspPdfUnreadable</c>.
+/// </summary>
+public sealed class SeedPdfUnreadableException : OnboardingDomainException
+{
+    public SeedPdfUnreadableException(string detail)
+        : base("SspPdfUnreadable", $"The seed PDF could not be read: {detail}") { }
+}
+
+/// <summary>
+/// Thrown when a narrative seed cannot be found for the given tenant.
+/// Maps to HTTP 404.
+/// </summary>
+public sealed class SeedNotFoundException : OnboardingDomainException
+{
+    public SeedNotFoundException(Guid id)
+        : base("SEED_NOT_FOUND", $"Narrative seed '{id}' was not found.") { }
+}
+
+/// <summary>
+/// Thrown when a seed has active citations and deletion was requested without confirmation.
+/// Maps to HTTP 409 / <c>WIZARD_NARRATIVE_SEED_HAS_CITATIONS</c>.
+/// </summary>
+public sealed class SeedHasCitationsException : OnboardingDomainException
+{
+    public int CitationCount { get; }
+
+    public SeedHasCitationsException(Guid id, int citationCount)
+        : base("WIZARD_NARRATIVE_SEED_HAS_CITATIONS",
+               $"Narrative seed '{id}' has {citationCount} active citation(s). Pass confirmCitations=true to force delete.")
+    {
+        CitationCount = citationCount;
+    }
+}
+```
+
+### Exception-to-HTTP Mapping
+
+| Exception | HTTP Status | `errorCode` |
+|-----------|-------------|-------------|
+| `TemplateFileTooLargeException` | `413` | `TEMPLATE_TOO_LARGE` |
+| `TemplateWrongFormatException` | `415` | `TEMPLATE_WRONG_FORMAT` |
+| `TemplateNotFoundException` | `404` | *(no body)* |
+| `TemplateDefaultProtectedException` | `409` | `TEMPLATE_DEFAULT_PROTECTED` |
+| `SeedPdfUnreadableException` | `413` | `SspPdfUnreadable` |
+| `SeedNotFoundException` | `404` | *(no body)* |
+| `SeedHasCitationsException` | `409` | `WIZARD_NARRATIVE_SEED_HAS_CITATIONS` |
+
+Register a global exception filter / middleware that catches `OnboardingDomainException` and writes the standard error envelope `{ ok, errorCode, message, suggestion }`.
+
+---
+
+## 5. Architecture Notes
+
+### Tenant Scoping
+Every service method accepts `tenantId` as an explicit parameter. Services **must never** cross tenant boundaries. The endpoint handlers resolve `tenantId` from the authenticated claims before invoking the service.
+
+### `storageBlobKey` Isolation
+`StorageBlobKey` is an infrastructure concern stored on the entity but never projected into API response DTOs. The download path in `DownloadAsync` resolves the blob internally. Ensure response projection strips this field unconditionally.
+
+### Default Template Atomicity
+The `MarkDefaultAsync` demote-then-promote pattern must execute inside a single database transaction to avoid a window where zero or two templates are simultaneously marked as default. Use `SELECT FOR UPDATE` or an equivalent optimistic-concurrency mechanism.
+
+### Blob Retention on Delete
+Soft-deletion does **not** remove blobs. Blob cleanup (if desired) should be handled by a separate background job after a configurable retention window, keyed off `deletedAt`.
+
+### Tags Serialization
+`INarrativeSeedDocumentService.UploadAsync` accepts `IList<string> tags` and the implementation serializes to JSON (`"[\"policy\",\"ac\"]"`) before persistence. The HTTP endpoint handler parses the repeated form field `tags[]` into `IList<string>` before calling the service.
+
+### Dependency Registration (example)
+```csharp
+builder.Services.AddScoped<IOrganizationTemplateService, OrganizationTemplateService>();
+builder.Services.AddScoped<INarrativeSeedDocumentService, NarrativeSeedDocumentService>();
+```

--- a/specs/068-org-template-admin/data-model.md
+++ b/specs/068-org-template-admin/data-model.md
@@ -1,0 +1,297 @@
+# Data Model — Spec 068: Org Templates & Narrative Seed Admin UI
+
+> Epic: #222 | Feature Area: Onboarding Wizard Administration
+> Backend migration: `Feature047_OnboardingWizard` (2026-05-07) + pending `feat222_NarrativeSeedIndexingFields`
+
+---
+
+## 1. Entities
+
+### 1.1 `OrganizationDocumentTemplate`
+
+Tenant-scoped entity that tracks uploaded document templates (SSP, SAR, SAP, etc.) stored in Azure Blob Storage.
+
+| Property | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `Id` | `Guid` | No | `Guid.NewGuid()` | Primary key |
+| `TenantId` | `Guid` | No | — | Tenant partition key |
+| `TemplateType` | `TemplateType` (enum) | No | — | SSP / SAR / SAP / CRM / HwSwInventory |
+| `Label` | `string` | No | `""` | Human-readable display name |
+| `Version` | `string` | No | `""` | Free-text version string (e.g. `"v2.1"`) |
+| `OriginalFileName` | `string` | No | `""` | Filename as uploaded by user |
+| `StorageBlobKey` | `string` | No | `""` | Blob key: `wizard/templates/{tenantId}/{Id}/{filename}` |
+| `FileFormat` | `TemplateFileFormat` (enum) | No | `Docx` | `Docx` or `Xlsx` |
+| `FileSizeBytes` | `long` | No | `0` | Size at upload time |
+| `ContentChecksumSha256` | `string` | No | `""` | SHA-256 hex digest of file content |
+| `IsDefault` | `bool` | No | `false` | Whether this is the org default for its `TemplateType` |
+| `ValidationStatus` | `TemplateValidationStatus` (enum) | No | `Pending` | `Pending / Compliant / FlaggedNonCompliant` |
+| `ValidationWarnings` | `string?` | Yes | `null` | JSON-serialised `string[]` of warning messages |
+| `Status` | `TemplateStatus` (enum) | No | `Active` | `Active / Superseded / Deleted` |
+| `CreatedAt` | `DateTimeOffset` | No | `UtcNow` | Immutable creation timestamp |
+| `CreatedBy` | `Guid` | No | — | User ID of uploader |
+| `UpdatedAt` | `DateTimeOffset` | No | `UtcNow` | Last mutation timestamp |
+| `UpdatedBy` | `Guid` | No | — | User ID of last modifier |
+| `DeletedAt` | `DateTimeOffset?` | Yes | `null` | Soft-delete timestamp; `null` = not deleted |
+
+#### Enumerations
+
+```csharp
+public enum TemplateType
+{
+    Ssp = 0,
+    Sar = 1,
+    Sap = 2,
+    Crm = 3,
+    HwSwInventory = 4
+}
+
+public enum TemplateFileFormat
+{
+    Docx = 0,
+    Xlsx = 1
+}
+
+public enum TemplateValidationStatus
+{
+    Pending            = 0,
+    Compliant          = 1,
+    FlaggedNonCompliant = 2
+}
+
+public enum TemplateStatus
+{
+    Active     = 0,
+    Superseded = 1,
+    Deleted    = 2
+}
+```
+
+---
+
+### 1.2 `NarrativeSeedDocument`
+
+Tenant-scoped entity that tracks uploaded narrative-seed documents indexed for AI-assisted narrative generation. Backed by an `EvidenceArtifact` (Feature 038) and an optional indexing job.
+
+| Property | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `Id` | `Guid` | No | `Guid.NewGuid()` | Primary key |
+| `TenantId` | `Guid` | No | — | Tenant partition key |
+| `Label` | `string` | No | `""` | Human-readable display name |
+| `Tags` | `string` | No | `"[]"` | JSON-serialised `string[]` of tags |
+| `EvidenceArtifactId` | `Guid` | No | — | FK → `EvidenceArtifact.Id` (Feature 038) |
+| `IndexingStatus` | `NarrativeSeedIndexingStatus` (enum) | No | `Pending` | `Pending / Indexed / Failed` |
+| `IndexJobId` | `Guid?` | Yes | `null` | FK → `WizardJobStatus.Id` |
+| `IndexedAt` | `DateTime?` | Yes | `null` | UTC completion time of successful index run *(migration feat222)* |
+| `IndexedChunkCount` | `int?` | Yes | `null` | Number of content chunks produced *(migration feat222)* |
+| `IndexingError` | `string?` | Yes | `null` | Last error message on failure *(migration feat222)* |
+| `Status` | `NarrativeSeedStatus` (enum) | No | `Active` | `Active / Deleted` |
+| `CreatedAt` | `DateTimeOffset` | No | `UtcNow` | Immutable creation timestamp |
+| `CreatedBy` | `Guid` | No | — | User ID who uploaded the seed |
+| `UpdatedAt` | `DateTimeOffset` | No | `UtcNow` | Last mutation timestamp |
+| `UpdatedBy` | `Guid` | No | — | User ID of last modifier |
+| `DeletedAt` | `DateTimeOffset?` | Yes | `null` | Soft-delete timestamp |
+
+#### Enumerations
+
+```csharp
+public enum NarrativeSeedIndexingStatus
+{
+    Pending = 0,
+    Indexed = 1,
+    Failed  = 2
+}
+
+public enum NarrativeSeedStatus
+{
+    Active  = 0,
+    Deleted = 1
+}
+```
+
+---
+
+## 2. EF Core `OnModelCreating` Configuration
+
+```csharp
+// OrganizationDocumentTemplate
+modelBuilder.Entity<OrganizationDocumentTemplate>(entity =>
+{
+    entity.HasKey(e => e.Id);
+
+    entity.HasIndex(e => e.TenantId);
+
+    // Filtered unique index — enforces "at most one default per (TenantId, TemplateType)"
+    entity.HasIndex(e => new { e.TenantId, e.TemplateType })
+          .HasFilter("[IsDefault] = 1")
+          .IsUnique()
+          .HasDatabaseName("UX_OrgDocTemplate_TenantType_Default");
+
+    entity.Property(e => e.Label).HasMaxLength(256).IsRequired();
+    entity.Property(e => e.Version).HasMaxLength(64).IsRequired();
+    entity.Property(e => e.OriginalFileName).HasMaxLength(512).IsRequired();
+    entity.Property(e => e.StorageBlobKey).HasMaxLength(1024).IsRequired();
+    entity.Property(e => e.ContentChecksumSha256).HasMaxLength(64).IsRequired();
+    entity.Property(e => e.ValidationWarnings).HasMaxLength(8000);
+
+    entity.Property(e => e.TemplateType).HasConversion<int>();
+    entity.Property(e => e.FileFormat).HasConversion<int>();
+    entity.Property(e => e.ValidationStatus).HasConversion<int>();
+    entity.Property(e => e.Status).HasConversion<int>();
+
+    // Global query filter — exclude soft-deleted rows by default
+    entity.HasQueryFilter(e => e.DeletedAt == null);
+});
+
+// NarrativeSeedDocument
+modelBuilder.Entity<NarrativeSeedDocument>(entity =>
+{
+    entity.HasKey(e => e.Id);
+
+    entity.HasIndex(e => e.TenantId);
+    entity.HasIndex(e => e.EvidenceArtifactId);
+    entity.HasIndex(e => e.IndexJobId);
+
+    entity.Property(e => e.Label).HasMaxLength(256).IsRequired();
+    entity.Property(e => e.Tags).HasMaxLength(4000).IsRequired();
+    entity.Property(e => e.IndexingError).HasMaxLength(4000);
+
+    entity.Property(e => e.IndexingStatus).HasConversion<int>();
+    entity.Property(e => e.Status).HasConversion<int>();
+
+    // Relationships
+    entity.HasOne<EvidenceArtifact>()
+          .WithMany()
+          .HasForeignKey(e => e.EvidenceArtifactId)
+          .OnDelete(DeleteBehavior.Restrict);
+
+    entity.HasOne<WizardJobStatus>()
+          .WithMany()
+          .HasForeignKey(e => e.IndexJobId)
+          .OnDelete(DeleteBehavior.SetNull)
+          .IsRequired(false);
+
+    // Global query filter — exclude soft-deleted rows by default
+    entity.HasQueryFilter(e => e.DeletedAt == null);
+});
+```
+
+---
+
+## 3. Migration SQL (UP only)
+
+### 3.1 `Feature047_OnboardingWizard` — base tables
+
+```sql
+-- OrganizationDocumentTemplates
+CREATE TABLE [dbo].[OrganizationDocumentTemplates] (
+    [Id]                    UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
+    [TenantId]              UNIQUEIDENTIFIER NOT NULL,
+    [TemplateType]          INT              NOT NULL,
+    [Label]                 NVARCHAR(256)    NOT NULL,
+    [Version]               NVARCHAR(64)     NOT NULL,
+    [OriginalFileName]      NVARCHAR(512)    NOT NULL,
+    [StorageBlobKey]        NVARCHAR(1024)   NOT NULL,
+    [FileFormat]            INT              NOT NULL DEFAULT 0,
+    [FileSizeBytes]         BIGINT           NOT NULL DEFAULT 0,
+    [ContentChecksumSha256] NVARCHAR(64)     NOT NULL DEFAULT '',
+    [IsDefault]             BIT              NOT NULL DEFAULT 0,
+    [ValidationStatus]      INT              NOT NULL DEFAULT 0,
+    [ValidationWarnings]    NVARCHAR(8000)   NULL,
+    [Status]                INT              NOT NULL DEFAULT 0,
+    [CreatedAt]             DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
+    [CreatedBy]             UNIQUEIDENTIFIER NOT NULL,
+    [UpdatedAt]             DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
+    [UpdatedBy]             UNIQUEIDENTIFIER NOT NULL,
+    [DeletedAt]             DATETIMEOFFSET   NULL,
+    CONSTRAINT [PK_OrganizationDocumentTemplates] PRIMARY KEY ([Id])
+);
+
+CREATE INDEX [IX_OrgDocTemplate_TenantId]
+    ON [dbo].[OrganizationDocumentTemplates] ([TenantId]);
+
+-- Filtered unique index: only one default per (TenantId, TemplateType)
+CREATE UNIQUE INDEX [UX_OrgDocTemplate_TenantType_Default]
+    ON [dbo].[OrganizationDocumentTemplates] ([TenantId], [TemplateType])
+    WHERE [IsDefault] = 1;
+
+-- NarrativeSeedDocuments
+CREATE TABLE [dbo].[NarrativeSeedDocuments] (
+    [Id]               UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
+    [TenantId]         UNIQUEIDENTIFIER NOT NULL,
+    [Label]            NVARCHAR(256)    NOT NULL,
+    [Tags]             NVARCHAR(4000)   NOT NULL DEFAULT '[]',
+    [EvidenceArtifactId] UNIQUEIDENTIFIER NOT NULL,
+    [IndexingStatus]   INT              NOT NULL DEFAULT 0,
+    [IndexJobId]       UNIQUEIDENTIFIER NULL,
+    [Status]           INT              NOT NULL DEFAULT 0,
+    [CreatedAt]        DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
+    [CreatedBy]        UNIQUEIDENTIFIER NOT NULL,
+    [UpdatedAt]        DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
+    [UpdatedBy]        UNIQUEIDENTIFIER NOT NULL,
+    [DeletedAt]        DATETIMEOFFSET   NULL,
+    CONSTRAINT [PK_NarrativeSeedDocuments] PRIMARY KEY ([Id]),
+    CONSTRAINT [FK_NarrativeSeed_EvidenceArtifact]
+        FOREIGN KEY ([EvidenceArtifactId]) REFERENCES [dbo].[EvidenceArtifacts]([Id])
+        ON DELETE NO ACTION,
+    CONSTRAINT [FK_NarrativeSeed_WizardJobStatus]
+        FOREIGN KEY ([IndexJobId]) REFERENCES [dbo].[WizardJobStatuses]([Id])
+        ON DELETE SET NULL
+);
+
+CREATE INDEX [IX_NarrativeSeed_TenantId]
+    ON [dbo].[NarrativeSeedDocuments] ([TenantId]);
+
+CREATE INDEX [IX_NarrativeSeed_EvidenceArtifactId]
+    ON [dbo].[NarrativeSeedDocuments] ([EvidenceArtifactId]);
+
+CREATE INDEX [IX_NarrativeSeed_IndexJobId]
+    ON [dbo].[NarrativeSeedDocuments] ([IndexJobId]);
+```
+
+### 3.2 `feat222_NarrativeSeedIndexingFields` — pending migration (3 columns)
+
+```sql
+-- Adds indexing-detail columns to NarrativeSeedDocuments
+ALTER TABLE [dbo].[NarrativeSeedDocuments]
+    ADD [IndexedAt]        DATETIME2        NULL,
+        [IndexedChunkCount] INT             NULL,
+        [IndexingError]    NVARCHAR(4000)   NULL;
+```
+
+> ⚠️ **Action required:** This migration has NOT yet been applied to any environment. Run it before enabling the narrative-seed admin UI in production.
+
+---
+
+## 4. Invariants & Business Rules
+
+| # | Rule | Enforcement |
+|---|---|---|
+| INV-1 | At most **one** `IsDefault = true` per `(TenantId, TemplateType)` pair | Filtered unique DB index `UX_OrgDocTemplate_TenantType_Default` |
+| INV-2 | Default template cannot be directly deleted — must demote (`DELETE /{id}/default/clear`) first | HTTP 409 `TEMPLATE_DEFAULT_PROTECTED` from backend handler |
+| INV-3 | File format must be `.docx` or `.xlsx`; anything else is rejected | HTTP 415 `TEMPLATE_WRONG_FORMAT` at upload endpoint |
+| INV-4 | File size limit enforced at upload; oversized files return 413 `TEMPLATE_TOO_LARGE` | Backend middleware / endpoint guard |
+| INV-5 | `NarrativeSeedDocument` deletion that would orphan active citations requires `?confirmCitations=true` | HTTP 409 `WIZARD_NARRATIVE_SEED_HAS_CITATIONS` |
+| INV-6 | Blob storage key is immutable after creation: `wizard/templates/{tenantId}/{Id}/{filename}` | Server-generated; never client-supplied |
+| INV-7 | `NarrativeSeedDocument.Tags` is always a valid JSON string array (never `null`) | Default `"[]"`; backend validates JSON structure |
+| INV-8 | `ContentChecksumSha256` is computed server-side on every upload/replace — not provided by client | Computed in upload handler using SHA-256 |
+| INV-9 | All soft-deleted rows are excluded from default EF queries via `HasQueryFilter` | Global query filter; `includeDeleted=true` ignores filter |
+| INV-10 | Endpoint group requires `OnboardingAdministratorRequirement` policy — no access for non-admin roles | HTTP 403 `AUTH_FORBIDDEN` |
+
+---
+
+## 5. Storage Layout
+
+```
+Azure Blob Storage container: [wizard-artifacts]
+└── wizard/
+    └── templates/
+        └── {tenantId}/           ← GUID (Tenant)
+            └── {templateId}/     ← GUID (OrganizationDocumentTemplate.Id)
+                └── {filename}    ← OriginalFileName (e.g., "FY26-SSP-Template-v2.docx")
+```
+
+Narrative seed file blobs follow the `EvidenceArtifact` storage pattern defined in Feature 038 (not duplicated here).
+
+---
+
+*Last updated: 2026-06-18 | Spec: 068-org-template-admin | Epic: #222*

--- a/specs/068-org-template-admin/plan.md
+++ b/specs/068-org-template-admin/plan.md
@@ -1,0 +1,197 @@
+# Implementation Plan — Spec 068: Org Templates & Narrative Seed Admin UI
+
+> Epic: #222 | Dependencies: Feature047_OnboardingWizard (base tables), Feature 038 (EvidenceArtifact)
+> Owner: TBD | Target: Sprint following epic #222 kickoff
+
+---
+
+## Prerequisites (must be satisfied before Phase 1)
+
+| # | Prerequisite | Status | Owner |
+|---|---|---|---|
+| P1 | `Feature047_OnboardingWizard` migration applied to all target environments | ✅ Done (2026-05-07) | Infra |
+| P2 | `feat222_NarrativeSeedIndexingFields` migration written and reviewed | ⚠️ Pending | Backend |
+| P3 | `TemplatesAdminPage.tsx` untracked file committed to feature branch | ⚠️ Pending | Frontend |
+| P4 | `OnboardingAdministratorRequirement` policy confirmed active in all envs | ✅ Done (Feature047) | Backend |
+| P5 | Azure Blob Storage container `wizard-artifacts` provisioned | ✅ Done (Feature047) | Infra |
+
+---
+
+## Phase 0 — Database Migration & Schema Gate
+
+**Goal:** Apply the pending `feat222_NarrativeSeedIndexingFields` migration so all three new columns exist in every environment before UI code ships.
+
+### Steps
+
+| Step | Action | File(s) | Notes |
+|---|---|---|---|
+| 0.1 | Create EF migration `feat222_NarrativeSeedIndexingFields` if not already generated | `Migrations/feat222_NarrativeSeedIndexingFields.cs` | Adds `IndexedAt`, `IndexedChunkCount`, `IndexingError` to `NarrativeSeedDocuments` |
+| 0.2 | Add `OnModelCreating` configuration for the three new nullable columns | `AppDbContext.cs` | See data-model.md §2 |
+| 0.3 | Run migration in `dev` environment and verify columns present | — | `dotnet ef database update` |
+| 0.4 | Add migration to CI pipeline gate — block deploy if migration pending | `deploy.yml` / `ci.yml` | Fail build if unapplied migrations detected |
+| 0.5 | Run migration in `staging` | — | Coordinate with Infra |
+
+**Phase 0 Gate Criteria:**
+- `dotnet ef migrations list` shows `feat222_NarrativeSeedIndexingFields` as `[Applied]` in dev
+- No EF runtime errors querying `NarrativeSeedDocuments` with the new columns projected
+
+---
+
+## Phase 1 — Backend: Templates API Hardening & Tests
+
+**Goal:** Verify all 9 template endpoints behave correctly end-to-end; add missing unit/integration tests.
+
+### Steps
+
+| Step | Action | File(s) | Notes |
+|---|---|---|---|
+| 1.1 | Review existing endpoint handlers for `GET /`, `POST /upload`, `GET /{id}`, `PATCH /{id}`, `DELETE /{id}` | `TemplateEndpoints.cs` (or equivalent) | Confirm response shapes match spec |
+| 1.2 | Verify `DELETE /{id}` returns `409 TEMPLATE_DEFAULT_PROTECTED` when `IsDefault=true` | `TemplateEndpoints.cs` | Add guard if missing |
+| 1.3 | Verify `POST /{id}/replace` sets old record to `Status=Superseded` and creates new record | `TemplateEndpoints.cs` | Returns `{ template, dependentsFlagged }` |
+| 1.4 | Verify `POST /{id}/default` enforces filtered unique index (demotes previous default if present) | `TemplateEndpoints.cs` | Must handle concurrent requests safely |
+| 1.5 | Verify `DELETE /{id}/default/clear` sets `IsDefault=false` and returns `204` | `TemplateEndpoints.cs` | — |
+| 1.6 | Verify `GET /{id}/download` returns file stream with `Content-Disposition: attachment; filename="{OriginalFileName}"` | `TemplateEndpoints.cs` | — |
+| 1.7 | Add integration tests for all template endpoints | `TemplateEndpoints.Tests.cs` | Cover happy path + all 4 error codes |
+| 1.8 | Add unit test for SHA-256 checksum computation on upload | `TemplateUploadService.Tests.cs` | — |
+
+**Phase 1 Gate Criteria:**
+- All 9 template endpoint integration tests pass
+- Error codes `TEMPLATE_WRONG_FORMAT`, `TEMPLATE_TOO_LARGE`, `TEMPLATE_DEFAULT_PROTECTED` each have a covering test
+- `POST /upload` and `POST /{id}/replace` both set `ContentChecksumSha256` correctly
+
+---
+
+## Phase 2 — Backend: Narrative Seeds API Hardening & Tests
+
+**Goal:** Verify the 3 seed endpoints and the background indexing handler; add tests.
+
+### Steps
+
+| Step | Action | File(s) | Notes |
+|---|---|---|---|
+| 2.1 | Review `POST /api/onboarding/narrative-seeds` — confirm 202 response with `{ document, jobId }` | `NarrativeSeedEndpoints.cs` | Verify `EvidenceArtifact` is created atomically |
+| 2.2 | Review `GET /api/onboarding/narrative-seeds` — confirm `includeDeleted=false` always (no param) | `NarrativeSeedEndpoints.cs` | Soft-deleted seeds must not appear |
+| 2.3 | Review `DELETE /{id}` — confirm `409 WIZARD_NARRATIVE_SEED_HAS_CITATIONS` when `confirmCitations=false` and citations exist | `NarrativeSeedEndpoints.cs` | Add guard if missing |
+| 2.4 | Review `NarrativeSeedIndexJobHandler.cs` — stub currently only transitions `Pending → Indexed` | `NarrativeSeedIndexJobHandler.cs` | Document stub behaviour in code comment; no AI logic yet |
+| 2.5 | Update `NarrativeSeedIndexJobHandler.cs` to populate `IndexedAt`, `IndexedChunkCount` (stub values: `DateTime.UtcNow`, `0`) | `NarrativeSeedIndexJobHandler.cs` | Requires Phase 0 migration columns |
+| 2.6 | Add integration tests for all 3 seed endpoints | `NarrativeSeedEndpoints.Tests.cs` | Cover 202, 204, 409 citation guard, 404 |
+| 2.7 | Add unit test for indexing handler state transition | `NarrativeSeedIndexJobHandler.Tests.cs` | — |
+
+**Phase 2 Gate Criteria:**
+- All 3 seed endpoint integration tests pass
+- `IndexedAt` and `IndexedChunkCount` are populated (with stub values) after handler runs
+- `DELETE` without `confirmCitations=true` correctly returns `409` when citations exist
+
+---
+
+## Phase 3 — Frontend: Route Registration & API Client
+
+**Goal:** Wire `TemplatesAdminPage.tsx` into the React Router and add all API client methods.
+
+### Steps
+
+| Step | Action | File(s) | Notes |
+|---|---|---|---|
+| 3.1 | Commit `TemplatesAdminPage.tsx` from untracked to feature branch | `src/features/onboarding/pages/TemplatesAdminPage.tsx` | Pre-existing; just needs a `git add` |
+| 3.2 | Add route entry for `/admin/templates` pointing to `TemplatesAdminPage` | Router config file (e.g., `AppRoutes.tsx` or `router.ts`) | Must be inside admin-guard route group |
+| 3.3 | Add template API methods to `onboardingApi.ts` | `src/features/onboarding/api/onboardingApi.ts` | `listTemplates`, `uploadTemplate`, `getTemplate`, `updateTemplate`, `deleteTemplate`, `downloadTemplate`, `replaceTemplate`, `setDefaultTemplate`, `clearDefaultTemplate` |
+| 3.4 | Add seed API methods to `onboardingApi.ts` | `src/features/onboarding/api/onboardingApi.ts` | `listNarrativeSeeds`, `createNarrativeSeed`, `deleteNarrativeSeed` |
+| 3.5 | Add TypeScript types for all request/response shapes | `src/features/onboarding/types/templateTypes.ts` (new file) | `OrganizationDocumentTemplate`, `NarrativeSeedDocument`, `TemplateUploadResponse`, `SeedCreateResponse` |
+| 3.6 | Verify route appears in admin navigation sidebar / breadcrumb | Sidebar component | — |
+
+**Phase 3 Gate Criteria:**
+- `/admin/templates` route resolves to `TemplatesAdminPage` in browser
+- `listTemplates` API call succeeds against local backend
+- TypeScript compiles with zero new errors
+
+---
+
+## Phase 4 — Frontend: UI Component Implementation
+
+**Goal:** Implement the full admin UI within `TemplatesAdminPage.tsx` for both tabs.
+
+### Document Templates Tab
+
+| Step | Action | Notes |
+|---|---|---|
+| 4.1 | Render templates list table: columns = Label, Type, Version, Format, Size, Status, IsDefault, ValidationStatus, Actions | Group by `TemplateType` or use filter dropdown |
+| 4.2 | Upload dialog: `templateType`, `label`, `version`, `isDefault` checkbox, file picker (`.docx`/`.xlsx` only) | Show `warnings[]` inline after upload |
+| 4.3 | Edit dialog (PATCH): `label`, `version` editable only | Inline form or modal |
+| 4.4 | Delete action: disabled if `IsDefault=true` — show tooltip "Demote from default first" | Call `DELETE /{id}` |
+| 4.5 | Set Default / Clear Default actions | Buttons in row actions |
+| 4.6 | Replace file action: file picker + optional new version string | Shows `dependentsFlagged` count in confirmation |
+| 4.7 | Download button: triggers browser download via `GET /{id}/download` | — |
+
+### Narrative Seeds Tab
+
+| Step | Action | Notes |
+|---|---|---|
+| 4.8 | Render seeds list table: columns = Label, Tags, IndexingStatus, IndexedAt, ChunkCount, Status, Actions | `IndexedAt` / `ChunkCount` blank until indexed |
+| 4.9 | Upload dialog: `label` (required), `tags` (chip input), file picker | Show 202 toast with jobId; display `Pending` status immediately |
+| 4.10 | Polling / refresh: auto-refresh seed list every 10 s while any seed has `IndexingStatus=Pending` | Or use job-status endpoint |
+| 4.11 | Delete action: if `confirmCitations=false` triggers 409 → surface "This seed has active citations — confirm?" dialog → retry with `confirmCitations=true` | Two-step flow per R6 |
+
+**Phase 4 Gate Criteria:**
+- All 7 template actions functional end-to-end (upload, list, edit, delete, set-default, clear-default, replace, download)
+- All 3 seed actions functional end-to-end (upload, list, delete with citation confirmation)
+- No accessibility (a11y) regressions in admin layout
+
+---
+
+## Phase 5 — Integration Testing & Regression
+
+**Goal:** End-to-end validation across backend + frontend; regression coverage.
+
+| Step | Action | Notes |
+|---|---|---|
+| 5.1 | Run full onboarding E2E suite against `staging` with new routes | Playwright or Cypress |
+| 5.2 | Verify `OnboardingAdministratorRequirement` policy blocks non-admin users at `/admin/templates` | Test with non-admin JWT |
+| 5.3 | Verify `403 AUTH_FORBIDDEN` surfaced as user-friendly error in UI | — |
+| 5.4 | Verify filtered unique index collision is handled gracefully (not exposed as raw 500) | Attempt concurrent `POST /{id}/default` on two different templates |
+| 5.5 | Load test: upload 10 MB `.docx` template file — verify no timeout, correct `FileSizeBytes`, correct SHA-256 | Manual or k6 |
+| 5.6 | Accessibility audit on `TemplatesAdminPage` | axe-core or Lighthouse |
+
+**Phase 5 Gate Criteria:**
+- All E2E tests pass in `staging`
+- Security policy blocking verified for non-admin role
+- No P1/P2 bugs open against 068 features
+
+---
+
+## Phase 6 — Documentation & SDK Completeness
+
+| Step | Action | Notes |
+|---|---|---|
+| 6.1 | Verify all 5 SDK spec files present: `data-model.md`, `research.md`, `plan.md`, `quickstart.md`, `checklists/requirements.md` | This spec |
+| 6.2 | Update CHANGELOG / release notes for Epic #222 | — |
+| 6.3 | Update API reference docs with new endpoints (if auto-generated from OpenAPI, verify Swagger annotations) | — |
+| 6.4 | Mark spec 068 as `status: complete` in spec registry | `specs/registry.md` or equivalent |
+
+---
+
+## Dependency Graph
+
+```
+Feature047 (done) ──► Phase 0 (migration) ──► Phase 2 (seeds backend)
+                  │                        └──► Phase 4 (seeds UI tab)
+                  └──► Phase 1 (templates backend) ──► Phase 3 (route + API client)
+                                                    └──► Phase 4 (templates UI tab)
+Phase 3 + Phase 4 ──► Phase 5 (E2E + regression)
+Phase 5 ──► Phase 6 (docs + SDK)
+```
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `feat222_NarrativeSeedIndexingFields` migration not applied before UI ships | Medium | High — runtime EF errors | Phase 0 gate + CI migration check |
+| Concurrent `POST /{id}/default` causes duplicate default | Low | Medium | Filtered unique index catches race; application guard reduces UX confusion |
+| `NarrativeSeedIndexJobHandler` stub misleads users ("Indexed" ≠ truly indexed) | Medium | Medium | UI badge/tooltip clarifies "stub indexing" until AI is injected |
+| Large file uploads time out through API proxy | Low | Medium | Increase proxy timeout; consider chunked upload in follow-on spec |
+| `TemplatesAdminPage.tsx` untracked file diverges from backend API contract | Low | High | Commit file immediately in Phase 3, Step 3.1 before further work |
+
+---
+
+*Last updated: 2026-06-18 | Spec: 068-org-template-admin | Epic: #222*

--- a/specs/068-org-template-admin/quickstart.md
+++ b/specs/068-org-template-admin/quickstart.md
@@ -1,0 +1,386 @@
+# Quickstart — Spec 068: Org Templates & Narrative Seed Admin UI
+
+> Epic: #222 | This guide gets a developer running the full feature locally in under 30 minutes.
+> Prerequisite knowledge: Basic familiarity with ASP.NET Core Minimal APIs, Entity Framework Core, and React/TypeScript.
+
+---
+
+## 1. Prerequisites
+
+| Tool | Minimum Version | Check command |
+|---|---|---|
+| .NET SDK | 8.0 | `dotnet --version` |
+| Node.js | 20 LTS | `node --version` |
+| npm | 10+ | `npm --version` |
+| SQL Server / LocalDB | 2019+ or LocalDB v16 | `sqllocaldb info` |
+| Azure CLI (optional, for real blob) | 2.50+ | `az --version` |
+| Azurite (local blob emulator) | 3.28+ | `azurite --version` |
+
+> **Tip:** Use Azurite instead of a real Azure Storage account for local development. All blob operations work identically.
+
+---
+
+## 2. Environment Setup
+
+### 2.1 Clone and branch
+
+```bash
+git clone https://github.com/azurenoops/ato-copilot.git
+cd ato-copilot
+git checkout -b feat/068-org-template-admin origin/main
+```
+
+### 2.2 Restore backend dependencies
+
+```bash
+cd src/Ato.Copilot.Api
+dotnet restore
+```
+
+### 2.3 Restore frontend dependencies
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm install
+```
+
+### 2.4 Configure local secrets
+
+Copy the local dev settings template (do **not** commit real secrets):
+
+```bash
+cd src/Ato.Copilot.Api
+cp appsettings.Development.json.example appsettings.Development.json
+```
+
+Set the blob storage connection string to point at Azurite:
+
+```json
+// appsettings.Development.json (relevant excerpt)
+{
+  "AzureStorage": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "TemplatesContainer": "wizard-artifacts"
+  }
+}
+```
+
+### 2.5 Start Azurite (blob emulator)
+
+In a separate terminal:
+
+```bash
+azurite --silent --location ./tmp/azurite --debug ./tmp/azurite/debug.log
+```
+
+Create the required container:
+
+```bash
+az storage container create \
+  --name wizard-artifacts \
+  --connection-string "UseDevelopmentStorage=true"
+```
+
+---
+
+## 3. Database Setup
+
+### 3.1 Apply all migrations (including the pending feat222 migration)
+
+```bash
+cd src/Ato.Copilot.Api
+dotnet ef database update
+```
+
+Expected output should include:
+
+```
+Applying migration 'Feature047_OnboardingWizard'...
+Applying migration 'feat222_NarrativeSeedIndexingFields'...
+Done.
+```
+
+> ⚠️ If `feat222_NarrativeSeedIndexingFields` does not appear, generate it first:
+> ```bash
+> dotnet ef migrations add feat222_NarrativeSeedIndexingFields
+> dotnet ef database update
+> ```
+
+### 3.2 Verify schema
+
+Connect to LocalDB and confirm the columns exist:
+
+```sql
+-- Run in SSMS or sqlcmd against (localdb)\MSSQLLocalDB
+SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_NAME = 'NarrativeSeedDocuments'
+ORDER BY ORDINAL_POSITION;
+```
+
+Expected columns include: `IndexedAt`, `IndexedChunkCount`, `IndexingError` (all nullable).
+
+Also verify the filtered unique index:
+
+```sql
+SELECT name, filter_definition
+FROM sys.indexes
+WHERE name = 'UX_OrgDocTemplate_TenantType_Default';
+-- Expected: filter_definition = '([IsDefault]=(1))'
+```
+
+---
+
+## 4. Running the Backend
+
+### 4.1 Start the API
+
+```bash
+cd src/Ato.Copilot.Api
+dotnet run --launch-profile Development
+```
+
+API will be available at: `https://localhost:7001` (or check `launchSettings.json`).
+
+### 4.2 Verify the template endpoints are registered
+
+```bash
+curl -s https://localhost:7001/api/onboarding/templates \
+  -H "Authorization: Bearer <your-dev-jwt>" | jq .
+```
+
+Expected: `[]` (empty list) or existing templates.
+
+To get a dev JWT, use the Swagger UI at `https://localhost:7001/swagger` → Authorize with the dev identity provider configured in `appsettings.Development.json`.
+
+### 4.3 Verify the narrative seed endpoints
+
+```bash
+curl -s https://localhost:7001/api/onboarding/narrative-seeds \
+  -H "Authorization: Bearer <your-dev-jwt>" | jq .
+```
+
+Expected: `[]` (empty list).
+
+---
+
+## 5. Running the Frontend
+
+### 5.1 Start the dev server
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm run dev
+```
+
+Dashboard will be available at: `http://localhost:5173` (or as configured in `vite.config.ts`).
+
+### 5.2 Verify the route is registered
+
+Navigate to: `http://localhost:5173/admin/templates`
+
+Expected: `TemplatesAdminPage` renders with two tabs — **Document Templates** and **Narrative Seeds**.
+
+> **If you see a 404 route:** `TemplatesAdminPage.tsx` may not yet be registered in the router.
+> Add the route entry per plan.md Phase 3, Step 3.2.
+
+### 5.3 Verify the API proxy
+
+The Vite dev server should proxy `/api/*` to the backend. Check `vite.config.ts`:
+
+```typescript
+// Expected proxy config
+server: {
+  proxy: {
+    '/api': {
+      target: 'https://localhost:7001',
+      changeOrigin: true,
+      secure: false,
+    },
+  },
+},
+```
+
+---
+
+## 6. Feature-Specific Verification Steps
+
+### 6.1 Upload a document template
+
+```bash
+# Upload a test .docx template
+curl -s -X POST https://localhost:7001/api/onboarding/templates/upload \
+  -H "Authorization: Bearer <your-dev-jwt>" \
+  -F "templateType=Ssp" \
+  -F "label=Test SSP Template" \
+  -F "version=v1.0" \
+  -F "isDefault=false" \
+  -F "file=@/path/to/test-template.docx" | jq .
+```
+
+Expected: `201 Created` with body:
+```json
+{
+  "template": {
+    "id": "<guid>",
+    "label": "Test SSP Template",
+    "version": "v1.0",
+    "templateType": "Ssp",
+    "fileFormat": "Docx",
+    "validationStatus": "Pending",
+    "isDefault": false,
+    "status": "Active",
+    ...
+  },
+  "warnings": []
+}
+```
+
+### 6.2 Set a template as default
+
+```bash
+TEMPLATE_ID="<guid-from-step-6.1>"
+curl -s -X POST "https://localhost:7001/api/onboarding/templates/${TEMPLATE_ID}/default" \
+  -H "Authorization: Bearer <your-dev-jwt>" | jq .isDefault
+# Expected: true
+```
+
+### 6.3 Verify default-protection on delete
+
+```bash
+curl -s -X DELETE "https://localhost:7001/api/onboarding/templates/${TEMPLATE_ID}" \
+  -H "Authorization: Bearer <your-dev-jwt>" -w "\nHTTP %{http_code}"
+# Expected: HTTP 409
+# Body should contain error code: TEMPLATE_DEFAULT_PROTECTED
+```
+
+### 6.4 Clear default and then delete
+
+```bash
+# Clear default first
+curl -s -X DELETE "https://localhost:7001/api/onboarding/templates/${TEMPLATE_ID}/default/clear" \
+  -H "Authorization: Bearer <your-dev-jwt>" -w "\nHTTP %{http_code}"
+# Expected: HTTP 204
+
+# Now delete
+curl -s -X DELETE "https://localhost:7001/api/onboarding/templates/${TEMPLATE_ID}" \
+  -H "Authorization: Bearer <your-dev-jwt>" -w "\nHTTP %{http_code}"
+# Expected: HTTP 204
+```
+
+### 6.5 Upload a narrative seed
+
+```bash
+curl -s -X POST https://localhost:7001/api/onboarding/narrative-seeds \
+  -H "Authorization: Bearer <your-dev-jwt>" \
+  -F "label=My Seed Document" \
+  -F "tags=[\"security\",\"access-control\"]" \
+  -F "file=@/path/to/seed.docx" | jq .
+```
+
+Expected: `202 Accepted` with body:
+```json
+{
+  "document": {
+    "id": "<guid>",
+    "label": "My Seed Document",
+    "indexingStatus": "Pending",
+    "status": "Active",
+    ...
+  },
+  "jobId": "<guid>"
+}
+```
+
+### 6.6 Verify blob storage
+
+Check Azurite storage explorer or CLI to confirm the blob was written:
+
+```bash
+az storage blob list \
+  --container-name wizard-artifacts \
+  --prefix "wizard/templates/" \
+  --connection-string "UseDevelopmentStorage=true" \
+  --output table
+```
+
+Expected: One blob entry per uploaded template, with the path format `wizard/templates/{tenantId}/{templateId}/{filename}`.
+
+### 6.7 Verify access control (non-admin user)
+
+```bash
+curl -s https://localhost:7001/api/onboarding/templates \
+  -H "Authorization: Bearer <non-admin-dev-jwt>" -w "\nHTTP %{http_code}"
+# Expected: HTTP 403
+# Body should contain error code: AUTH_FORBIDDEN
+```
+
+---
+
+## 7. Running Tests
+
+### 7.1 Backend unit + integration tests
+
+```bash
+cd src/Ato.Copilot.Api.Tests
+dotnet test --filter "Category=Templates|Category=NarrativeSeeds" --logger "console;verbosity=normal"
+```
+
+### 7.2 Frontend component tests
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npm run test -- --testPathPattern="TemplatesAdmin|NarrativeSeeds"
+```
+
+### 7.3 End-to-end tests (Playwright)
+
+```bash
+cd src/Ato.Copilot.Dashboard
+npx playwright test --grep "@templates-admin" --headed
+```
+
+> Requires the backend to be running (Step 4.1) and Azurite to be running (Step 2.5).
+
+---
+
+## 8. Common Issues & Fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `SqlException: Invalid column name 'IndexedAt'` | `feat222_NarrativeSeedIndexingFields` migration not applied | Run `dotnet ef database update` (§3.1) |
+| `404` on `/admin/templates` route | Route not registered in React Router | Add route entry per plan.md Phase 3, Step 3.2 |
+| `403 AUTH_FORBIDDEN` on all template endpoints | Dev JWT does not have `OnboardingAdministrator` role claim | Use admin-scoped dev identity or add role claim to dev IdP config |
+| Upload returns `415 TEMPLATE_WRONG_FORMAT` | File is not `.docx` or `.xlsx` | Use a proper Office document for testing |
+| Upload returns `413 TEMPLATE_TOO_LARGE` | File exceeds size limit | Use a smaller test file; check `MaxFileSizeMb` config |
+| Blob not found after upload | Azurite not running or container missing | Start Azurite and create `wizard-artifacts` container (§2.5) |
+| `UX_OrgDocTemplate_TenantType_Default` unique constraint violation | Two concurrent requests both set `IsDefault=true` | Application guard should catch this first; check handler concurrency logic |
+| Narrative seed stuck at `Pending` | `NarrativeSeedIndexJobHandler` not running | Ensure background service is registered in `Program.cs`; check job queue |
+
+---
+
+## 9. Useful Dev Shortcuts
+
+```bash
+# Watch backend + auto-rebuild
+dotnet watch run --project src/Ato.Copilot.Api
+
+# Watch frontend
+cd src/Ato.Copilot.Dashboard && npm run dev
+
+# Reset DB and reapply all migrations
+dotnet ef database drop --force && dotnet ef database update
+
+# List all registered API endpoints (requires .NET 8 endpoint listing)
+curl -s https://localhost:7001/api/debug/routes | grep onboarding | sort
+
+# Check blob storage contents
+az storage blob list \
+  --container-name wizard-artifacts \
+  --connection-string "UseDevelopmentStorage=true" \
+  --output table
+```
+
+---
+
+*Last updated: 2026-06-18 | Spec: 068-org-template-admin | Epic: #222*

--- a/specs/068-org-template-admin/research.md
+++ b/specs/068-org-template-admin/research.md
@@ -1,0 +1,165 @@
+# Research — Spec 068: Org Templates & Narrative Seed Admin UI
+
+> Epic: #222 | Research decisions recorded here are binding for implementation in plan.md.
+> Format: `R<N>` — numbered decisions, each with alternatives considered and rationale.
+
+---
+
+## R1 — Single `TemplatesAdminPage.tsx` vs. Separate Page per Entity
+
+**Decision:** Use a single tabbed `TemplatesAdminPage.tsx` (already written as an untracked file) containing both the Document Templates tab and the Narrative Seeds tab.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Single page with two tabs — `/admin/templates` renders both panels |
+| B | Two distinct routes: `/admin/templates` and `/admin/narrative-seeds` |
+| C | Inline both panels on the existing Onboarding Settings page |
+
+**Rationale:** Both entities are administered by the same `OnboardingAdministrator` role, are conceptually related (content used by the Onboarding Wizard), and benefit from shared navigation context. Keeping them on one route reduces route-registration overhead (one entry in the router) and simplifies the breadcrumb hierarchy. Option B was rejected because it fragments a cohesive admin surface. Option C was rejected because the Settings page already has an unrelated concern scope.
+
+---
+
+## R2 — File Upload Strategy: Multipart/Form-Data vs. Presigned URL
+
+**Decision:** Use server-side multipart/form-data upload through the API (`POST /api/onboarding/templates/upload`). The server streams the file to Blob Storage, computes the SHA-256 checksum, and persists the `OrganizationDocumentTemplate` row atomically.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Multipart through API — server owns storage key generation and checksum |
+| B | Client obtains presigned SAS URL from API, uploads directly to Blob, then calls API to register |
+| C | Base64-encoded JSON body (rejected immediately — impractical for binary files) |
+
+**Rationale:** Option A keeps the `StorageBlobKey` and `ContentChecksumSha256` server-generated and never client-supplied (see INV-6 and INV-8 in data-model.md), which prevents tampering with storage paths. Option B would require a two-phase protocol and would complicate rollback if the registration call fails after the blob is already written. The additional round-trip latency of Option A is acceptable for infrequent admin uploads.
+
+---
+
+## R3 — Default-Template Invariant Enforcement: DB vs. Application Layer
+
+**Decision:** Enforce the "at most one default per `(TenantId, TemplateType)`" invariant at the database layer via a filtered unique index (`UX_OrgDocTemplate_TenantType_Default`), and additionally guard at the application layer in the `POST /{id}/default` handler.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Filtered unique DB index + application-layer guard |
+| B | Application-layer only (serialised via distributed lock / optimistic concurrency) |
+| C | DB index only, no application guard |
+
+**Rationale:** The filtered unique index is the authoritative enforcement point and prevents race conditions from concurrent requests without requiring distributed locking. The application guard provides a clean 409 error response before the DB constraint fires, improving developer experience. Option B alone is fragile under concurrent writes. Option C alone produces an opaque DB error that is difficult to surface as a user-friendly API error code.
+
+---
+
+## R4 — Soft Delete vs. Hard Delete for Templates and Seeds
+
+**Decision:** Both entities use soft delete (`DeletedAt` timestamp, `Status = Deleted`). Hard physical deletion from the database is not performed via the admin API. Blob Storage objects are **not** immediately deleted on soft-delete — a separate cleanup process (out of scope for this spec) handles orphaned blobs.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Soft delete only; blob GC deferred |
+| B | Immediate hard delete from DB + immediate blob deletion |
+| C | Hard DB delete; blob retention policy handles blob cleanup asynchronously |
+
+**Rationale:** Soft delete preserves audit history and allows recovery if a template is accidentally removed. Immediate blob deletion (Option B) risks data loss on accidental delete before the UI has a confirmation flow. Option C loses the audit trail. The EF global query filter (`HasQueryFilter(e => e.DeletedAt == null)`) ensures soft-deleted rows are invisible to standard queries without code changes at each call site.
+
+---
+
+## R5 — Narrative Seed Indexing: Synchronous vs. Asynchronous
+
+**Decision:** Narrative seed ingestion is asynchronous. `POST /api/onboarding/narrative-seeds` returns `202 Accepted` immediately with `{ document, jobId }`. The actual indexing is performed by `NarrativeSeedIndexJobHandler.cs` (a background job). The UI polls or relies on job-status endpoints for completion.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Async — 202 + jobId; background handler transitions Pending → Indexed |
+| B | Synchronous — wait for indexing to complete before returning 201 |
+| C | Fire-and-forget with webhook callback to client |
+
+**Rationale:** Document indexing (chunking, embedding) is CPU/IO-intensive and can take seconds to minutes for large documents. Option B would result in long-running HTTP requests with timeout risk and poor UX. Option C requires client infrastructure not present. The job-status pattern (`WizardJobStatus`) is already established in Feature047 and reused here for consistency.
+
+**Current limitation:** `NarrativeSeedIndexJobHandler.cs` is a **stub** — it only transitions `Pending → Indexed` without actual AI/embedding logic. Real AI injection is deferred to a follow-on feature. The admin UI should reflect `IndexingStatus` accurately but users should be aware that "Indexed" currently means "processed by stub" not "semantically indexed."
+
+---
+
+## R6 — Citation-Safe Deletion of Narrative Seeds
+
+**Decision:** Deleting a `NarrativeSeedDocument` that has active citations requires the caller to explicitly pass `?confirmCitations=true`. Without it, the backend returns `409 WIZARD_NARRATIVE_SEED_HAS_CITATIONS`. The UI surfaces a two-step confirmation dialog.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Query-param confirmation gate; 409 without it |
+| B | Always allow delete; citations become orphaned (data integrity risk) |
+| C | Block delete entirely if citations exist; require citation cleanup first |
+
+**Rationale:** Option A balances safety with administrator flexibility — admins can force-delete if they knowingly accept the citation impact. Option B produces silent data corruption. Option C is too restrictive and may trap admins who cannot easily identify and remove all citations first. The query-param pattern is RESTful and avoids an additional "check citations" endpoint.
+
+---
+
+## R7 — Validation Warnings on Template Upload
+
+**Decision:** The upload endpoint performs server-side structural validation of the uploaded template and returns a `warnings` array in the 201 response body alongside the `template` object. Warnings do not block the upload — they are informational. The `ValidationStatus` transitions to `Compliant` (no warnings) or `FlaggedNonCompliant` (warnings present).
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Non-blocking warnings; status reflects compliance; warnings returned in response |
+| B | Blocking validation — reject non-compliant templates with 422 |
+| C | No server-side validation; trust caller to upload valid templates |
+
+**Rationale:** Template compliance (e.g., presence of required bookmarks, placeholder fields) is a best-effort check. Blocking on warnings (Option B) would prevent admins from uploading partially compliant templates that are still usable. Option C gives up any quality signal. Warnings stored as JSON in `ValidationWarnings` are surfaced in the admin UI so admins can see and act on issues without being blocked.
+
+---
+
+## R8 — Route Registration for `TemplatesAdminPage.tsx`
+
+**Decision:** `TemplatesAdminPage.tsx` requires only a **route registration** addition — the page component already exists as an untracked file. The route should be added to the admin section of the React Router configuration alongside other admin pages.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Add single route entry in router config; page file is ready |
+| B | Re-scaffold the page from scratch |
+| C | Embed admin UI inline in an existing page without a dedicated route |
+
+**Rationale:** Since `TemplatesAdminPage.tsx` is already written, only the router wiring is missing. Re-scaffolding (Option B) would introduce regressions. Option C degrades UX and contradicts the single-route approach decided in R1.
+
+---
+
+## R9 — API Client Location for Frontend
+
+**Decision:** All API calls for both templates and seeds are added to the **existing** `onboardingApi.ts` file at:
+`src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts`
+
+No new API client file is created.
+
+**Alternatives considered:**
+
+| Option | Notes |
+|---|---|
+| A (chosen) | Extend existing `onboardingApi.ts` |
+| B | Create `templatesAdminApi.ts` and `narrativeSeedsApi.ts` as separate files |
+| C | Use a generic `fetch` wrapper directly in component hooks |
+
+**Rationale:** Consolidating with the existing onboarding API file maintains the established feature-based API organisation pattern. Splitting (Option B) would create import complexity and require a barrel file update. Option C bypasses the RTK Query / Axios cache and retry patterns already in place.
+
+---
+
+## R10 — Pending Migration Gate (`feat222_NarrativeSeedIndexingFields`)
+
+**Decision:** The three new columns (`IndexedAt`, `IndexedChunkCount`, `IndexingError`) on `NarrativeSeedDocument` must be applied via the `feat222_NarrativeSeedIndexingFields` EF migration **before** the narrative-seed admin UI is enabled in any environment. The UI feature flag or route guard should check for the presence of these columns (or defer to environment configuration).
+
+**Rationale:** The base `Feature047_OnboardingWizard` migration does not include these columns. Deploying the UI without the migration will cause EF query failures at runtime. The migration is named and defined; it simply has not yet been applied. Implementation plan (plan.md Phase 0) lists this as a prerequisite gate.
+
+---
+
+*Last updated: 2026-06-18 | Spec: 068-org-template-admin | Epic: #222*


### PR DESCRIPTION
## Summary

Upgrades spec `068-org-template-admin` from a 2-file STUB to a full SDK-complete spec directory.

**Epic:** #222 — Org Templates & Narrative Seed Management  
**Dispatched by:** Batman strategic assessment (W10 dispatch queue P1)  
**Authored by:** Oracle

## Files Added (8 new files, 3,505 lines)

| File | Description |
|------|-------------|
| `data-model.md` | Entity property tables for `OrganizationDocumentTemplate` + `NarrativeSeedDocument`, all enums, EF `OnModelCreating` block, Migration SQL UP (`Feature047_OnboardingWizard` + pending `feat222_NarrativeSeedIndexingFields`), 10 invariants |
| `research.md` | 10 numbered decisions (R1–R10): page layout, upload strategy, default invariant enforcement, soft-delete policy, async indexing, citation-safe deletion, validation warnings, route registration, API client consolidation, migration gate |
| `plan.md` | 7-phase implementation sequence (Phase 0–6), per-phase gate criteria, dependency diagram, 5-risk register |
| `quickstart.md` | Dev prerequisites, env setup (Azurite, secrets), schema verification SQL, 7 curl verification commands, test commands, 8-row common issues table |
| `contracts/http-api.md` | All 12 endpoints (9 template + 3 seed) — full URL, auth, request shape, success response, error codes |
| `contracts/internal-services.md` | `IOrganizationTemplateService` (9 methods) + `INarrativeSeedDocumentService` (3 methods) — full C# signatures, XML doc comments, step-by-step implementation outlines, exception hierarchy |
| `contracts/frontend-types.md` | TypeScript enums, entity interfaces, API request/response types, all 12 `onboardingApi.ts` function signatures, 14 React component prop interfaces, utility/type-guard/FormData-builder functions |
| `checklists/requirements.md` | 70+ QA checklist items across 9 dimensions (entities, EF config, migrations, endpoints, contracts, architecture) |

## Existing Files (unchanged)

- `spec.md` — 16,269 bytes, 3 user stories, 15 FRs, edge cases, test plan, DoD
- `tasks.md` — 6,245 bytes, 24 tasks across 6 phases with issue refs (#312, #313, #314)

## Key Architecture Notes Preserved

- **Task #314 gate:** US3 (Seed → AI pipeline transparency) blocked until `NarrativeSeedIndexJobHandler` stub is resolved — not claimed as implemented
- **Untracked file pattern:** `TemplatesAdminPage.tsx` already written; scope is route registration + wiring
- **Pending migration:** `feat222_NarrativeSeedIndexingFields` required for `IndexedAt`, `IndexedChunkCount`, `IndexingError` fields