### PR TITLE
fix(#426,#427): add route aliases for /categorization and /control-inheritance URLs

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -110,7 +110,11 @@ function AppContent() {
             <Route path="poam" element={<PoamManagement />} />
             <Route path="capability-coverage" element={<CapabilityCoverage />} />
             <Route path="inheritance" element={<ControlInheritance />} />
+            {/* Alias: Oracle E2E tests and direct links use /control-inheritance → redirect to /inheritance */}
+            <Route path="control-inheritance" element={<Navigate to="../inheritance" replace />} />
             <Route path="baseline" element={<BaselineManagement />} />
+            {/* Alias: Oracle E2E tests and direct links use /categorization → redirect to /baseline */}
+            <Route path="categorization" element={<Navigate to="../baseline" replace />} />
             <Route path="profile/:sectionType" element={<SystemProfile />} />
             {/* Epic #121 / Task #146 — Authorization phase page */}
             <Route path="authorize" element={<AuthorizationPage />} />


### PR DESCRIPTION
## Summary
Fixes #426 and #427: white screen on Categorization and Control Inheritance pages when navigating via direct URL or E2E test harness.

## Root Cause
The sidebar nav links correctly route to `/systems/:id/baseline` (Categorization) and `/systems/:id/inheritance` (Control Inheritance). However, Oracle's E2E tests and direct URL evidence used `/systems/:id/categorization` and `/systems/:id/control-inheritance` — neither URL matched any defined child route in App.tsx, so React Router's `<Outlet>` rendered nothing (blank `<main>`).

## Fix
Add `<Navigate>` redirect routes mapping the alias URLs to the canonical routes:
- `/systems/:id/categorization` → `../baseline` (BaselineManagement page)
- `/systems/:id/control-inheritance` → `../inheritance` (ControlInheritance page)

React Router `replace` flag is set so the alias URL doesn't land in browser history.

## Test Plan
- [ ] Navigate directly to `/systems/:id/categorization` → redirects to `/systems/:id/baseline`, Categorization & Baseline page renders
- [ ] Navigate directly to `/systems/:id/control-inheritance` → redirects to `/systems/:id/inheritance`, Control Inheritance page renders
- [ ] Sidebar nav "Categorization" link still works (routes to `baseline`)
- [ ] Sidebar nav "Control Inheritance" link still works (routes to `inheritance`)
- [ ] No regression on any other system detail sub-routes

Closes #426
Closes #427
