### PR TITLE
fix(#436): add role=dialog ARIA attributes to EvidenceUploadDialog

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/EvidenceUploadDialog.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/EvidenceUploadDialog.tsx
@@ -165,8 +165,13 @@ export default function EvidenceUploadDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={handleBackdrop}>
-      <div className="absolute inset-0 bg-black/40" />
-      <div className="relative z-10 flex max-h-[90vh] w-full max-w-lg flex-col rounded-lg bg-white shadow-xl">
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+      <div
+        className="relative z-10 flex max-h-[90vh] w-full max-w-lg flex-col rounded-lg bg-white shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Upload Evidence"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b px-6 py-4">
           <h2 className="text-lg font-semibold text-gray-900">Attach Evidence</h2>


### PR DESCRIPTION
## Summary
Fixes #436: clicking "Upload Evidence" button produces no visible modal/action.

## Root Cause
`EvidenceUploadDialog` renders correctly when `showUpload` state is `true` — the conditional render logic in `EvidenceRepository` is correct. The dialog was mounting and showing visually, but it lacked `role="dialog"` and `aria-modal="true"` attributes on the modal container div. Without these ARIA attributes:
1. Playwright's `getByRole('dialog')` locator returns no match, causing E2E test failures
2. Screen readers and accessibility testing tools don't recognize the overlay as a dialog
3. The backdrop `<div>` was missing `aria-hidden="true"`, leaving it in the accessibility tree

## Fix
- Added `role="dialog"` and `aria-modal="true"` to the modal content container
- Added `aria-label="Upload Evidence"` for accessible name
- Added `aria-hidden="true"` to the backdrop overlay

## Test Plan
- [ ] Navigate to `/systems/:id/evidence`
- [ ] Click "+ Upload Evidence" button
- [ ] Upload dialog appears with file picker, category, and control fields
- [ ] `page.getByRole('dialog')` resolves in Playwright
- [ ] Clicking backdrop closes the dialog
- [ ] Clicking X button closes the dialog

Closes #436
