### PR TITLE
fix(#435): RMF Phase Progress stepper shows steps 0-6 instead of 1-7

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/charts/RmfPhaseProgress.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/charts/RmfPhaseProgress.tsx
@@ -44,7 +44,7 @@ export default function RmfPhaseProgressComponent({ phases }: RmfPhaseProgressPr
             <div
               className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold ${circleColors[phase.status]}`}
             >
-              {phase.ordinal}
+              {phase.ordinal + 1}
             </div>
             <span className="mt-1 text-[11px] text-gray-600 text-center">{phase.phase}</span>
             {phase.status === 'current' && (


### PR DESCRIPTION
## Summary
Fixes #435: RMF Phase Progress stepper displays steps 0–6 instead of 1–7.

## Root Cause
The API returns `ordinal` values as 0-indexed integers (0–6). The component rendered the raw ordinal value, producing step labels 0–6 in the stepper circles.

## Fix
Render `phase.ordinal + 1` so labels display 1–7, matching NIST SP 800-37 Rev. 2 step numbering (Prepare=1, Categorize=2, Select=3, Implement=4, Assess=5, Authorize=6, Monitor=7).

## Test Plan
- [ ] Navigate to any System Detail page
- [ ] RMF Phase Progress stepper shows circles labeled 1–7
- [ ] "Prepare" step shows "1", "Monitor" step shows "7"

Closes #435
