### PR TITLE
fix(#430): System Detail sidebar nav links don't update page content

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/layout/SystemLayout.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/layout/SystemLayout.tsx
@@ -161,7 +161,7 @@ export default function SystemLayout() {
     );
   }
 
-  const basePath = `/systems/${detail.systemId}`;
+  const basePath = `/systems/${id}`;
 
   // Count incomplete profile sections for notification badge on details tab
   const profileActionCount = profileCompleteness


### PR DESCRIPTION
## Summary
Fixes #430: System Detail sidebar nav links don't update page content.

## Root Cause
SystemLayout built `basePath` using `detail.systemId` from the API response. If the API returns a systemId that differs in format from the `id` URL parameter (e.g., UUID casing normalization), NavLink `to` values pointed to paths that didn't match the active route context, preventing client-side navigation from triggering.

## Fix
Use `id` from `useParams` for `basePath` construction. This ensures NavLinks and breadcrumbs are always anchored to the same identifier that React Router used to match the current route.

## Test Plan
- [ ] Click "Narratives" in sidebar → URL updates to /systems/:id/narratives, content changes
- [ ] Click "Capabilities" → URL updates, content changes
- [ ] Click "Control Inheritance" → URL updates, content changes
- [ ] Breadcrumb links still work

Closes #430
