### PR TITLE
fix(#431): add 'Select Baseline' CTA to Narratives empty state

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/pages/Narratives.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/Narratives.tsx
@@ -613,8 +613,24 @@ export default function Narratives() {
               <tbody className="divide-y divide-gray-100">
                 {items.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-4 py-12 text-center text-gray-400">
-                      No narratives found. Select a baseline to auto-populate controls.
+                    <td colSpan={9} className="px-4 py-12 text-center">
+                      {/* fix/431: Provide actionable CTA when no baseline is configured */}
+                      <div className="flex flex-col items-center gap-3">
+                        <svg className="h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75a2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+                        </svg>
+                        <p className="text-sm font-medium text-gray-500">No narratives found.</p>
+                        <p className="text-xs text-gray-400">
+                          This system has no security baseline selected. Select a baseline in the
+                          RMF Wizard to auto-populate control narratives.
+                        </p>
+                        <a
+                          href={`/systems/${systemId}/categorize`}
+                          className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        >
+                          Select Baseline
+                        </a>
+                      </div>
                     </td>
                   </tr>
                 ) : items.map((n) => (


### PR DESCRIPTION
## Problem Statement
The Control Narratives page for Coastal Watch (and any system without a ControlBaseline) shows 0 controls with a passive message: "No narratives found. Select a baseline to auto-populate controls." There is no button to act on this guidance. Oracle E2E tests require a visible, actionable CTA button in this state.

**File affected:** `src/Ato.Copilot.Dashboard/src/pages/Narratives.tsx`

## Root Cause
`GET /api/dashboard/systems/{id}/narratives` correctly returns an empty array when no `ControlBaseline` exists for the system. The UI's empty state (`items.length === 0`) displayed only a static text message with no linked button or actionable path forward.

Note: Test System (with a baseline) shows 339 controls and narratives correctly — this is a UI-only gap, not a backend issue.

## Fix
Replaced the static empty-state `<td>` text with a structured empty state that includes:
1. An icon (document/list SVG)
2. A heading: "No narratives found."
3. Descriptive text explaining that a baseline must be selected
4. A **"Select Baseline"** CTA `<a>` button linking to `/systems/{systemId}/categorize` (the RMF Wizard categorization step)

## Acceptance Criteria
- [ ] Coastal Watch narratives page shows a "Select Baseline" button when no baseline is configured
- [ ] Clicking "Select Baseline" navigates to the categorization/RMF wizard step
- [ ] Test System narratives page still shows 339 controls (no regression)

## Test Plan
Navigate to: `/systems/92afdc15-bc6f-4648-8073-ad6af396cf97/narratives` (Coastal Watch)
Expected: Visible "Select Baseline" button in the table body

Closes #431