### PR TITLE
fix(#433): phase-aware 'In Setup' badge and 'Not Configured' impact level for early RMF phases

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/cards/SystemSummaryRow.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/cards/SystemSummaryRow.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import type { PortfolioSystemSummary } from '../../types/dashboard';
 import AtoCountdown from './AtoCountdown';
 
@@ -17,8 +18,35 @@ const rmfBadgeColor: Record<string, string> = {
   Monitor: 'bg-teal-100 text-teal-700',
 };
 
+// fix/433: Systems in early RMF phases (Prepare, Categorize) legitimately lack
+// a baseline, boundary, and role assignments. The amber "Setup Incomplete" badge
+// is misleading — these systems ARE correctly set up for their phase. We use a
+// phase-aware label: Prepare/Categorize → "Phase Setup" (informational, gray),
+// later phases → "Setup Incomplete" (amber, calls for action).
+function setupBadge(phase: string, isSetupComplete: boolean): ReactElement | null {
+  if (isSetupComplete) return null;
+  const earlyPhase = phase === 'Prepare' || phase === 'Categorize';
+  if (earlyPhase) {
+    return (
+      <span className="ml-2 inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+        In Setup
+      </span>
+    );
+  }
+  return (
+    <span className="ml-2 inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+      Setup Incomplete
+    </span>
+  );
+}
+
 export default function SystemSummaryRow({ system, onEdit }: SystemSummaryRowProps) {
   const navigate = useNavigate();
+
+  // fix/433: ImpactLevel === 'Unknown' means no baseline configured. Render
+  // 'Not Configured' to avoid confusion with a genuine data-retrieval failure.
+  const displayImpactLevel =
+    system.impactLevel === 'Unknown' ? 'Not Configured' : system.impactLevel;
 
   return (
     <tr
@@ -27,13 +55,9 @@ export default function SystemSummaryRow({ system, onEdit }: SystemSummaryRowPro
     >
       <td className="py-3 pl-4 pr-3">
         <span className="font-medium text-gray-900">{system.name}</span>
-        {system.isSetupComplete === false && (
-          <span className="ml-2 inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
-            Setup Incomplete
-          </span>
-        )}
+        {setupBadge(system.currentRmfPhase, system.isSetupComplete)}
       </td>
-      <td className="px-3 py-3 text-sm text-gray-500">{system.impactLevel}</td>
+      <td className="px-3 py-3 text-sm text-gray-500">{displayImpactLevel}</td>
       <td className="px-3 py-3">
         <span
           className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${rmfBadgeColor[system.currentRmfPhase] ?? 'bg-gray-100 text-gray-700'}`}


### PR DESCRIPTION
## Problem Statement
All 6 registered systems show "Setup Incomplete" badge on the Systems list. 5 of 6 systems show "Unknown" for Impact Level. These are systems legitimately in the Prepare phase — they haven't been categorized yet. The amber "Setup Incomplete" badge is misleading and the "Unknown" label implies a data-fetch error rather than an intentional pre-configuration state.

**File affected:** `src/Ato.Copilot.Dashboard/src/components/cards/SystemSummaryRow.tsx`

## Root Cause
1. `IsSetupComplete = HasBoundary AND HasRoles AND HasCategorization`. Systems in Prepare/Categorize phase legitimately have none of these — they're expected to not have them yet. The badge was applied uniformly without considering RMF phase context.
2. `ImpactLevel = 'Unknown'` is the DashboardService fallback when `system.ControlBaseline` is null (baseline not yet selected). "Unknown" implies an error rather than "not yet configured."

## Fix
**SystemSummaryRow.tsx:**
1. Introduced `setupBadge(phase, isSetupComplete)` helper that renders:
   - **Gray "In Setup"** for Prepare/Categorize phase systems (normal state, no action needed)
   - **Amber "Setup Incomplete"** for later phases where missing artifacts need attention
2. Map `'Unknown'` to `'Not Configured'` in `displayImpactLevel` for human-readable display (API value unchanged).

## Acceptance Criteria
- [ ] Coastal Watch, Eagle Eye, etc. in Prepare phase show gray "In Setup" badge (not amber)
- [ ] Test System in Prepare with `ImpactLevel = Moderate` shows "Moderate" correctly
- [ ] Systems with `ImpactLevel = Unknown` (no baseline) show "Not Configured" instead
- [ ] E2E test: `await expect(impactCell).not.toHaveText('Unknown')` passes for Test System

Closes #433