### PR TITLE
fix(#432): add GET /api/dashboard root endpoint and nginx proxy rules

### DIFF
--- a/src/Ato.Copilot.Dashboard/nginx.conf
+++ b/src/Ato.Copilot.Dashboard/nginx.conf
@@ -16,6 +16,28 @@ server {
         proxy_ssl_server_name on;
     }
 
+    # fix/432: bare /api/dashboard (no trailing slash) and /dashboard route the
+    # same endpoint — required by Oracle E2E tests and external tooling.
+    location = /api/dashboard {
+        proxy_pass ${MCP_BASE_URL}/api/dashboard;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
+    location = /dashboard {
+        proxy_pass ${MCP_BASE_URL}/api/dashboard;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
     # Proxy v1 REST API (authorization packages, SAR endpoints)
     location /api/v1/ {
         proxy_pass ${MCP_BASE_URL};

--- a/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
@@ -36,6 +36,41 @@ public static class DashboardEndpoints
         var group = app.MapGroup("/api/dashboard")
             .WithTags("Dashboard");
 
+        // fix/432: Root /api/dashboard path redirected to metrics summary so that
+        // GET /api/dashboard and GET /dashboard (proxied via nginx) return useful
+        // data rather than 404. The dashboard UI called this path in early versions;
+        // external tooling (Playwright E2E, Oracle QA) uses it as a smoke-check.
+        group.MapGet("", async (
+                [AsParameters] PortfolioQuery query,
+                DashboardService service,
+                CancellationToken ct) =>
+            {
+                var result = await service.GetPortfolioAsync(query, ct);
+                var items = result.Items ?? [];
+                var avgCompliance = items.Count > 0
+                    ? Math.Round(items.Average(i => i.ComplianceScore), 1)
+                    : 0;
+                var configuredSystems = items.Count(i => i.IsSetupComplete);
+                var coveragePercent = items.Count > 0
+                    ? Math.Round(100.0 * configuredSystems / items.Count, 1)
+                    : (double?)null;
+                return Results.Ok(new
+                {
+                    totalSystems = result.TotalCount,
+                    avgCompliance,
+                    openPoams = items.Sum(i => i.OpenPoamCount),
+                    overduePoams = items.Sum(i => i.OverduePoamCount),
+                    catIFindings = items.Sum(i => i.CatICounts),
+                    catIIFindings = items.Sum(i => i.CatIICounts),
+                    atoAtRisk = items.Count(i =>
+                        string.Equals(i.AtoSeverity, "red", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(i.AtoSeverity, "expired", StringComparison.OrdinalIgnoreCase)),
+                    coveragePercent,
+                    _links = new { portfolio = "/api/dashboard/portfolio", metrics = "/api/dashboard/metrics" },
+                });
+            })
+            .WithName("GetDashboardRoot");
+
         // ─── Portfolio (US1) ─────────────────────────────────────────────────
         group.MapGet("/portfolio", async (
                 [AsParameters] PortfolioQuery query,


### PR DESCRIPTION
## Problem Statement
`GET /api/dashboard` and `GET /dashboard` return HTTP 404 from both the MCP server and the nginx proxy. The MCP backend only registered sub-paths (`/api/dashboard/portfolio`, `/api/dashboard/metrics`) but not the root `/api/dashboard`. nginx also lacked proxy rules for the bare paths. This affects Oracle E2E tests, Playwright smoke checks, and any external tooling that probes the dashboard URL.

**Files affected:**
- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs`
- `src/Ato.Copilot.Dashboard/nginx.conf`

## Root Cause
1. `DashboardEndpoints.MapDashboardEndpoints()` registered a `MapGroup("/api/dashboard")` but no handler for the empty path `""` — so `GET /api/dashboard` returned 404.
2. nginx had `/api/dashboard/` (with trailing slash) but not `= /api/dashboard` (exact-match, no slash) or `= /dashboard`.

## Fix
1. **DashboardEndpoints.cs**: Added `group.MapGet("")` that returns a portfolio metrics summary with HATEOAS `_links` pointing to canonical sub-routes. Identical payload shape to `/api/dashboard/metrics`.
2. **nginx.conf**: Added `location = /api/dashboard` and `location = /dashboard` exact-match proxy blocks routing to `${MCP_BASE_URL}/api/dashboard`.

## Acceptance Criteria
- [ ] `GET /api/dashboard` → `200 OK` with `{totalSystems, avgCompliance, ...}`
- [ ] `GET /dashboard` → `200 OK` (same payload via nginx proxy)
- [ ] `GET /api/dashboard/portfolio` still works (no regression)

## Test Plan
```bash
curl -s https://ca-ato-copilot-mcp-v2.blackwater-9393aa1a.centralus.azurecontainerapps.io/api/dashboard | jq .totalSystems
# Expected: 6

curl -s https://ca-ato-copilot-dashboard-st.blackwater-9393aa1a.centralus.azurecontainerapps.io/api/dashboard | jq .totalSystems
# Expected: 6 (through nginx proxy)
```

Closes #432