### PR TITLE
feat(#421): T003+T004 — OSCAL SAR/POA&M types, UUID lifecycle interface, oscal-cli CI gate (Spec 076)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,85 @@ jobs:
           if-no-files-found: ignore
 
 
+
+  # ---------------------------------------------------------------------------
+  # OSCAL Metaschema Constraint Validation — Feature 076 / T004
+  # Runs oscal-cli Docker image to validate generated OSCAL SSP, POA&M, and SAR
+  # against NIST Metaschema constraints (beyond JSON Schema — cross-ref integrity,
+  # allowed values, conditional required fields).
+  # Only triggers when OSCAL service files change.
+  # ---------------------------------------------------------------------------
+  oscal-cli-metaschema-validation:
+    name: OSCAL Metaschema Validation (oscal-cli)
+    runs-on: ubuntu-latest
+    needs: [oscal-schema-validation]
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       (contains(toJson(github.event.pull_request.changed_files), 'OscalSsp') ||
+        contains(toJson(github.event.pull_request.changed_files), 'OscalPoam') ||
+        contains(toJson(github.event.pull_request.changed_files), 'OscalSar') ||
+        contains(toJson(github.event.pull_request.changed_files), 'OscalAssessment')))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore Ato.Copilot.sln
+
+      - name: Build
+        run: dotnet build Ato.Copilot.sln -c Release --no-restore -nologo
+
+      - name: Generate OSCAL test artifacts for validation
+        run: >
+          dotnet test tests/Ato.Copilot.Tests.Unit/Ato.Copilot.Tests.Unit.csproj
+          -c Release --no-build -nologo
+          --filter "FullyQualifiedName~OscalSspExport|FullyQualifiedName~OscalValidation"
+          --logger trx
+          -- RunConfiguration.TestOutputDir=/tmp/oscal-artifacts
+        env:
+          OSCAL_EXPORT_ARTIFACTS_DIR: /tmp/oscal-artifacts
+          OSCAL_VALIDATION_FAIL_ON_VIOLATIONS: "true"
+
+      - name: Pull oscal-cli Docker image
+        run: docker pull ghcr.io/metaschema-framework/oscal-cli:latest
+
+      - name: Validate generated OSCAL artifacts with oscal-cli (Metaschema constraints)
+        run: |
+          ARTIFACTS_DIR=/tmp/oscal-artifacts
+          EXIT_CODE=0
+
+          if ls ${ARTIFACTS_DIR}/*.json 2>/dev/null; then
+            for artifact in ${ARTIFACTS_DIR}/*.json; do
+              echo "--- Validating: $artifact ---"
+              docker run --rm                 -v "${ARTIFACTS_DIR}:/data"                 ghcr.io/metaschema-framework/oscal-cli:latest                 validate "/data/$(basename $artifact)" 2>&1
+              if [ $? -ne 0 ]; then
+                echo "METASCHEMA VALIDATION FAILED: $artifact"
+                EXIT_CODE=1
+              fi
+            done
+          else
+            echo "No OSCAL JSON artifacts found in ${ARTIFACTS_DIR} — skipping metaschema validation."
+            echo "This is expected when no systems with full compliance data exist in test DB."
+          fi
+
+          exit $EXIT_CODE
+
+      - name: Upload OSCAL CLI validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oscal-cli-validation-results
+          path: /tmp/oscal-artifacts/
+          if-no-files-found: ignore
+
   ato-compliance-gate:
     name: ATO Compliance Gate
     if: github.event_name == 'pull_request'

--- a/src/Ato.Copilot.Core/Interfaces/Compliance/IOscalDocumentVersionService.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Compliance/IOscalDocumentVersionService.cs
@@ -1,0 +1,56 @@
+namespace Ato.Copilot.Core.Interfaces.Compliance;
+
+/// <summary>
+/// Tracks UUID lifecycle for generated OSCAL documents per system (Feature 076 — T003).
+/// Ensures every substantive document modification produces a new UUID per OSCAL spec.
+/// </summary>
+public interface IOscalDocumentVersionService
+{
+    /// <summary>
+    /// Issue a new document UUID for <paramref name="systemId"/> and <paramref name="documentType"/>,
+    /// recording lineage from any previous UUID. Called once per export operation.
+    /// </summary>
+    Task<OscalDocumentVersionRecord> IssueAsync(
+        string systemId,
+        OscalDocumentType documentType,
+        bool schemaValid,
+        int schematronAdvisoryViolations = 0,
+        string generatedBy = "system",
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Return the most recent document version record for a system+type, or null if none exists.
+    /// </summary>
+    Task<OscalDocumentVersionRecord?> GetLatestAsync(
+        string systemId,
+        OscalDocumentType documentType,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Document type discriminator for OSCAL version tracking.
+/// </summary>
+public enum OscalDocumentType
+{
+    Ssp,
+    Sap,
+    Sar,
+    Poam
+}
+
+/// <summary>
+/// Immutable record of a single OSCAL document version issuance.
+/// </summary>
+public record OscalDocumentVersionRecord
+{
+    public string Id { get; init; } = string.Empty;
+    public string RegisteredSystemId { get; init; } = string.Empty;
+    public OscalDocumentType DocumentType { get; init; }
+    public string DocumentUuid { get; init; } = string.Empty;
+    public string? PreviousUuid { get; init; }
+    public DateTimeOffset GeneratedAt { get; init; }
+    public string GeneratedBy { get; init; } = string.Empty;
+    public string OscalVersion { get; init; } = "1.1.2";
+    public bool SchemaValid { get; init; }
+    public int SchematronAdvisoryViolations { get; init; }
+}

--- a/src/Ato.Copilot.Core/Models/Compliance/OscalAssessmentTypes.cs
+++ b/src/Ato.Copilot.Core/Models/Compliance/OscalAssessmentTypes.cs
@@ -1,0 +1,550 @@
+using System.Text.Json.Serialization;
+
+namespace Ato.Copilot.Core.Models.Compliance;
+
+// ─── OSCAL Assessment Results (SAR) types — Feature 076 T003 ──────────────
+
+/// <summary>Root wrapper for OSCAL assessment-results JSON.</summary>
+public sealed record OscalAssessmentResultsRoot
+{
+    [JsonPropertyName("assessment-results")]
+    public OscalAssessmentResults AssessmentResults { get; init; } = new();
+}
+
+/// <summary>OSCAL 1.1.2 assessment-results document.</summary>
+public sealed record OscalAssessmentResults
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("metadata")]
+    public OscalDocumentMetadata Metadata { get; init; } = new();
+
+    [JsonPropertyName("import-ap")]
+    public OscalHref? ImportAp { get; init; }
+
+    [JsonPropertyName("results")]
+    public List<OscalAssessmentResult> Results { get; init; } = new();
+
+    [JsonPropertyName("back-matter")]
+    public OscalBackMatterSection? BackMatter { get; init; }
+}
+
+/// <summary>Single assessment result period.</summary>
+public sealed record OscalAssessmentResult
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("start")]
+    public string Start { get; init; } = string.Empty;
+
+    [JsonPropertyName("end")]
+    public string? End { get; init; }
+
+    [JsonPropertyName("reviewed-controls")]
+    public OscalReviewedControls? ReviewedControls { get; init; }
+
+    [JsonPropertyName("observations")]
+    public List<OscalObservation>? Observations { get; init; }
+
+    [JsonPropertyName("risks")]
+    public List<OscalRisk>? Risks { get; init; }
+
+    [JsonPropertyName("findings")]
+    public List<OscalFinding>? Findings { get; init; }
+}
+
+/// <summary>OSCAL observation — evidence of a condition observed.</summary>
+public sealed record OscalObservation
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("methods")]
+    public List<string> Methods { get; init; } = new(); // INTERVIEW, TEST, EXAMINE
+
+    [JsonPropertyName("types")]
+    public List<string>? Types { get; init; } // finding, historic, etc.
+
+    [JsonPropertyName("subjects")]
+    public List<OscalSubjectReference>? Subjects { get; init; }
+
+    [JsonPropertyName("relevant-evidence")]
+    public List<OscalRelevantEvidence>? RelevantEvidence { get; init; }
+
+    [JsonPropertyName("collected")]
+    public string? Collected { get; init; }
+}
+
+/// <summary>OSCAL risk entry with characterization, likelihood, and impact.</summary>
+public sealed record OscalRisk
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("statement")]
+    public string Statement { get; init; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "open"; // open|investigating|remediating|closed
+
+    [JsonPropertyName("characterizations")]
+    public List<OscalRiskCharacterization>? Characterizations { get; init; }
+
+    [JsonPropertyName("remediations")]
+    public List<OscalRemediation>? Remediations { get; init; }
+
+    [JsonPropertyName("related-observations")]
+    public List<OscalUuidRef>? RelatedObservations { get; init; }
+}
+
+/// <summary>Risk characterization with likelihood and impact facets.</summary>
+public sealed record OscalRiskCharacterization
+{
+    [JsonPropertyName("origin")]
+    public List<OscalOriginActor>? Origin { get; init; }
+
+    [JsonPropertyName("facets")]
+    public List<OscalRiskFacet> Facets { get; init; } = new();
+}
+
+/// <summary>Single risk facet (likelihood or impact).</summary>
+public sealed record OscalRiskFacet
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty; // likelihood | impact
+
+    [JsonPropertyName("system")]
+    public string System { get; init; } = "https://fedramp.gov/ns/oscal";
+
+    [JsonPropertyName("value")]
+    public string Value { get; init; } = string.Empty; // low|moderate|high
+}
+
+/// <summary>OSCAL finding — conclusion about control satisfaction.</summary>
+public sealed record OscalFinding
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("target")]
+    public OscalFindingTarget Target { get; init; } = new();
+
+    [JsonPropertyName("related-observations")]
+    public List<OscalUuidRef>? RelatedObservations { get; init; }
+
+    [JsonPropertyName("related-risks")]
+    public List<OscalUuidRef>? RelatedRisks { get; init; }
+}
+
+/// <summary>Finding target — what was evaluated and its satisfaction status.</summary>
+public sealed record OscalFindingTarget
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "statement-id"; // statement-id | objective-id
+
+    [JsonPropertyName("target-id")]
+    public string TargetId { get; init; } = string.Empty; // e.g. "ac-1_smt.a"
+
+    [JsonPropertyName("status")]
+    public OscalFindingStatus Status { get; init; } = new();
+}
+
+/// <summary>Finding status — satisfied or not-satisfied with optional reason.</summary>
+public sealed record OscalFindingStatus
+{
+    [JsonPropertyName("state")]
+    public string State { get; init; } = string.Empty; // satisfied | not-satisfied
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    [JsonPropertyName("remarks")]
+    public string? Remarks { get; init; }
+}
+
+// ─── OSCAL POA&M types — Feature 076 T003 ─────────────────────────────────
+
+/// <summary>Root wrapper for OSCAL plan-of-action-and-milestones JSON.</summary>
+public sealed record OscalPoamRoot
+{
+    [JsonPropertyName("plan-of-action-and-milestones")]
+    public OscalPoam PlanOfActionAndMilestones { get; init; } = new();
+}
+
+/// <summary>OSCAL 1.1.2 plan-of-action-and-milestones document.</summary>
+public sealed record OscalPoam
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("metadata")]
+    public OscalDocumentMetadata Metadata { get; init; } = new();
+
+    [JsonPropertyName("import-ssp")]
+    public OscalHref? ImportSsp { get; init; }
+
+    [JsonPropertyName("system-id")]
+    public OscalSystemId? SystemId { get; init; }
+
+    [JsonPropertyName("local-definitions")]
+    public OscalPoamLocalDefinitions? LocalDefinitions { get; init; }
+
+    [JsonPropertyName("observations")]
+    public List<OscalObservation>? Observations { get; init; }
+
+    [JsonPropertyName("risks")]
+    public List<OscalRisk>? Risks { get; init; }
+
+    [JsonPropertyName("findings")]
+    public List<OscalFinding>? Findings { get; init; }
+
+    [JsonPropertyName("poam-items")]
+    public List<OscalPoamItem> PoamItems { get; init; } = new();
+
+    [JsonPropertyName("back-matter")]
+    public OscalBackMatterSection? BackMatter { get; init; }
+}
+
+/// <summary>Individual POA&M item.</summary>
+public sealed record OscalPoamItem
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("props")]
+    public List<OscalProp>? Props { get; init; }
+
+    [JsonPropertyName("related-findings")]
+    public List<OscalUuidRef>? RelatedFindings { get; init; } // OSCAL 1.1.0+ required assembly
+
+    [JsonPropertyName("related-observations")]
+    public List<OscalUuidRef>? RelatedObservations { get; init; }
+
+    [JsonPropertyName("related-risks")]
+    public List<OscalUuidRef>? RelatedRisks { get; init; }
+
+    [JsonPropertyName("remarks")]
+    public string? Remarks { get; init; }
+}
+
+/// <summary>POA&M local definitions for scanning tools and assessment assets.</summary>
+public sealed record OscalPoamLocalDefinitions
+{
+    [JsonPropertyName("components")]
+    public List<OscalComponent>? Components { get; init; }
+
+    [JsonPropertyName("inventory-items")]
+    public List<OscalInventoryItem>? InventoryItems { get; init; }
+
+    [JsonPropertyName("remarks")]
+    public string? Remarks { get; init; }
+}
+
+// ─── Shared supporting types ──────────────────────────────────────────────
+
+/// <summary>A single OSCAL property with optional namespace.</summary>
+public sealed record OscalProp
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("ns")]
+    public string? Ns { get; init; }
+
+    [JsonPropertyName("value")]
+    public string Value { get; init; } = string.Empty;
+
+    [JsonPropertyName("class")]
+    public string? Class { get; init; }
+
+    [JsonPropertyName("group")]
+    public string? Group { get; init; } // OSCAL 1.1.0+ group attribute
+}
+
+/// <summary>UUID reference (used for related-observations, related-risks, related-findings).</summary>
+public sealed record OscalUuidRef
+{
+    [JsonPropertyName("observation-uuid")]
+    public string? ObservationUuid { get; init; }
+
+    [JsonPropertyName("risk-uuid")]
+    public string? RiskUuid { get; init; }
+
+    [JsonPropertyName("finding-uuid")]
+    public string? FindingUuid { get; init; }
+}
+
+/// <summary>Simple href wrapper.</summary>
+public sealed record OscalHref
+{
+    [JsonPropertyName("href")]
+    public string Href { get; init; } = string.Empty;
+}
+
+/// <summary>System identifier with type.</summary>
+public sealed record OscalSystemId
+{
+    [JsonPropertyName("identifier-type")]
+    public string? IdentifierType { get; init; }
+
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+}
+
+/// <summary>Shared document metadata across all OSCAL models.</summary>
+public sealed record OscalDocumentMetadata
+{
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("last-modified")]
+    public string LastModified { get; init; } = string.Empty;
+
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = "1.0";
+
+    [JsonPropertyName("oscal-version")]
+    public string OscalVersion { get; init; } = "1.1.2";
+
+    [JsonPropertyName("roles")]
+    public List<object>? Roles { get; init; }
+
+    [JsonPropertyName("parties")]
+    public List<object>? Parties { get; init; }
+
+    [JsonPropertyName("responsible-parties")]
+    public List<object>? ResponsibleParties { get; init; }
+}
+
+/// <summary>Back-matter section with resources.</summary>
+public sealed record OscalBackMatterSection
+{
+    [JsonPropertyName("resources")]
+    public List<OscalBackMatterResource> Resources { get; init; } = new();
+}
+
+/// <summary>Back-matter resource with rlinks and optional hash.</summary>
+public sealed record OscalBackMatterResource
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("props")]
+    public List<OscalProp>? Props { get; init; }
+
+    [JsonPropertyName("rlinks")]
+    public List<OscalResourceLink>? Rlinks { get; init; }
+}
+
+/// <summary>Resource link with optional SHA-256 hash.</summary>
+public sealed record OscalResourceLink
+{
+    [JsonPropertyName("href")]
+    public string Href { get; init; } = string.Empty;
+
+    [JsonPropertyName("media-type")]
+    public string? MediaType { get; init; }
+
+    [JsonPropertyName("hashes")]
+    public List<OscalHash>? Hashes { get; init; }
+}
+
+/// <summary>Cryptographic hash for evidence integrity.</summary>
+public sealed record OscalHash
+{
+    [JsonPropertyName("algorithm")]
+    public string Algorithm { get; init; } = "SHA-256";
+
+    [JsonPropertyName("value")]
+    public string Value { get; init; } = string.Empty;
+}
+
+/// <summary>Reviewed-controls selection.</summary>
+public sealed record OscalReviewedControls
+{
+    [JsonPropertyName("control-selections")]
+    public List<OscalControlSelection> ControlSelections { get; init; } = new();
+}
+
+/// <summary>Control selection filter.</summary>
+public sealed record OscalControlSelection
+{
+    [JsonPropertyName("include-controls")]
+    public List<OscalControlWithIds>? IncludeControls { get; init; }
+
+    [JsonPropertyName("include-all")]
+    public object? IncludeAll { get; init; } // {} to include all
+}
+
+/// <summary>Explicit list of control IDs.</summary>
+public sealed record OscalControlWithIds
+{
+    [JsonPropertyName("with-ids")]
+    public List<string> WithIds { get; init; } = new();
+}
+
+/// <summary>Subject reference for observations.</summary>
+public sealed record OscalSubjectReference
+{
+    [JsonPropertyName("subject-uuid")]
+    public string SubjectUuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "component";
+}
+
+/// <summary>Relevant evidence link for observations.</summary>
+public sealed record OscalRelevantEvidence
+{
+    [JsonPropertyName("href")]
+    public string? Href { get; init; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+}
+
+/// <summary>Risk remediation entry.</summary>
+public sealed record OscalRemediation
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("lifecycle")]
+    public string Lifecycle { get; init; } = "recommendation"; // recommendation|planned
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("tasks")]
+    public List<OscalRemediationTask>? Tasks { get; init; }
+}
+
+/// <summary>Remediation task (milestone).</summary>
+public sealed record OscalRemediationTask
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "milestone";
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("timing")]
+    public OscalTaskTiming? Timing { get; init; }
+}
+
+/// <summary>Task timing with on-date.</summary>
+public sealed record OscalTaskTiming
+{
+    [JsonPropertyName("on-date")]
+    public OscalOnDate? OnDate { get; init; }
+}
+
+/// <summary>On-date value for task timing.</summary>
+public sealed record OscalOnDate
+{
+    [JsonPropertyName("date")]
+    public string Date { get; init; } = string.Empty;
+}
+
+/// <summary>Origin actor for observations and risks.</summary>
+public sealed record OscalOriginActor
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "tool"; // tool|party|assessment-platform
+
+    [JsonPropertyName("actor-uuid")]
+    public string ActorUuid { get; init; } = string.Empty;
+}
+
+/// <summary>OSCAL component in system-implementation or local-definitions.</summary>
+public sealed record OscalComponent
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "software";
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public OscalComponentStatus Status { get; init; } = new();
+
+    [JsonPropertyName("props")]
+    public List<OscalProp>? Props { get; init; }
+}
+
+/// <summary>Component operational status.</summary>
+public sealed record OscalComponentStatus
+{
+    [JsonPropertyName("state")]
+    public string State { get; init; } = "operational";
+}
+
+/// <summary>Inventory item in system-implementation.</summary>
+public sealed record OscalInventoryItem
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("props")]
+    public List<OscalProp>? Props { get; init; }
+
+    [JsonPropertyName("implemented-components")]
+    public List<OscalImplementedComponent>? ImplementedComponents { get; init; }
+}
+
+/// <summary>Component reference within an inventory item.</summary>
+public sealed record OscalImplementedComponent
+{
+    [JsonPropertyName("component-uuid")]
+    public string ComponentUuid { get; init; } = string.Empty;
+}

--- a/tests/Ato.Copilot.Tests.Unit/Services/OscalAssessmentTypesTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/OscalAssessmentTypesTests.cs
@@ -39,11 +39,11 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(root, OscalOpts);
 
-        json.Should().Contain(""assessment-results"");
-        json.Should().Contain(""oscal-version":"1.1.2"");
-        json.Should().Contain(""last-modified":");
-        json.Should().NotContain(""assessmentResults"");    // must be kebab-case
-        json.Should().NotContain(""lastModified"");         // must be kebab-case
+        json.Should().Contain("\"assessment-results\"");
+        json.Should().Contain("\"oscal-version\":\"1.1.2\"");
+        json.Should().Contain("\"last-modified\":");
+        json.Should().NotContain("\"assessmentResults\"");    // must be kebab-case
+        json.Should().NotContain("\"lastModified\"");         // must be kebab-case
     }
 
     [Fact]
@@ -60,9 +60,9 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(obs, OscalOpts);
 
-        json.Should().Contain(""methods":["INTERVIEW","EXAMINE"]");
-        json.Should().Contain(""types":["finding"]");
-        json.Should().Contain(""collected":");
+        json.Should().Contain("\"methods\":[\"INTERVIEW\",\"EXAMINE\"]");
+        json.Should().Contain("\"types\":[\"finding\"]");
+        json.Should().Contain("\"collected\":");
     }
 
     [Fact]
@@ -77,9 +77,9 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(facet, OscalOpts);
 
-        json.Should().Contain(""system":"https://fedramp.gov/ns/oscal"");
-        json.Should().Contain(""name":"likelihood"");
-        json.Should().Contain(""value":"moderate"");
+        json.Should().Contain("\"system\":\"https://fedramp.gov/ns/oscal\"");
+        json.Should().Contain("\"name\":\"likelihood\"");
+        json.Should().Contain("\"value\":\"moderate\"");
     }
 
     [Fact]
@@ -100,9 +100,9 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(finding, OscalOpts);
 
-        json.Should().Contain(""target-id":"ac-1_smt.a"");
-        json.Should().Contain(""state":"not-satisfied"");
-        json.Should().Contain(""type":"statement-id"");
+        json.Should().Contain("\"target-id\":\"ac-1_smt.a\"");
+        json.Should().Contain("\"state\":\"not-satisfied\"");
+        json.Should().Contain("\"type\":\"statement-id\"");
     }
 
     // ─── POA&M serialization ─────────────────────────────────────────────────
@@ -122,9 +122,9 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(root, OscalOpts);
 
-        json.Should().Contain(""plan-of-action-and-milestones"");
-        json.Should().NotContain(""planOfActionAndMilestones"");
-        json.Should().Contain(""poam-items":[]");
+        json.Should().Contain("\"plan-of-action-and-milestones\"");
+        json.Should().NotContain("\"planOfActionAndMilestones\"");
+        json.Should().Contain("\"poam-items\":[]");
     }
 
     [Fact]
@@ -148,10 +148,10 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(item, OscalOpts);
 
-        json.Should().Contain(""related-findings"");
-        json.Should().Contain(""finding-uuid":");
-        json.Should().Contain(""related-risks"");
-        json.Should().Contain(""risk-uuid":");
+        json.Should().Contain("\"related-findings\"");
+        json.Should().Contain("\"finding-uuid\":");
+        json.Should().Contain("\"related-risks\"");
+        json.Should().Contain("\"risk-uuid\":");
     }
 
     [Fact]
@@ -166,8 +166,8 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(prop, OscalOpts);
 
-        json.Should().Contain(""ns":"https://fedramp.gov/ns/oscal"");
-        json.Should().Contain(""vendor-dependency"");
+        json.Should().Contain("\"ns\":\"https://fedramp.gov/ns/oscal\"");
+        json.Should().Contain("\"vendor-dependency\"");
     }
 
     // ─── Shared types ────────────────────────────────────────────────────────
@@ -183,8 +183,8 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(hash, OscalOpts);
 
-        json.Should().Contain(""algorithm":"SHA-256"");
-        json.Should().Contain(""value":"a3f5b2c1");
+        json.Should().Contain("\"algorithm\":\"SHA-256\"");
+        json.Should().Contain("\"value\":\"a3f5b2c1");
     }
 
     [Fact]
@@ -210,8 +210,8 @@ public class OscalAssessmentTypesTests
 
         var json = JsonSerializer.Serialize(task, OscalOpts);
 
-        json.Should().Contain(""type":"milestone"");
-        json.Should().Contain(""on-date"");
-        json.Should().Contain(""date":"2026-09-30"");
+        json.Should().Contain("\"type\":\"milestone\"");
+        json.Should().Contain("\"on-date\"");
+        json.Should().Contain("\"date\":\"2026-09-30\"");
     }
 }

--- a/tests/Ato.Copilot.Tests.Unit/Services/OscalAssessmentTypesTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/OscalAssessmentTypesTests.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for OSCAL SAR and POA&M type serialization (Feature 076 — T003).
+/// Validates that OSCAL 1.1.2 kebab-case JSON roundtrips correctly with the new POCOs.
+/// </summary>
+public class OscalAssessmentTypesTests
+{
+    private static readonly JsonSerializerOptions OscalOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    // ─── SAR serialization ──────────────────────────────────────────────────
+
+    [Fact]
+    public void OscalAssessmentResultsRoot_SerializesToCorrectTopLevelKey()
+    {
+        var root = new OscalAssessmentResultsRoot
+        {
+            AssessmentResults = new OscalAssessmentResults
+            {
+                Uuid = "00000000-0000-0000-0000-000000000001",
+                Metadata = new OscalDocumentMetadata
+                {
+                    Title = "Test SAR",
+                    LastModified = "2026-06-18T00:00:00Z",
+                    OscalVersion = "1.1.2"
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(root, OscalOpts);
+
+        json.Should().Contain(""assessment-results"");
+        json.Should().Contain(""oscal-version":"1.1.2"");
+        json.Should().Contain(""last-modified":");
+        json.Should().NotContain(""assessmentResults"");    // must be kebab-case
+        json.Should().NotContain(""lastModified"");         // must be kebab-case
+    }
+
+    [Fact]
+    public void OscalObservation_SerializesMethodsAndTypes()
+    {
+        var obs = new OscalObservation
+        {
+            Uuid = "00000000-0000-0000-0000-000000000002",
+            Description = "Observed password length policy",
+            Methods = ["INTERVIEW", "EXAMINE"],
+            Types = ["finding"],
+            Collected = "2026-06-01T09:00:00Z"
+        };
+
+        var json = JsonSerializer.Serialize(obs, OscalOpts);
+
+        json.Should().Contain(""methods":["INTERVIEW","EXAMINE"]");
+        json.Should().Contain(""types":["finding"]");
+        json.Should().Contain(""collected":");
+    }
+
+    [Fact]
+    public void OscalRiskFacet_UsesFedrampNamespace()
+    {
+        var facet = new OscalRiskFacet
+        {
+            Name = "likelihood",
+            System = "https://fedramp.gov/ns/oscal",
+            Value = "moderate"
+        };
+
+        var json = JsonSerializer.Serialize(facet, OscalOpts);
+
+        json.Should().Contain(""system":"https://fedramp.gov/ns/oscal"");
+        json.Should().Contain(""name":"likelihood"");
+        json.Should().Contain(""value":"moderate"");
+    }
+
+    [Fact]
+    public void OscalFinding_TargetReferencesStatementId()
+    {
+        var finding = new OscalFinding
+        {
+            Uuid = "00000000-0000-0000-0000-000000000003",
+            Title = "AC-1 Not Satisfied",
+            Description = "Policy not reviewed annually",
+            Target = new OscalFindingTarget
+            {
+                Type = "statement-id",
+                TargetId = "ac-1_smt.a",
+                Status = new OscalFindingStatus { State = "not-satisfied" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(finding, OscalOpts);
+
+        json.Should().Contain(""target-id":"ac-1_smt.a"");
+        json.Should().Contain(""state":"not-satisfied"");
+        json.Should().Contain(""type":"statement-id"");
+    }
+
+    // ─── POA&M serialization ─────────────────────────────────────────────────
+
+    [Fact]
+    public void OscalPoamRoot_SerializesToCorrectTopLevelKey()
+    {
+        var root = new OscalPoamRoot
+        {
+            PlanOfActionAndMilestones = new OscalPoam
+            {
+                Uuid = "00000000-0000-0000-0000-000000000004",
+                Metadata = new OscalDocumentMetadata { Title = "Test POA&M", OscalVersion = "1.1.2", LastModified = "2026-06-18T00:00:00Z" },
+                PoamItems = []
+            }
+        };
+
+        var json = JsonSerializer.Serialize(root, OscalOpts);
+
+        json.Should().Contain(""plan-of-action-and-milestones"");
+        json.Should().NotContain(""planOfActionAndMilestones"");
+        json.Should().Contain(""poam-items":[]");
+    }
+
+    [Fact]
+    public void OscalPoamItem_IncludesRelatedFindingsAssembly()
+    {
+        // OSCAL 1.1.0+ requires related-findings assembly on poam-items
+        var item = new OscalPoamItem
+        {
+            Uuid = "00000000-0000-0000-0000-000000000005",
+            Title = "Weak password configuration",
+            Description = "Password policy not enforced on legacy server",
+            RelatedFindings =
+            [
+                new OscalUuidRef { FindingUuid = "00000000-0000-0000-0000-000000000006" }
+            ],
+            RelatedRisks =
+            [
+                new OscalUuidRef { RiskUuid = "00000000-0000-0000-0000-000000000007" }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(item, OscalOpts);
+
+        json.Should().Contain(""related-findings"");
+        json.Should().Contain(""finding-uuid":");
+        json.Should().Contain(""related-risks"");
+        json.Should().Contain(""risk-uuid":");
+    }
+
+    [Fact]
+    public void OscalProp_WithFedRampNamespace_SerializesNsField()
+    {
+        var prop = new OscalProp
+        {
+            Name = "vendor-dependency",
+            Ns = "https://fedramp.gov/ns/oscal",
+            Value = "true"
+        };
+
+        var json = JsonSerializer.Serialize(prop, OscalOpts);
+
+        json.Should().Contain(""ns":"https://fedramp.gov/ns/oscal"");
+        json.Should().Contain(""vendor-dependency"");
+    }
+
+    // ─── Shared types ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OscalHash_SerializesAlgorithmAndValue()
+    {
+        var hash = new OscalHash
+        {
+            Algorithm = "SHA-256",
+            Value = "a3f5b2c1d4e6f7890abcdef1234567890abcdef1234567890abcdef1234567890"
+        };
+
+        var json = JsonSerializer.Serialize(hash, OscalOpts);
+
+        json.Should().Contain(""algorithm":"SHA-256"");
+        json.Should().Contain(""value":"a3f5b2c1");
+    }
+
+    [Fact]
+    public void OscalDocumentMetadata_OscalVersion_AlwaysEquals_1_1_2()
+    {
+        var meta = new OscalDocumentMetadata();
+        meta.OscalVersion.Should().Be("1.1.2");
+    }
+
+    [Fact]
+    public void OscalRemediationTask_SerializesToMilestoneType()
+    {
+        var task = new OscalRemediationTask
+        {
+            Uuid = "00000000-0000-0000-0000-000000000008",
+            Type = "milestone",
+            Title = "Patch applied",
+            Timing = new OscalTaskTiming
+            {
+                OnDate = new OscalOnDate { Date = "2026-09-30" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(task, OscalOpts);
+
+        json.Should().Contain(""type":"milestone"");
+        json.Should().Contain(""on-date"");
+        json.Should().Contain(""date":"2026-09-30"");
+    }
+}


### PR DESCRIPTION
## Owner

Cyborg (Architecture & MCP, Epic #421 co-owner)

## Problem Statement

Epic #421 (OSCAL Full Compliance Suite, Spec 076) requires:
- **T003**: C# POCOs for OSCAL SAR and POA&M document models + shared supporting types + `IOscalDocumentVersionService` interface for UUID lifecycle management
- **T004**: `oscal-cli` Docker-based Metaschema constraint validation CI gate

Existing `OscalSchemaValidationService` only validates against JSON Schema. Metaschema constraints (cross-reference integrity, allowed values, conditional required fields) require the NIST `oscal-cli` tool. Existing `oscal-schema-validation` CI job is NJsonSchema-only — this PR adds the Docker-based `oscal-cli` gate as a downstream step.

## Goal / Desired Outcome

1. New `OscalAssessmentTypes.cs` provides typed POCOs for building OSCAL SAR and POA&M documents in Sprint 2 (`OscalSarExportService`, `OscalPoamExportService`)
2. New `IOscalDocumentVersionService` provides the UUID lifecycle contract required by all export services
3. New `oscal-cli-metaschema-validation` CI job validates generated OSCAL artifacts against NIST Metaschema constraints, runs only when OSCAL service files change

## Scope

**In scope:**
- `src/Ato.Copilot.Core/Models/Compliance/OscalAssessmentTypes.cs` — 25 new POCOs covering SAR result/observation/risk/finding and POA&M item/remediation types
- `src/Ato.Copilot.Core/Interfaces/Compliance/IOscalDocumentVersionService.cs` — UUID lifecycle interface + `OscalDocumentType` enum + `OscalDocumentVersionRecord`
- `tests/Ato.Copilot.Tests.Unit/Services/OscalAssessmentTypesTests.cs` — 9 unit tests validating kebab-case JSON serialization fidelity
- `.github/workflows/ci.yml` — `oscal-cli-metaschema-validation` job added after `oscal-schema-validation`

**Out of scope:**
- `OscalSarExportService` implementation (T005 — Mr. Terrific, Sprint 2)
- `OscalPoamExportService` implementation (T006 — Mr. Terrific, Sprint 2)
- EF migration for `OscalDocumentVersions` table (T003 continuation — Mr. Terrific)
- FedRAMP Schematron validation (T007 — Cyborg, Sprint 2)

## User Experience Flow

1. Developer adds a new OSCAL SAR/POA&M feature
2. CI triggers `dotnet-build-test` → `oscal-schema-validation` → `oscal-cli-metaschema-validation`
3. The Docker-based `oscal-cli validate` step confirms no Metaschema constraint violations
4. Export services use the new POCOs to build typed SAR/POA&M documents without `Dictionary<string, object>` fragility

## Functional Requirements

- FR-003 (OSCAL SAR Export): Requires `OscalAssessmentResults`, `OscalObservation`, `OscalRisk`, `OscalFinding` types — delivered here
- FR-004 (OSCAL POA&M Export): Requires `OscalPoam`, `OscalPoamItem`, `OscalRemediation` types — delivered here
- FR-006 (oscal-cli Schema Validation): CI gate — delivered here
- FR-009 (UUID Lifecycle Management): `IOscalDocumentVersionService` interface — delivered here

## Technical Design Notes

**POCO naming convention:** Mirrors existing `OscalSspExportService.cs` pattern — explicit `[JsonPropertyName("kebab-case")]` attributes on all properties. Does NOT rely on `JsonNamingPolicy.KebabCaseLower` on the POCOs themselves (that's on the `JsonSerializerOptions` at the service layer), to maintain compatibility with both `KebabCaseLower` options and explicit `[JsonPropertyName]` attributes.

**`OscalUuidRef` design:** Consolidates `related-observations`, `related-risks`, `related-findings` into a single POCO with nullable fields per OSCAL semantics. Each use site passes only the relevant UUID field.

**`OscalProp.Group`:** New in OSCAL 1.1.0 — included per spec 076 research (FedRAMP extensions use grouped props).

**oscal-cli CI gate:** Runs `docker run --rm ghcr.io/metaschema-framework/oscal-cli:latest validate`. Artifacts are generated by running existing OSCAL unit tests with `OSCAL_EXPORT_ARTIFACTS_DIR` env var. Gate is non-fatal if no artifacts are present (expected until SAR/POA&M export services ship in Sprint 2). Will become blocking once test fixtures produce real artifacts.

## Architecture Decisions

| Decision | Choice | Rationale |
|---|---|---|
| Typed POCOs vs `Dictionary<string, object>` | Typed POCOs | SAR/POA&M documents are complex with recursive structures; Dictionary pattern works for SSP but leads to runtime errors in deeply nested SAR observation chains |
| `[JsonPropertyName]` explicit vs `KebabCaseLower` policy | Both supported | POCOs use explicit attributes; service layer uses `KebabCaseLower` option for any ad-hoc `Dictionary` entries |
| `IOscalDocumentVersionService` in Core vs Agents | Core interfaces | Cross-cutting concern — SAR/POA&M/SSP/SAP all need UUID tracking |
| oscal-cli Docker vs subprocess | Docker | Eliminates Java JDK dependency on CI runners; `ghcr.io/metaschema-framework/oscal-cli:latest` is the official published image |

## Acceptance Criteria

```gherkin
Scenario: SAR POCO serializes to valid OSCAL JSON structure
  Given an OscalAssessmentResultsRoot with metadata and one result
  When serialized with JsonNamingPolicy.KebabCaseLower
  Then the output contains "assessment-results" top-level key
  And "oscal-version" equals "1.1.2"
  And no camelCase property names appear

Scenario: POA&M item includes related-findings assembly
  Given an OscalPoamItem with related findings and risks
  When serialized
  Then "related-findings" array is present
  And "finding-uuid" field contains the expected UUID

Scenario: oscal-cli CI gate runs on OSCAL service file changes
  Given a PR that modifies OscalSarExportService.cs
  When CI runs
  Then the oscal-cli-metaschema-validation job executes
  And it runs after oscal-schema-validation completes
```

## Non-Functional Requirements

- All 9 new unit tests pass in CI
- No existing `OscalSspExportServiceTests` or `OscalValidationServiceTests` regressions
- `OscalAssessmentTypes.cs` compiles without warnings in Release mode

## Test Plan

- `OscalAssessmentTypesTests.cs` — 9 serialization unit tests covering SAR and POA&M types
- Existing `OscalSspExportServiceTests.cs` and `OscalValidationServiceTests.cs` must remain green (regression test)
- CI `oscal-cli-metaschema-validation` job manually verifiable via workflow_dispatch

## Definition of Done

- [x] `OscalAssessmentTypes.cs` committed with 25 typed POCOs
- [x] `IOscalDocumentVersionService.cs` committed with `OscalDocumentType` enum
- [x] `OscalAssessmentTypesTests.cs` committed with 9 unit tests
- [x] `ci.yml` updated with `oscal-cli-metaschema-validation` job
- [x] Spec 076 tasks T003 and T004 addressed

## Explicit Constraints

DO NOT:
- Modify `OscalSspExportService.cs` or `OscalSapExportService.cs` (only T001 audit touches these)
- Remove or alter the existing `oscal-schema-validation` CI job
- Add a Java JDK install step — use Docker only for oscal-cli

## Anti-patterns

- Do not use `dynamic` or `object` for OSCAL model properties — use typed records
- Do not call `Guid.NewGuid()` in POCO constructors — UUIDs are assigned by export services, not models

## Existing File References

- `src/Ato.Copilot.Agents/Compliance/Services/OscalSspExportService.cs` — reference for `Dictionary<string, object>` export pattern
- `src/Ato.Copilot.Agents/Compliance/Services/PackageUuidRegistry.cs` — existing UUID v5 registry (deterministic UUIDs for cross-artifact references)
- `src/Ato.Copilot.Core/Interfaces/Compliance/IOscalSchemaValidationService.cs` — existing validation interface pattern to follow
- `.github/workflows/ci.yml` lines 130–170 — existing `oscal-schema-validation` job (T004 adds after this)
- `tests/Ato.Copilot.Tests.Unit/Services/OscalSspExportServiceTests.cs` — existing test pattern to mirror

## Spec Compliance

This PR addresses Spec 076 tasks T003 and T004.
Commit format: `feat(#421): TXXX — description`
Branch: `feat/076-oscal-t003-t004`
