### PR TITLE
fix(#434): propagate system TenantId to PoamItem — prevent cross-tenant rejection from agent scope

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/AuthorizationService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/AuthorizationService.cs
@@ -387,13 +387,30 @@ public class AuthorizationService : IAuthorizationService
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AtoCopilotContext>();
 
-        // Verify system exists
-        _ = await db.RegisteredSystems.FindAsync([systemId], cancellationToken)
+        // fix/434: Retrieve the system AND its TenantId using AsNoTracking so EF does
+        // not load navigations (ControlBaseline) into the change tracker. The
+        // TenantStampingSaveChangesInterceptor walks loaded reference navigations and
+        // rejects a PoamItem insert when the ambient ITenantContextAccessor has no
+        // active HTTP request (its EffectiveTenantId falls back to Guid.Empty /
+        // DefaultTenantId=00000000-0000-0000-0000-000000000001) while the referenced
+        // ControlBaseline carries the real user tenant id. By setting TenantId
+        // explicitly from the system record the interceptor accepts the insert without
+        // a cross-tenant FK walk.
+        var system = await db.RegisteredSystems
+            .Where(s => s.Id == systemId)
+            .Select(s => new { s.Id, s.TenantId })
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken)
             ?? throw new InvalidOperationException($"System '{systemId}' not found.");
 
         var poam = new PoamItem
         {
             RegisteredSystemId = systemId,
+            // fix/434: Stamp TenantId from the system record so the
+            // TenantStampingSaveChangesInterceptor does not fall back to the
+            // ambient (empty) scope tenant when the call originates from an
+            // agent tool rather than an HTTP request.
+            TenantId = system.TenantId,
             FindingId = findingId,
             Weakness = weakness,
             WeaknessSource = findingId != null ? "SCA Assessment" : "Manual",


### PR DESCRIPTION
## Problem Statement
All MCP write operations — `compliance_create_poam`, `compliance_write_narrative`, `compliance_set_inheritance`, `compliance_collect_evidence` — fail with a tenant mismatch error when called from the chat agent:

```
POA&M tenant:        00000000-0000-0000-0000-000000000001
ControlBaseline tenant: 5d43b3ad-3084-4d36-b4bd-64286c79ff60
```

**Files affected:** `src/Ato.Copilot.Agents/Compliance/Services/AuthorizationService.cs`

## Root Cause
`AuthorizationService.CreatePoamAsync` calls `_scopeFactory.CreateScope()` to create a new DI scope for the database context. This new scope has **no active HTTP request**, so `ITenantContextAccessor.Current` is `null`. The `TenantStampingSaveChangesInterceptor` then falls back to stamping `TenantId = Guid.Empty` which maps to `DefaultTenantId = 00000000-0000-0000-0000-000000000001`.

The interceptor then walks EF change-tracker navigations on the `PoamItem` insert, finds the `RegisteredSystem.ControlBaseline` navigation (loaded via `FindAsync`) with the real user `TenantId`, and throws `TenantConsistencyException` because `PoamItem.TenantId (00..01) != ControlBaseline.TenantId (5d43b3ad...)`.

## Fix
1. Replace `db.RegisteredSystems.FindAsync([systemId])` with an `AsNoTracking` projection that only fetches `Id` and `TenantId` — this prevents loading the `ControlBaseline` navigation into the change tracker, eliminating the FK walk that triggers the cross-tenant check.
2. Explicitly set `PoamItem.TenantId = system.TenantId` before adding to the context, providing the correct tenant rather than relying on the ambient (empty) scope.

## Acceptance Criteria
- [ ] `compliance_create_poam` succeeds for "Test System" via MCP chat
- [ ] Response contains a POA&M ID and `status: Ongoing`
- [ ] No "tenant mismatch" error in the response
- [ ] `compliance_write_narrative`, `compliance_set_inheritance`, `compliance_collect_evidence` are unblocked (same root cause)

## Test Plan
```
POST /mcp/chat
{"message": "Create a POA&M item for Test System: control AC-2, weakness: Account management process not documented, POC: John Doe, due date: 2026-09-30"}
```
Expected: POA&M created successfully with ID and Ongoing status.

Closes #434