### PR TITLE
fix(#425): correct AI provider health-check endpoint (nginx + AiHealthBanner)

### DIFF
--- a/src/Ato.Copilot.Dashboard/nginx.conf
+++ b/src/Ato.Copilot.Dashboard/nginx.conf
@@ -133,6 +133,17 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Proxy MCP server health check (fix/425: AiHealthBanner uses /api/health)
+    location = /api/health {
+        proxy_pass ${MCP_BASE_URL}/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
     # Proxy MCP chat/tools endpoints (strip /api prefix — server has /mcp/*)
     location /api/mcp/ {
         rewrite ^/api/mcp/(.*)$ /mcp/$1 break;

--- a/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
@@ -28,8 +28,12 @@ export function useAiHealthCheck() {
   const check = useCallback(async (): Promise<boolean> => {
     setStatus('checking');
     try {
-      const baseUrl = import.meta.env.VITE_MCP_BASE_URL || '/api';
-      const url = `${baseUrl}/mcp/health`;
+      // fix/425: The MCP server exposes health at /health (root), not /mcp/health.
+      // nginx proxies /api/health → ${MCP_BASE_URL}/health so the dashboard can
+      // reach it without CORS issues. VITE_MCP_BASE_URL is only used in dev/vscode
+      // where the server is accessed directly; the nginx proxy is used in staging/prod.
+      const baseUrl = import.meta.env.VITE_MCP_BASE_URL || '';
+      const url = `${baseUrl}/api/health`;
       const token = await acquireBearer();
       const headers: Record<string, string> = { Accept: 'application/json' };
       if (token) headers['Authorization'] = `Bearer ${token}`;


### PR DESCRIPTION
## Problem Statement
`AiHealthBanner.tsx` checks the AI provider by probing `${VITE_MCP_BASE_URL}/mcp/health` on every chat panel open and before each send. There is no `/mcp/health` endpoint on the MCP server — health lives at root `/health`. Additionally, nginx had no proxy block for `/api/health`, so the request either returned a 404 or crossed origins. The result: the banner shows "AI provider is currently unreachable" permanently, blocking all chat functionality.

**Files affected:**
- `src/Ato.Copilot.Dashboard/nginx.conf`
- `src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx`

## Root Cause
1. Wrong path: `${VITE_MCP_BASE_URL}/mcp/health` → endpoint does not exist. Correct path: `/health` (MCP root).
2. Missing nginx proxy: no `location = /api/health {}` block existed, so the path was never forwarded to the MCP container.

## Fix
1. **nginx.conf**: Added `location = /api/health` proxy block that forwards to `${MCP_BASE_URL}/health` (the real health endpoint).
2. **AiHealthBanner.tsx**: Changed health-check URL from `${VITE_MCP_BASE_URL}/mcp/health` to `${VITE_MCP_BASE_URL}/api/health` (resolves to relative `/api/health` in production, which nginx now proxies correctly).

## Acceptance Criteria
- [ ] Opening the chat panel does NOT show "AI provider is currently unreachable" when the MCP server is healthy
- [ ] `GET /api/health` returns `200 OK` with `{"status":"healthy"}` through the nginx proxy
- [ ] Chat messages send and receive responses from the AI provider

## Test Plan
```bash
curl https://ca-ato-copilot-dashboard-st.blackwater-9393aa1a.centralus.azurecontainerapps.io/api/health
# Expected: 200 {"status":"healthy","service":"ATO Copilot MCP","version":"1.0.0"}
```

Closes #425