### PR TITLE
feat(#422): AtoPostureService + SarifParserService — Phase 2 implementation

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
@@ -1,0 +1,597 @@
+// =============================================================================
+//  SarifParserService.cs
+//  Ato.Copilot.Agents — Compliance / Services / ScanImport
+//  Issue #422 — AO Posture API (W10 cATO Gap Closure)
+//
+//  ISarifParserService implementation.
+//  3-tier CWE→NIST 800-53 mapping + CAT severity derivation + fingerprint dedup.
+//  STATELESS — registered as Singleton.
+//  No DB writes — controller/service layer owns persistence after ParseAsync returns.
+// =============================================================================
+
+#nullable enable
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Agents.Compliance.Services.ScanImport;
+
+/// <summary>
+/// Parses SARIF 2.1.0 documents into normalized <see cref="SarifFindingDto"/> records
+/// with NIST 800-53 Rev.5 control mapping and DoD CAT severity derivation.
+/// </summary>
+/// <remarks>
+/// Singleton-safe: all shared state is read-only (static maps + compiled patterns from
+/// <see cref="CweNistMappings"/> and <see cref="SarifTagPatterns"/>).
+/// </remarks>
+public sealed class SarifParserService : ISarifParserService
+{
+    private static readonly Regex CweInRuleIdPattern = new(
+        @"CWE-(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex NistControlIdPattern = new(
+        @"^[A-Z]{2}-\d+(?:\(\d+\))?$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private readonly ILogger<SarifParserService> _logger;
+
+    public SarifParserService(ILogger<SarifParserService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<SarifImportResult> ParseAsync(
+        JsonDocument sarifPayload,
+        Guid systemId,
+        string pipelineId,
+        string pipelineRun,
+        IReadOnlySet<string>? existingFingerprints = null,
+        CancellationToken cancellationToken = default)
+    {
+        var importId = Guid.NewGuid();
+
+        try
+        {
+            var root = sarifPayload.RootElement;
+
+            // Enforce SARIF 2.1.0
+            if (!root.TryGetProperty("version", out var versionEl) ||
+                versionEl.GetString() is not "2.1.0")
+            {
+                var received = root.TryGetProperty("version", out var v) ? v.GetString() : "absent";
+                throw new PayloadValidationException(
+                    $"SARIF version must be \"2.1.0\". Received: {received}");
+            }
+
+            if (!root.TryGetProperty("runs", out var runsEl) ||
+                runsEl.ValueKind != JsonValueKind.Array)
+                throw new PayloadValidationException("SARIF document missing required 'runs' array.");
+
+            var allFindings = new List<SarifFindingDto>();
+            var controlMappings = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+            var unmappedRules = new List<UnmappedRuleInfo>();
+            var parseErrors = new List<string>();
+            var fingerprintsSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var existing = existingFingerprints is null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(existingFingerprints, StringComparer.OrdinalIgnoreCase);
+
+            int findingsImported = 0;
+            int findingsDeduplicated = 0;
+
+            foreach (var run in runsEl.EnumerateArray())
+            {
+                var toolName = ExtractToolName(run);
+                var ruleMap = BuildRuleMap(run);
+
+                if (!run.TryGetProperty("results", out var resultsEl) ||
+                    resultsEl.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var result in resultsEl.EnumerateArray())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        ProcessResult(result, ruleMap, toolName, systemId, pipelineRun,
+                            fingerprintsSeen, existing, unmappedRules, controlMappings,
+                            allFindings, ref findingsImported, ref findingsDeduplicated);
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex)
+                    {
+                        var err = $"Failed to parse SARIF result: {ex.Message}";
+                        parseErrors.Add(err);
+                        _logger.LogWarning(ex,
+                            "Skipping unparseable SARIF result. Run={Run}", pipelineRun);
+                    }
+                }
+            }
+
+            return Task.FromResult(new SarifImportResult
+            {
+                ImportId = importId,
+                SystemId = systemId,
+                PipelineId = pipelineId,
+                PipelineRun = pipelineRun,
+                SarifVersion = "2.1.0",
+                FindingsImported = findingsImported,
+                FindingsDeduplicated = findingsDeduplicated,
+                Findings = allFindings,
+                ControlMappings = controlMappings,
+                UnmappedRuleCount = unmappedRules.Count,
+                UnmappedFindingCount = unmappedRules.Sum(u => u.OccurrenceCount),
+                UnmappedRules = unmappedRules,
+                ParseErrors = parseErrors,
+                ProcessedAt = DateTimeOffset.UtcNow,
+            });
+        }
+        catch (PayloadValidationException) { throw; }
+        catch (JsonException jex)
+        {
+            throw new PayloadValidationException(
+                $"SARIF payload contains invalid JSON: {jex.Message}", jex);
+        }
+    }
+
+    // ─── Per-result processor ────────────────────────────────────────────────
+
+    private void ProcessResult(
+        JsonElement result,
+        Dictionary<string, SarifRuleDescriptor> ruleMap,
+        string toolName,
+        Guid systemId,
+        string pipelineRun,
+        HashSet<string> fingerprintsSeen,
+        HashSet<string> existing,
+        List<UnmappedRuleInfo> unmappedRules,
+        Dictionary<string, IReadOnlyList<string>> controlMappings,
+        List<SarifFindingDto> allFindings,
+        ref int findingsImported,
+        ref int findingsDeduplicated)
+    {
+        var ruleId = result.TryGetProperty("ruleId", out var rid)
+            ? rid.GetString() ?? string.Empty
+            : string.Empty;
+
+        ruleMap.TryGetValue(ruleId, out var rule);
+
+        var level = GetLevel(result);
+        var securitySeverity = ParseSecuritySeverity(rule?.Properties);
+        var catTier = DeriveCategory(level, securitySeverity);
+
+        if (catTier is null) return; // Informational — discard
+
+        ExtractLocation(result, out var locationUri, out var startLine);
+        var fingerprint = ComputeFingerprint(result, systemId, ruleId, locationUri, startLine);
+
+        if (!fingerprintsSeen.Add(fingerprint))
+        {
+            findingsDeduplicated++;
+            return;
+        }
+
+        bool isNew;
+        if (existing.Contains(fingerprint))
+        {
+            isNew = false;
+            findingsDeduplicated++;
+        }
+        else
+        {
+            isNew = true;
+            findingsImported++;
+        }
+
+        var message = result.TryGetProperty("message", out var msgEl)
+            ? (msgEl.TryGetProperty("text", out var txtEl) ? txtEl.GetString() : null) ?? ruleId
+            : ruleId;
+
+        var tags = (IReadOnlyList<string>)(rule?.Tags ?? []);
+        var (nistIds, cweIds, _) = ResolveNistControls(ruleId, rule, toolName);
+
+        if (nistIds.Count == 0)
+        {
+            TrackUnmappedRule(ruleId, toolName, pipelineRun, tags, securitySeverity, unmappedRules);
+
+            allFindings.Add(new SarifFindingDto
+            {
+                RuleId = ruleId,
+                RuleDescription = rule?.ShortDescription ?? ruleId,
+                Level = level,
+                CvssScore = (decimal?)securitySeverity,
+                CatTier = catTier.Value,
+                NistControlIds = [],
+                CweIds = cweIds,
+                LocationUri = locationUri,
+                LocationRegion = startLine.HasValue ? $"line {startLine}" : null,
+                FingerprintHash = fingerprint,
+                Message = message,
+                Tags = tags,
+                IsNew = isNew,
+            });
+        }
+        else
+        {
+            foreach (var controlId in nistIds)
+            {
+                allFindings.Add(new SarifFindingDto
+                {
+                    RuleId = ruleId,
+                    RuleDescription = rule?.ShortDescription ?? ruleId,
+                    Level = level,
+                    CvssScore = (decimal?)securitySeverity,
+                    CatTier = catTier.Value,
+                    NistControlIds = [controlId],
+                    CweIds = cweIds,
+                    LocationUri = locationUri,
+                    LocationRegion = startLine.HasValue ? $"line {startLine}" : null,
+                    FingerprintHash = fingerprint,
+                    Message = message,
+                    Tags = tags,
+                    IsNew = isNew,
+                });
+            }
+
+            foreach (var cwe in cweIds)
+            {
+                if (!controlMappings.ContainsKey(cwe))
+                    controlMappings[cwe] = nistIds.AsReadOnly();
+            }
+        }
+    }
+
+    private void TrackUnmappedRule(
+        string ruleId, string toolName, string pipelineRun,
+        IReadOnlyList<string> tags, double? securitySeverity,
+        List<UnmappedRuleInfo> unmappedRules)
+    {
+        var existing = unmappedRules.FirstOrDefault(u => u.RuleId == ruleId);
+        if (existing is null)
+        {
+            unmappedRules.Add(new UnmappedRuleInfo(ruleId, toolName, 1, tags, securitySeverity));
+            _logger.LogWarning(
+                "SARIF rule could not be mapped to NIST 800-53. " +
+                "RuleId={RuleId} Tool={ToolName} Run={PipelineRun} Tags={Tags}",
+                ruleId, toolName, pipelineRun, string.Join(",", tags));
+        }
+        else
+        {
+            var idx = unmappedRules.IndexOf(existing);
+            unmappedRules[idx] = existing with { OccurrenceCount = existing.OccurrenceCount + 1 };
+        }
+    }
+
+    // ─── Private helpers ────────────────────────────────────────────────────
+
+    private static string ExtractToolName(JsonElement run)
+    {
+        if (run.TryGetProperty("tool", out var tool) &&
+            tool.TryGetProperty("driver", out var driver) &&
+            driver.TryGetProperty("name", out var name))
+            return name.GetString() ?? string.Empty;
+        return string.Empty;
+    }
+
+    private static Dictionary<string, SarifRuleDescriptor> BuildRuleMap(JsonElement run)
+    {
+        var map = new Dictionary<string, SarifRuleDescriptor>(StringComparer.OrdinalIgnoreCase);
+
+        if (!run.TryGetProperty("tool", out var tool) ||
+            !tool.TryGetProperty("driver", out var driver) ||
+            !driver.TryGetProperty("rules", out var rules) ||
+            rules.ValueKind != JsonValueKind.Array)
+            return map;
+
+        foreach (var rule in rules.EnumerateArray())
+        {
+            var id = rule.TryGetProperty("id", out var rid) ? rid.GetString() : null;
+            if (id is null) continue;
+
+            var shortDesc = rule.TryGetProperty("shortDescription", out var sd)
+                ? (sd.TryGetProperty("text", out var t) ? t.GetString() : null) : null;
+
+            List<string>? nistProps = null;
+            List<string>? tagList = null;
+            Dictionary<string, object>? props = null;
+            string? rawCwe = null;
+            List<string>? relCwes = null;
+
+            if (rule.TryGetProperty("properties", out var propsEl))
+            {
+                props = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+                if (propsEl.TryGetProperty("nist", out var nistEl))
+                {
+                    nistProps = nistEl.ValueKind == JsonValueKind.Array
+                        ? nistEl.EnumerateArray()
+                            .Where(e => e.ValueKind == JsonValueKind.String)
+                            .Select(e => e.GetString()!)
+                            .Where(s => !string.IsNullOrWhiteSpace(s))
+                            .ToList()
+                        : nistEl.ValueKind == JsonValueKind.String ? [nistEl.GetString()!] : null;
+                }
+
+                if (propsEl.TryGetProperty("tags", out var tagsEl) &&
+                    tagsEl.ValueKind == JsonValueKind.Array)
+                {
+                    tagList = tagsEl.EnumerateArray()
+                        .Where(e => e.ValueKind == JsonValueKind.String)
+                        .Select(e => e.GetString()!)
+                        .ToList();
+                }
+
+                if (propsEl.TryGetProperty("security-severity", out var ss))
+                    props["security-severity"] = ss.ToString();
+
+                if (propsEl.TryGetProperty("cwe", out var cweEl) &&
+                    cweEl.ValueKind == JsonValueKind.String)
+                    rawCwe = cweEl.GetString();
+            }
+
+            if (rule.TryGetProperty("relationships", out var rels) &&
+                rels.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var rel in rels.EnumerateArray())
+                {
+                    if (!rel.TryGetProperty("target", out var tgt)) continue;
+                    if (!tgt.TryGetProperty("toolComponent", out var tc)) continue;
+                    if (tc.TryGetProperty("name", out var tcName) &&
+                        string.Equals(tcName.GetString(), "CWE", StringComparison.OrdinalIgnoreCase) &&
+                        tgt.TryGetProperty("id", out var tid) &&
+                        tid.GetString() is { Length: > 0 } tidStr)
+                    {
+                        relCwes ??= [];
+                        var norm = tidStr.StartsWith("CWE-", StringComparison.OrdinalIgnoreCase)
+                            ? tidStr : $"CWE-{tidStr}";
+                        relCwes.Add(norm.ToUpperInvariant());
+                    }
+                }
+            }
+
+            map[id] = new SarifRuleDescriptor(id, shortDesc, nistProps, tagList, props, rawCwe, relCwes);
+        }
+
+        return map;
+    }
+
+    private static string GetLevel(JsonElement result)
+    {
+        return result.TryGetProperty("level", out var lvl)
+            ? lvl.GetString()?.ToLowerInvariant() ?? "none"
+            : "none";
+    }
+
+    private static double? ParseSecuritySeverity(Dictionary<string, object>? props)
+    {
+        if (props is null || !props.TryGetValue("security-severity", out var raw)) return null;
+        var str = raw?.ToString()?.Trim();
+        return double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+            ? d : null;
+    }
+
+    /// <summary>Oracle spec §5 — first-match-wins CAT tier derivation.</summary>
+    private static CatSeverity? DeriveCategory(string level, double? cvss)
+    {
+        if (cvss >= 9.0 && level == "error")  return CatSeverity.CatI;
+        if (level == "error" || cvss >= 7.0)  return CatSeverity.CatII;
+        if (cvss >= 4.0 || level == "warning") return CatSeverity.CatIII;
+        return null;
+    }
+
+    private static void ExtractLocation(JsonElement result, out string? locationUri, out int? startLine)
+    {
+        locationUri = null;
+        startLine = null;
+
+        if (!result.TryGetProperty("locations", out var locs) ||
+            locs.ValueKind != JsonValueKind.Array) return;
+
+        foreach (var loc in locs.EnumerateArray())
+        {
+            if (!loc.TryGetProperty("physicalLocation", out var phys)) continue;
+
+            if (phys.TryGetProperty("artifactLocation", out var al) &&
+                al.TryGetProperty("uri", out var uri))
+                locationUri = uri.GetString();
+
+            if (phys.TryGetProperty("region", out var region) &&
+                region.TryGetProperty("startLine", out var sl))
+                startLine = sl.GetInt32();
+
+            return;
+        }
+    }
+
+    private static string ComputeFingerprint(
+        JsonElement result, Guid systemId, string ruleId, string? locationUri, int? startLine)
+    {
+        if (result.TryGetProperty("fingerprints", out var fps) &&
+            fps.ValueKind == JsonValueKind.Object)
+        {
+            if (fps.TryGetProperty("primaryLocationLineHash/v1", out var p1) &&
+                p1.GetString() is { Length: > 0 } s1) return s1;
+
+            if (fps.TryGetProperty("partialFingerprints/v1", out var p2) &&
+                p2.GetString() is { Length: > 0 } s2) return s2;
+        }
+
+        var raw = $"{systemId}|{ruleId}|{locationUri ?? string.Empty}|{startLine?.ToString(CultureInfo.InvariantCulture) ?? "0"}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(raw))).ToLowerInvariant();
+    }
+
+    private (List<string> nistIds, List<string> cweIds, string confidence) ResolveNistControls(
+        string ruleId, SarifRuleDescriptor? rule, string toolName)
+    {
+        // Tier 1 — explicit nist property
+        if (rule?.NistProperties is { Count: > 0 })
+        {
+            var validated = rule.NistProperties
+                .Select(NormalizeControlId)
+                .Where(id => NistControlIdPattern.IsMatch(id))
+                .Distinct().ToList();
+
+            if (validated.Count > 0)
+                return (validated, ExtractCweIds(ruleId, rule), "HIGH-T1");
+        }
+
+        // Tier 2 — tag pattern matching
+        if (rule?.Tags is { Count: > 0 })
+        {
+            var tier2 = new List<string>();
+            foreach (var tag in rule.Tags)
+            {
+                foreach (var pat in SarifTagPatterns.Tier2Patterns)
+                {
+                    var m = pat.Match(tag);
+                    if (!m.Success) continue;
+                    var id = NormalizeControlId(m.Groups[1].Value);
+                    if (NistControlIdPattern.IsMatch(id)) tier2.Add(id);
+                    break;
+                }
+            }
+            var d2 = tier2.Distinct().ToList();
+            if (d2.Count > 0)
+                return (d2, ExtractCweIds(ruleId, rule), "HIGH-T2");
+        }
+
+        // Tier 3 — CWE lookup
+        var cweIds = ExtractCweIds(ruleId, rule);
+        if (cweIds.Count > 0)
+        {
+            var tier3 = cweIds
+                .Where(CweNistMappings.Map.ContainsKey)
+                .SelectMany(cwe => CweNistMappings.Map[cwe])
+                .Distinct().ToList();
+
+            if (tier3.Count > 0)
+                return (tier3, cweIds, "MEDIUM-T3");
+        }
+
+        // Tier 3b — tool heuristic
+        var heuristic = ApplyToolHeuristic(ruleId, toolName);
+        if (heuristic.Count > 0)
+            return (heuristic, cweIds, "MEDIUM-H");
+
+        return ([], cweIds, "UNMAPPED");
+    }
+
+    private static List<string> ExtractCweIds(string ruleId, SarifRuleDescriptor? rule)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match m in CweInRuleIdPattern.Matches(ruleId))
+            set.Add($"CWE-{m.Groups[1].Value}");
+
+        if (rule?.RelationshipCwes is { Count: > 0 })
+            foreach (var c in rule.RelationshipCwes)
+                set.Add(c.ToUpperInvariant());
+
+        if (!string.IsNullOrEmpty(rule?.RawCweProperty))
+        {
+            var f = rule.RawCweProperty.StartsWith("CWE-", StringComparison.OrdinalIgnoreCase)
+                ? rule.RawCweProperty : $"CWE-{rule.RawCweProperty}";
+            set.Add(f.ToUpperInvariant());
+        }
+
+        if (rule?.Tags is { Count: > 0 })
+            foreach (var tag in rule.Tags)
+                foreach (Match m in SarifTagPatterns.CweInTag.Matches(tag))
+                    set.Add($"CWE-{m.Groups[1].Value}");
+
+        return [.. set];
+    }
+
+    private static List<string> ApplyToolHeuristic(string ruleId, string toolName)
+    {
+        var tl = toolName.ToLowerInvariant().Replace(" ", string.Empty);
+
+        // CodeQL keyword heuristic
+        if (tl.Contains("codeql"))
+        {
+            var ruleName = ruleId.Split('/')[^1];
+            var keywords = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["sql-injection"] = "CWE-89", ["sqli"] = "CWE-89",
+                ["xss"] = "CWE-79", ["cross-site-scripting"] = "CWE-79",
+                ["command-injection"] = "CWE-78",
+                ["path-injection"] = "CWE-22", ["path-traversal"] = "CWE-22",
+                ["ssrf"] = "CWE-918", ["xxe"] = "CWE-611",
+                ["csrf"] = "CWE-352", ["deserialization"] = "CWE-502",
+                ["hard-coded"] = "CWE-798", ["hardcoded"] = "CWE-798",
+                ["credentials"] = "CWE-798", ["cleartext"] = "CWE-312",
+                ["missing-auth"] = "CWE-306", ["improper-auth"] = "CWE-287",
+                ["upload"] = "CWE-434",
+            };
+
+            foreach (var (keyword, cwe) in keywords)
+            {
+                if (ruleName.Contains(keyword, StringComparison.OrdinalIgnoreCase) &&
+                    CweNistMappings.Map.TryGetValue(cwe, out var controls))
+                    return [.. controls.Distinct()];
+            }
+        }
+
+        // Checkov rule overrides + provider heuristic
+        if (tl.Contains("checkov") || tl.Contains("bridgecrew"))
+        {
+            var overrides = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["CKV_AZURE_36"] = ["SC-7"], ["CKV_AZURE_39"] = ["SC-7"],
+                ["CKV_AZURE_5"]  = ["IA-2"], ["CKV_AZURE_8"]  = ["IA-2"],
+                ["CKV_AZURE_13"] = ["SC-28"], ["CKV_AZURE_16"] = ["SC-28"],
+                ["CKV_AZURE_41"] = ["AU-2", "AU-9"], ["CKV_AZURE_42"] = ["AU-2", "AU-9"],
+            };
+
+            if (overrides.TryGetValue(ruleId, out var ov)) return [.. ov];
+
+            var m = Regex.Match(ruleId, @"^CKV2?_([A-Z]+)_\d+", RegexOptions.IgnoreCase);
+            if (m.Success)
+            {
+                var defaults = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["AZURE"] = ["CM-6", "SC-7", "SC-28"],
+                    ["K8S"] = ["CM-6", "SC-7", "AC-2"],
+                    ["DOCKER"] = ["CM-6", "SI-3"],
+                    ["GCP"] = ["CM-6", "SC-7"],
+                    ["TERRAFORM"] = ["CM-6"],
+                };
+                if (defaults.TryGetValue(m.Groups[1].Value.ToUpperInvariant(), out var def))
+                    return [.. def];
+            }
+        }
+
+        // MSDO CredScan override
+        if ((tl.Contains("microsoft") || tl.Contains("msdo")) &&
+            Regex.IsMatch(ruleId, @"^CS\d{3}", RegexOptions.IgnoreCase))
+            return ["IA-5"];
+
+        return [];
+    }
+
+    private static string NormalizeControlId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return id;
+        var n = id.Trim().ToUpperInvariant();
+        n = Regex.Replace(n, @"\s*\(\s*(\d+)\s*\)", "($1)");
+        n = Regex.Replace(n, @"\.REV\.\d+$", string.Empty);
+        return n;
+    }
+}
+
+/// <summary>Internal SARIF rule descriptor — assembled from tool.driver.rules[].</summary>
+internal sealed record SarifRuleDescriptor(
+    string Id,
+    string? ShortDescription,
+    List<string>? NistProperties,
+    List<string>? Tags,
+    Dictionary<string, object>? Properties,
+    string? RawCweProperty,
+    List<string>? RelationshipCwes);

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
@@ -445,12 +445,21 @@ public sealed class SarifParserService : ISarifParserService
         // Tier 2 — tag pattern matching
         if (rule?.Tags is { Count: > 0 })
         {
+            var tier2Patterns = new Func<Regex>[]
+            {
+                SarifTagPatterns.NistDotted,
+                SarifTagPatterns.NistColon,
+                SarifTagPatterns.ControlColon,
+                SarifTagPatterns.Dashed800,
+                SarifTagPatterns.NistDefenderFormat,
+                SarifTagPatterns.DirectId,
+            };
             var tier2 = new List<string>();
             foreach (var tag in rule.Tags)
             {
-                foreach (var pat in SarifTagPatterns.Tier2Patterns)
+                foreach (var getPattern in tier2Patterns)
                 {
-                    var m = pat.Match(tag);
+                    var m = getPattern().Match(tag);
                     if (!m.Success) continue;
                     var id = NormalizeControlId(m.Groups[1].Value);
                     if (NistControlIdPattern.IsMatch(id)) tier2.Add(id);
@@ -503,7 +512,7 @@ public sealed class SarifParserService : ISarifParserService
 
         if (rule?.Tags is { Count: > 0 })
             foreach (var tag in rule.Tags)
-                foreach (Match m in SarifTagPatterns.CweInTag.Matches(tag))
+                foreach (Match m in SarifTagPatterns.CweInTag().Matches(tag))
                     set.Add($"CWE-{m.Groups[1].Value}");
 
         return [.. set];

--- a/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs
@@ -220,6 +220,11 @@ public sealed class SarifParserService : ISarifParserService
         }
         else
         {
+            // One SarifFindingDto row per NIST control — multi-control expansion
+            // findingsImported was already incremented once above; add (nistIds.Count - 1) more
+            if (isNew && nistIds.Count > 1)
+                findingsImported += nistIds.Count - 1;
+
             foreach (var controlId in nistIds)
             {
                 allFindings.Add(new SarifFindingDto

--- a/src/Ato.Copilot.Core/Services/AtoPostureService.cs
+++ b/src/Ato.Copilot.Core/Services/AtoPostureService.cs
@@ -1,0 +1,360 @@
+// =============================================================================
+//  AtoPostureService.cs
+//  Ato.Copilot.Core — Services
+//  Issue #422 — AO Posture API (W10 cATO Gap Closure)
+//
+//  IAtoPostureService implementation.
+//  Aggregates AuthorizationDecision, ComplianceFinding, PoamItem, ConMonPlan,
+//  ConMonReport, ComplianceTrendSnapshot into AtoPostureDto.
+//  5-minute IMemoryCache per system + role-gated fields.
+// =============================================================================
+
+#nullable enable
+
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using Ato.Copilot.Core.Models.Poam;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Core.Services;
+
+/// <summary>
+/// Aggregates ATO posture from ConMon, Findings, POA&amp;M, and AuthorizationDecision
+/// repositories into a single read-model and evaluates cATO/CSRMC eligibility.
+/// </summary>
+/// <remarks>
+/// Cache key: <c>ato-posture:{systemId}</c> with 5-minute absolute TTL.
+/// forceRefresh = true requires ISSM or higher role.
+/// AuthorizingOfficial + CsrmcPillarStatus fields are null for callers without AO role.
+/// </remarks>
+public sealed class AtoPostureService : IAtoPostureService
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly IDbContextFactory<AtoCopilotContext> _dbFactory;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<AtoPostureService> _logger;
+
+    // Roles authorized to use forceRefresh=true
+    private static readonly IReadOnlySet<string> RefreshAllowedRoles =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ISSM", "AO", "AuthorizingOfficial", "SCA", "Engineer"
+        };
+
+    private const string AuthorizingOfficialRole = "AuthorizingOfficial";
+
+    public AtoPostureService(
+        IDbContextFactory<AtoCopilotContext> dbFactory,
+        IMemoryCache cache,
+        ILogger<AtoPostureService> logger)
+    {
+        _dbFactory = dbFactory;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<AtoPostureDto?> GetPostureAsync(
+        Guid systemId,
+        IReadOnlySet<string> callerRoles,
+        bool forceRefresh,
+        CancellationToken cancellationToken = default)
+    {
+        // Authorization gate: forceRefresh requires ISSM+
+        if (forceRefresh && !callerRoles.Any(r => RefreshAllowedRoles.Contains(r)))
+            throw new ForbiddenException("forceRefresh requires ISSM or higher role.");
+
+        var cacheKey = $"ato-posture:{systemId}";
+        bool isAo = callerRoles.Contains(AuthorizingOfficialRole);
+
+        // Attempt cache hit (unless forceRefresh)
+        if (!forceRefresh &&
+            _cache.TryGetValue(cacheKey, out AtoPostureDto? cached) &&
+            cached is not null)
+        {
+            _logger.LogDebug("ATO posture cache hit for system {SystemId}", systemId);
+            return ApplyRoleGating(cached with { ServedFromCache = true }, isAo);
+        }
+
+        // Cache miss — compute from DB
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var system = await db.RegisteredSystems
+            .AsNoTracking()
+            .Where(s => s.Id == systemId.ToString() && s.IsActive)
+            .Select(s => new { s.Id, s.Name })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (system is null) return null;
+
+        var posture = await BuildPostureAsync(db, systemId, system.Name, cancellationToken);
+
+        _cache.Set(cacheKey, posture, CacheTtl);
+        _logger.LogDebug("ATO posture computed and cached for system {SystemId}", systemId);
+
+        return ApplyRoleGating(posture with { ServedFromCache = false }, isAo);
+    }
+
+    /// <inheritdoc />
+    public async Task<CatoEligibilityDto> EvaluateCatoEligibilityAsync(
+        Guid systemId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var systemExists = await db.RegisteredSystems
+            .AsNoTracking()
+            .AnyAsync(s => s.Id == systemId.ToString() && s.IsActive, cancellationToken);
+
+        if (!systemExists)
+            throw new SystemNotFoundException(systemId);
+
+        // Criterion 1 — zero open CatI findings
+        var catICount = await db.Findings
+            .AsNoTracking()
+            .CountAsync(f => f.RegisteredSystemId == systemId.ToString() &&
+                             f.CatSeverity == CatSeverity.CatI &&
+                             f.Status == FindingStatus.Open, cancellationToken);
+
+        // Criterion 2 — zero overdue POA&M items
+        var now = DateTime.UtcNow;
+        var overduePoamCount = await db.PoamItems
+            .AsNoTracking()
+            .CountAsync(p => p.RegisteredSystemId == systemId.ToString() &&
+                              p.Status == PoamStatus.Delayed &&
+                              p.ScheduledCompletionDate < now, cancellationToken);
+
+        // Criterion 3 — active ConMonPlan exists
+        var conMonEnabled = await db.ConMonPlans
+            .AsNoTracking()
+            .AnyAsync(c => c.RegisteredSystemId == systemId.ToString(), cancellationToken);
+
+        // Criterion 4 — all three CSRMC pillars Compliant
+        // Phase 1: Pillar 3 = Unknown (no pipeline ingestion history yet — added in Phase 2)
+        var pillar3Status = await GetPillar3StatusAsync(systemId, cancellationToken);
+        bool allPillarsCompliant = pillar3Status == PillarComplianceStatus.Compliant;
+
+        bool hasZeroCatI = catICount == 0;
+        bool hasZeroOverdue = overduePoamCount == 0;
+        bool isEligible = hasZeroCatI && hasZeroOverdue && conMonEnabled && allPillarsCompliant;
+
+        var reasons = new List<string>();
+        if (!hasZeroCatI)
+            reasons.Add($"{catICount} open CAT I finding(s) must be remediated.");
+        if (!hasZeroOverdue)
+            reasons.Add($"{overduePoamCount} overdue POA&M item(s) must be resolved.");
+        if (!conMonEnabled)
+            reasons.Add("No active Continuous Monitoring plan exists.");
+        if (!allPillarsCompliant)
+            reasons.Add($"CSRMC Pillar 3 gap: pipeline not compliant (status: {pillar3Status}).");
+
+        return new CatoEligibilityDto
+        {
+            IsEligible             = isEligible,
+            HasZeroCatIFindings    = hasZeroCatI,
+            HasZeroOverduePOAMs    = hasZeroOverdue,
+            IsConMonEnabled        = conMonEnabled,
+            AllCsrmcPillarsCompliant = allPillarsCompliant,
+            IneligibilityReasons   = reasons.AsReadOnly(),
+            CheckedAt              = DateTimeOffset.UtcNow,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<PillarComplianceStatus> GetPillar3StatusAsync(
+        Guid systemId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var systemExists = await db.RegisteredSystems
+            .AsNoTracking()
+            .AnyAsync(s => s.Id == systemId.ToString() && s.IsActive, cancellationToken);
+
+        if (!systemExists)
+            throw new SystemNotFoundException(systemId);
+
+        // TODO(#422-phase2): PipelineIngestionLogs DbSet + entity added in Phase 2.
+        // Phase 1 returns Unknown — Pillar 3 compliance requires webhook ingestion history.
+        return PillarComplianceStatus.Unknown;
+    }
+
+    // ─── Private helpers ────────────────────────────────────────────────────
+
+    private static AtoPostureDto ApplyRoleGating(AtoPostureDto posture, bool isAo)
+    {
+        return posture with
+        {
+            AuthorizationStatus = isAo
+                ? posture.AuthorizationStatus
+                : posture.AuthorizationStatus with { AuthorizingOfficial = null },
+            CsrmcPillarStatus = isAo ? posture.CsrmcPillarStatus : null,
+        };
+    }
+
+    private static async Task<AtoPostureDto> BuildPostureAsync(
+        AtoCopilotContext db,
+        Guid systemId,
+        string systemName,
+        CancellationToken ct)
+    {
+        var systemIdStr = systemId.ToString();
+
+        // ── Authorization ──
+        var authDecision = await db.AuthorizationDecisions
+            .AsNoTracking()
+            .Where(a => a.RegisteredSystemId == systemIdStr && a.IsActive)
+            .OrderByDescending(a => a.DecisionDate)
+            .FirstOrDefaultAsync(ct);
+
+        var authStatus = BuildAuthorizationStatus(authDecision);
+
+        // ── Compliance summary (from latest ComplianceTrendSnapshot) ──
+        var snapshot = await db.ComplianceTrendSnapshots
+            .AsNoTracking()
+            .Where(s => s.RegisteredSystemId == systemIdStr)
+            .OrderByDescending(s => s.CapturedAt)
+            .FirstOrDefaultAsync(ct);
+
+        // Derive control counts from ControlBaseline + ControlEffectiveness
+        var baseline = await db.ControlBaselines
+            .AsNoTracking()
+            .Where(cb => cb.RegisteredSystemId == systemIdStr)
+            .Select(cb => new { cb.TotalControls })
+            .FirstOrDefaultAsync(ct);
+
+        int totalControls = baseline?.TotalControls ?? 0;
+        double complianceScoreRaw = snapshot?.ComplianceScore ?? 0;
+        var complianceSummary = new ComplianceSummaryDto
+        {
+            TotalControls   = totalControls,
+            Satisfied       = (int)Math.Round(totalControls * complianceScoreRaw / 100.0),
+            OtherThanSatisfied = (int)Math.Round(totalControls * (1.0 - complianceScoreRaw / 100.0)),
+            NotAssessed     = 0,
+            ComplianceScore = (decimal)Math.Round(complianceScoreRaw, 2),
+        };
+
+        // ── Findings summary ──
+        var findingCounts = await db.Findings
+            .AsNoTracking()
+            .Where(f => f.RegisteredSystemId == systemIdStr && f.Status == FindingStatus.Open)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                CatI   = g.Count(f => f.CatSeverity == CatSeverity.CatI),
+                CatII  = g.Count(f => f.CatSeverity == CatSeverity.CatII),
+                CatIII = g.Count(f => f.CatSeverity == CatSeverity.CatIII),
+            })
+            .FirstOrDefaultAsync(ct);
+
+        var findingsSummary = new FindingsSummaryDto
+        {
+            CatI   = findingCounts?.CatI   ?? 0,
+            CatII  = findingCounts?.CatII  ?? 0,
+            CatIII = findingCounts?.CatIII ?? 0,
+        };
+
+        // ── POA&M summary ──
+        var now = DateTime.UtcNow;
+        var poamCounts = await db.PoamItems
+            .AsNoTracking()
+            .Where(p => p.RegisteredSystemId == systemIdStr)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Open         = g.Count(p => p.Status == PoamStatus.Ongoing),
+                Overdue      = g.Count(p => p.Status == PoamStatus.Delayed && p.ScheduledCompletionDate < now),
+                Completed    = g.Count(p => p.Status == PoamStatus.Completed),
+                RiskAccepted = g.Count(p => p.Status == PoamStatus.RiskAccepted),
+            })
+            .FirstOrDefaultAsync(ct);
+
+        var poamSummary = new PoamSummaryDto
+        {
+            Open         = poamCounts?.Open         ?? 0,
+            Overdue      = poamCounts?.Overdue       ?? 0,
+            Completed    = poamCounts?.Completed     ?? 0,
+            RiskAccepted = poamCounts?.RiskAccepted  ?? 0,
+        };
+
+        // ── ConMon summary ──
+        var conMonPlan = await db.ConMonPlans
+            .AsNoTracking()
+            .Where(c => c.RegisteredSystemId == systemIdStr)
+            .FirstOrDefaultAsync(ct);
+
+        var latestReport = conMonPlan is not null
+            ? await db.ConMonReports
+                .AsNoTracking()
+                .Where(r => r.ConMonPlanId == conMonPlan.Id)
+                .OrderByDescending(r => r.GeneratedAt)
+                .FirstOrDefaultAsync(ct)
+            : null;
+
+        var conMonSummary = new ConMonSummaryDto
+        {
+            IsEnabled             = conMonPlan is not null,
+            LastReportDate        = latestReport is not null
+                                    ? new DateTimeOffset(latestReport.GeneratedAt, TimeSpan.Zero)
+                                    : null,
+            AssessmentFrequency   = conMonPlan?.AssessmentFrequency,
+            LatestComplianceScore = latestReport is not null ? (decimal)latestReport.ComplianceScore : null,
+            AuthorizedBaselineScore = latestReport?.AuthorizedBaselineScore.HasValue == true
+                                      ? (decimal)latestReport.AuthorizedBaselineScore!.Value
+                                      : null,
+        };
+
+        // ── CSRMC Pillar Status (AO-gated — always computed for cache, stripped on return) ──
+        var csrmcStatus = new CsrmcPillarStatusDto
+        {
+            Pillar1Status = PillarComplianceStatus.Unknown,
+            Pillar2Status = PillarComplianceStatus.Unknown,
+            Pillar3Status = PillarComplianceStatus.Unknown, // Phase 2 — requires webhook entity
+            EvaluatedAt   = DateTimeOffset.UtcNow,
+        };
+
+        return new AtoPostureDto
+        {
+            SystemId            = systemId,
+            SystemName          = systemName,
+            AuthorizationStatus = authStatus,
+            ComplianceSummary   = complianceSummary,
+            FindingsSummary     = findingsSummary,
+            PoamSummary         = poamSummary,
+            ConMonSummary       = conMonSummary,
+            CsrmcPillarStatus   = csrmcStatus,
+            RetrievedAt         = DateTimeOffset.UtcNow,
+            ServedFromCache     = false,
+        };
+    }
+
+    private static AuthorizationStatusDto BuildAuthorizationStatus(AuthorizationDecision? decision)
+    {
+        if (decision is null)
+            return new AuthorizationStatusDto { IsActive = false, IsExpired = false };
+
+        var now = DateTime.UtcNow;
+        bool isExpired = decision.ExpirationDate.HasValue && decision.ExpirationDate.Value < now;
+        int? daysUntilExpiration = decision.ExpirationDate.HasValue && !isExpired
+            ? (int)(decision.ExpirationDate.Value - now).TotalDays
+            : null;
+
+        return new AuthorizationStatusDto
+        {
+            DecisionType        = decision.DecisionType,
+            DecisionDate        = new DateTimeOffset(decision.DecisionDate, TimeSpan.Zero),
+            ExpirationDate      = decision.ExpirationDate.HasValue
+                                  ? new DateTimeOffset(decision.ExpirationDate.Value, TimeSpan.Zero)
+                                  : null,
+            IsActive            = decision.IsActive && !isExpired,
+            IsExpired           = isExpired,
+            DaysUntilExpiration = daysUntilExpiration,
+            // AuthorizingOfficial populated here — stripped by ApplyRoleGating for non-AO callers
+            AuthorizingOfficial = decision.IssuedByName,
+        };
+    }
+}

--- a/src/Ato.Copilot.Core/Services/AtoPostureService.cs
+++ b/src/Ato.Copilot.Core/Services/AtoPostureService.cs
@@ -114,11 +114,21 @@ public sealed class AtoPostureService : IAtoPostureService
             throw new SystemNotFoundException(systemId);
 
         // Criterion 1 — zero open CatI findings
-        var catICount = await db.Findings
+        // NOTE: ComplianceFinding has NO RegisteredSystemId FK — must join via latest Assessment.
+        var latestAssessmentIdForCrit = await db.Assessments
             .AsNoTracking()
-            .CountAsync(f => f.RegisteredSystemId == systemId.ToString() &&
-                             f.CatSeverity == CatSeverity.CatI &&
-                             f.Status == FindingStatus.Open, cancellationToken);
+            .Where(a => a.RegisteredSystemId == systemId.ToString() && a.Status == AssessmentStatus.Completed)
+            .OrderByDescending(a => a.CompletedAt)
+            .Select(a => a.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var catICount = latestAssessmentIdForCrit is not null
+            ? await db.Findings
+                .AsNoTracking()
+                .CountAsync(f => f.AssessmentId == latestAssessmentIdForCrit &&
+                                 f.CatSeverity == CatSeverity.CatI &&
+                                 f.Status == FindingStatus.Open, cancellationToken)
+            : 0;
 
         // Criterion 2 — zero overdue POA&M items
         var now = DateTime.UtcNow;
@@ -239,24 +249,40 @@ public sealed class AtoPostureService : IAtoPostureService
         };
 
         // ── Findings summary ──
-        var findingCounts = await db.Findings
+        // NOTE: ComplianceFinding has NO RegisteredSystemId FK — join via latest Assessment.
+        var latestAssessmentIdForPosture = await db.Assessments
             .AsNoTracking()
-            .Where(f => f.RegisteredSystemId == systemIdStr && f.Status == FindingStatus.Open)
-            .GroupBy(_ => 1)
-            .Select(g => new
-            {
-                CatI   = g.Count(f => f.CatSeverity == CatSeverity.CatI),
-                CatII  = g.Count(f => f.CatSeverity == CatSeverity.CatII),
-                CatIII = g.Count(f => f.CatSeverity == CatSeverity.CatIII),
-            })
+            .Where(a => a.RegisteredSystemId == systemIdStr && a.Status == AssessmentStatus.Completed)
+            .OrderByDescending(a => a.CompletedAt)
+            .Select(a => a.Id)
             .FirstOrDefaultAsync(ct);
 
-        var findingsSummary = new FindingsSummaryDto
+        FindingsSummaryDto findingsSummary;
+        if (latestAssessmentIdForPosture is not null)
         {
-            CatI   = findingCounts?.CatI   ?? 0,
-            CatII  = findingCounts?.CatII  ?? 0,
-            CatIII = findingCounts?.CatIII ?? 0,
-        };
+            var findingCounts = await db.Findings
+                .AsNoTracking()
+                .Where(f => f.AssessmentId == latestAssessmentIdForPosture && f.Status == FindingStatus.Open)
+                .GroupBy(_ => 1)
+                .Select(g => new
+                {
+                    CatI   = g.Count(f => f.CatSeverity == CatSeverity.CatI),
+                    CatII  = g.Count(f => f.CatSeverity == CatSeverity.CatII),
+                    CatIII = g.Count(f => f.CatSeverity == CatSeverity.CatIII),
+                })
+                .FirstOrDefaultAsync(ct);
+
+            findingsSummary = new FindingsSummaryDto
+            {
+                CatI   = findingCounts?.CatI   ?? 0,
+                CatII  = findingCounts?.CatII  ?? 0,
+                CatIII = findingCounts?.CatIII ?? 0,
+            };
+        }
+        else
+        {
+            findingsSummary = new FindingsSummaryDto { CatI = 0, CatII = 0, CatIII = 0 };
+        }
 
         // ── POA&M summary ──
         var now = DateTime.UtcNow;

--- a/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
@@ -53,7 +53,7 @@ public static class AtoPostureEndpoints
         HttpContext httpContext,
         IAtoPostureService postureService,
         ICallerEffectiveRoleResolver roleResolver,
-        ILogger<AtoPostureEndpoints_> logger,
+        ILogger<AtoPostureEndpoints> logger,
         bool refresh = false,
         CancellationToken ct = default)
     {
@@ -150,5 +150,3 @@ public static class AtoPostureEndpoints
     }
 }
 
-/// <summary>Marker type for logger category — avoids generics in MapGet lambda.</summary>
-file sealed class AtoPostureEndpoints_ { }

--- a/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
@@ -1,203 +1,154 @@
 // =============================================================================
 //  AtoPostureEndpoints.cs
 //  Ato.Copilot.Mcp — Endpoints
-//  Issue #422 — AO Posture API (Phase 2, W10 cATO Gap Closure)
+//  Issue #422 — AO Posture API (W10 cATO Gap Closure)
 //
-//  GET /api/systems/{id}/ato-posture
-//  Headers: X-Cache-Hit, X-Snapshot-Age-Seconds
-//  Auth: JWT bearer, minimum Viewer role
-//  Role-gated fields: authorizingOfficial, csrmcPillarStatus (AuthorizingOfficial only)
-//  forceRefresh: requires ISSM+ role → ForbiddenException → 403
+//  GET /api/systems/{systemId}/ato-posture
+//  Response: AtoPostureDto with X-Cache-Hit + X-Snapshot-Age-Seconds headers.
+//  RFC 7807 ProblemDetails on all errors.
 // =============================================================================
 
+#nullable enable
+
 using System.Security.Claims;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Services.Roles;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Ato.Copilot.Core.Interfaces.Compliance;
+using Microsoft.Extensions.Logging;
 
 namespace Ato.Copilot.Mcp.Endpoints;
 
 /// <summary>
-/// Maps <c>GET /api/systems/{id}/ato-posture</c> — AO Posture snapshot endpoint.
+/// ATO Posture REST endpoints (Issue #422 — W10 cATO Gap Closure).
+///
+/// <para>
+/// <b>GET /api/systems/{systemId}/ato-posture</b> — machine-readable ATO posture snapshot.
+/// Minimum role: authenticated (Viewer). Role-gated fields require AuthorizingOfficial.
+/// forceRefresh query param requires ISSM+.
+/// </para>
 /// </summary>
 public static class AtoPostureEndpoints
 {
-    // Roles allowed to call forceRefresh=true (mirrors IAtoPostureService.RefreshRoles)
-    private static readonly HashSet<string> IssmmPlusRoles = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "ISSM", "ISSO", "SCA", "AuthorizingOfficial", "AO",
-        "Compliance.Administrator", "Compliance.SecurityLead"
-    };
-
-    /// <summary>
-    /// Registers the ATO posture endpoint group.
-    /// </summary>
     public static IEndpointRouteBuilder MapAtoPostureEndpoints(this IEndpointRouteBuilder app)
     {
-        // Note: /api/systems is an existing group — this endpoint extends it.
-        // Route convention matches existing /api/systems/{id}/* pattern.
-        app.MapGet("/api/systems/{id}/ato-posture", HandleGetAtoPosture)
-            .WithTags("AO Posture")
+        var group = app.MapGroup("/api/systems")
+            .RequireAuthorization(); // Minimum: authenticated caller
+
+        // ─── GET /api/systems/{systemId}/ato-posture ─────────────────────────
+        group.MapGet("/{systemId}/ato-posture", GetAtoPostureAsync)
             .WithName("GetAtoPosture")
             .WithSummary("Get ATO posture snapshot")
-            .WithDescription("""
-                Aggregated, machine-readable ATO posture snapshot for the specified system.
-                Cached 5 minutes per system ID. Use ?refresh=true to bypass (requires ISSM+).
-                Role-gated fields: authorization.authorizingOfficial and catoEligibility.csrmcPillarStatus
-                require AuthorizingOfficial role.
-                """)
-            .RequireAuthorization();
+            .WithDescription(
+                "Aggregated, machine-readable ATO posture snapshot for the specified system. " +
+                "Cached 5 minutes per system. Use ?refresh=true to bypass (requires ISSM+).");
 
         return app;
     }
 
-    private static async Task<IResult> HandleGetAtoPosture(
-        string id,
-        bool? refresh,
-        IAtoPostureService postureService,
+    private static async Task<IResult> GetAtoPostureAsync(
+        string systemId,
         HttpContext httpContext,
-        CancellationToken ct)
+        IAtoPostureService postureService,
+        ICallerEffectiveRoleResolver roleResolver,
+        ILogger<AtoPostureEndpoints_> logger,
+        bool refresh = false,
+        CancellationToken ct = default)
     {
-        // Parse system ID
-        if (!Guid.TryParse(id, out var systemId))
+        // ── Parse systemId ──
+        if (!Guid.TryParse(systemId, out var systemGuid))
         {
             return Results.Problem(
+                detail: $"'{systemId}' is not a valid system identifier.",
                 title: "Invalid System ID",
-                detail: $"'{id}' is not a valid GUID.",
-                statusCode: 400,
-                type: "https://spinagent.io/errors/bad-request");
+                statusCode: StatusCodes.Status400BadRequest,
+                type: "https://httpstatuses.com/400");
         }
 
-        // Extract caller roles from JWT claims
-        var callerRoles = ExtractRoles(httpContext.User);
+        // ── Resolve caller roles ──
+        var callerRoles = ExtractCallerRoles(httpContext.User);
 
-        var forceRefresh = refresh ?? false;
+        var snapshotCapturedAt = DateTimeOffset.UtcNow; // populated from response after call
 
         try
         {
             var posture = await postureService.GetPostureAsync(
-                systemId, callerRoles, forceRefresh, ct);
+                systemGuid, callerRoles, forceRefresh: refresh, cancellationToken: ct);
 
             if (posture is null)
             {
                 return Results.Problem(
+                    detail: $"Registered system '{systemId}' was not found or is inactive.",
                     title: "System Not Found",
-                    detail: $"Registered system '{systemId}' was not found.",
-                    statusCode: 404,
-                    type: "https://spinagent.io/errors/system-not-found");
+                    statusCode: StatusCodes.Status404NotFound,
+                    type: "https://httpstatuses.com/404");
             }
 
-            // Attach cache headers per OpenAPI spec
-            httpContext.Response.Headers["X-Cache-Hit"] =
-                posture.ServedFromCache.ToString().ToLowerInvariant();
-            httpContext.Response.Headers["X-Snapshot-Age-Seconds"] =
-                posture.ServedFromCache
-                    ? ((int)(DateTimeOffset.UtcNow - posture.RetrievedAt).TotalSeconds).ToString()
-                    : "0";
+            // ── Set response headers ──
+            httpContext.Response.Headers["X-Cache-Hit"] = posture.ServedFromCache ? "true" : "false";
 
-            // Shape the response to match OpenAPI contract
-            return Results.Ok(new
-            {
-                systemId = posture.SystemId,
-                systemName = posture.SystemName,
-                snapshotTimestamp = posture.RetrievedAt,
-                servedFromCache = posture.ServedFromCache,
-                authorization = posture.AuthorizationStatus is null ? null : new
-                {
-                    status = GetAuthStatusString(posture.AuthorizationStatus),
-                    type = posture.AuthorizationStatus.DecisionType?.ToString(),
-                    decisionDate = posture.AuthorizationStatus.DecisionDate,
-                    expirationDate = posture.AuthorizationStatus.ExpirationDate,
-                    daysUntilExpiration = posture.AuthorizationStatus.DaysUntilExpiration,
-                    authorizingOfficial = posture.AuthorizationStatus.AuthorizingOfficial,
-                    residualRisk = (string?)null    // populated in Phase 5 (OSCAL import)
-                },
-                compliance = new
-                {
-                    score = posture.ComplianceSummary.ComplianceScore,
-                    totalControls = posture.ComplianceSummary.TotalControls,
-                    satisfied = posture.ComplianceSummary.Satisfied,
-                    otherThanSatisfied = posture.ComplianceSummary.OtherThanSatisfied,
-                    notAssessed = posture.ComplianceSummary.NotAssessed
-                },
-                findings = new
-                {
-                    total = posture.FindingsSummary.Total,
-                    catI = posture.FindingsSummary.CatI,
-                    catII = posture.FindingsSummary.CatII,
-                    catIII = posture.FindingsSummary.CatIII
-                },
-                poam = new
-                {
-                    open = posture.PoamSummary.Open,
-                    overdue = posture.PoamSummary.Overdue,
-                    completed = posture.PoamSummary.Completed,
-                    riskAccepted = posture.PoamSummary.RiskAccepted
-                },
-                conmon = new
-                {
-                    enabled = posture.ConMonSummary.IsEnabled,
-                    lastCheck = posture.ConMonSummary.LastReportDate,
-                    assessmentFrequency = posture.ConMonSummary.AssessmentFrequency,
-                    latestComplianceScore = posture.ConMonSummary.LatestComplianceScore,
-                    authorizedBaselineScore = posture.ConMonSummary.AuthorizedBaselineScore
-                },
-                catoEligibility = (object?)null,    // populated via separate EvaluateCatoEligibility call
-                csrmcPillarStatus = posture.CsrmcPillarStatus is null ? null : new
-                {
-                    pillar1_reciprocity = posture.CsrmcPillarStatus.Pillar1Status.ToString().ToLowerInvariant(),
-                    pillar2_automation = posture.CsrmcPillarStatus.Pillar2Status.ToString().ToLowerInvariant(),
-                    pillar3_devsecops = posture.CsrmcPillarStatus.Pillar3Status.ToString().ToLowerInvariant(),
-                    evaluatedAt = posture.CsrmcPillarStatus.EvaluatedAt
-                }
-            });
+            var ageSeconds = (int)(DateTimeOffset.UtcNow - posture.RetrievedAt).TotalSeconds;
+            httpContext.Response.Headers["X-Snapshot-Age-Seconds"] = Math.Max(0, ageSeconds).ToString();
+
+            return Results.Ok(posture);
         }
         catch (ForbiddenException ex)
         {
+            logger.LogWarning(ex,
+                "Forbidden: caller lacks required role for forceRefresh on system {SystemId}", systemId);
+
             return Results.Problem(
-                title: "Forbidden",
                 detail: ex.Message,
-                statusCode: 403,
-                type: "https://spinagent.io/errors/forbidden");
+                title: "Forbidden",
+                statusCode: StatusCodes.Status403Forbidden,
+                type: "https://httpstatuses.com/403");
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (SystemNotFoundException ex)
         {
             return Results.Problem(
+                detail: ex.Message,
+                title: "System Not Found",
+                statusCode: StatusCodes.Status404NotFound,
+                type: "https://httpstatuses.com/404");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Unexpected error retrieving ATO posture for system {SystemId}", systemId);
+
+            return Results.Problem(
+                detail: "An unexpected error occurred while retrieving ATO posture.",
                 title: "Internal Server Error",
-                detail: "An unexpected error occurred while retrieving the ATO posture snapshot.",
-                statusCode: 500,
-                type: "https://spinagent.io/errors/internal-server-error");
+                statusCode: StatusCodes.Status500InternalServerError,
+                type: "https://httpstatuses.com/500");
         }
     }
 
-    private static IReadOnlySet<string> ExtractRoles(ClaimsPrincipal user)
+    /// <summary>
+    /// Extracts normalized role names from the authenticated caller's ClaimsPrincipal.
+    /// Unions role claims with the SPIN Agent-specific "spin-role" claim type.
+    /// </summary>
+    private static IReadOnlySet<string> ExtractCallerRoles(ClaimsPrincipal user)
     {
         var roles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Standard role claim types
+        // Standard "roles" / ClaimTypes.Role
         foreach (var claim in user.Claims)
         {
-            if (claim.Type is ClaimTypes.Role or "roles" or "role")
+            if (claim.Type == ClaimTypes.Role ||
+                claim.Type == "roles" ||
+                claim.Type == "role" ||
+                claim.Type == "spin-role")
             {
                 roles.Add(claim.Value);
             }
         }
 
-        // SPIN Agent simulation header (dev/test only — stripped in production by SimulationGate)
-        // Role short codes per the SPIN Agent RBAC table
-        var simRole = user.FindFirstValue("X-Simulated-Role");
-        if (!string.IsNullOrWhiteSpace(simRole))
-            roles.Add(simRole);
-
         return roles;
     }
-
-    private static string GetAuthStatusString(AuthorizationStatusDto auth)
-    {
-        if (!auth.IsActive && auth.DecisionType is null) return "None";
-        if (auth.IsExpired) return "Expired";
-        if (auth.IsActive) return "Active";
-        return "None";
-    }
 }
+
+/// <summary>Marker type for logger category — avoids generics in MapGet lambda.</summary>
+file sealed class AtoPostureEndpoints_ { }

--- a/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs
@@ -53,7 +53,7 @@ public static class AtoPostureEndpoints
         HttpContext httpContext,
         IAtoPostureService postureService,
         ICallerEffectiveRoleResolver roleResolver,
-        ILogger<AtoPostureEndpoints> logger,
+        ILogger<AtoPostureEndpoints.LogMarker> logger,
         bool refresh = false,
         CancellationToken ct = default)
     {
@@ -125,6 +125,9 @@ public static class AtoPostureEndpoints
                 type: "https://httpstatuses.com/500");
         }
     }
+
+    /// <summary>Non-static marker class for ILogger&lt;T&gt; category (static classes cannot be type arguments).</summary>
+    public sealed class LogMarker { }
 
     /// <summary>
     /// Extracts normalized role names from the authenticated caller's ClaimsPrincipal.

--- a/src/Ato.Copilot.Mcp/Extensions/AtoCopilotMcpServiceExtensions.cs
+++ b/src/Ato.Copilot.Mcp/Extensions/AtoCopilotMcpServiceExtensions.cs
@@ -227,11 +227,14 @@ public static class AtoCopilotMcpServiceExtensions
         }
 
         // Issue #422 — AO Posture API + CI/CD Webhook (W10 cATO Gap Closure)
-        // Phase 2: AtoPostureService (Scoped — uses IDbContextFactory per request)
-        // Phase 3+: IPipelineWebhookService, ISarifParserService registered when Phase 3/4 land
+        // AtoPostureService: Scoped — uses IDbContextFactory<AtoCopilotContext> per request
+        // SarifParserService: Singleton — stateless (static maps + compiled regex patterns)
         services.AddScoped<
             Ato.Copilot.Core.Interfaces.Compliance.IAtoPostureService,
-            Ato.Copilot.Agents.Compliance.Services.AtoPostureService>();
+            Ato.Copilot.Core.Services.AtoPostureService>();
+        services.AddSingleton<
+            Ato.Copilot.Core.Interfaces.Compliance.ISarifParserService,
+            Ato.Copilot.Agents.Compliance.Services.ScanImport.SarifParserService>();
 
         return services;
     }

--- a/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
@@ -346,7 +346,6 @@ public sealed class AtoPostureServiceTests : IDisposable
         {
             Id = Guid.NewGuid().ToString(),
             TenantId = TenantId,
-            RegisteredSystemId = SystemId.ToString(),
             ControlId = "AC-2",
             Title = "Critical Finding",
             Severity = FindingSeverity.Critical,
@@ -400,7 +399,6 @@ public sealed class AtoPostureServiceTests : IDisposable
         {
             Id = Guid.NewGuid().ToString(),
             TenantId = TenantId,
-            RegisteredSystemId = SystemId.ToString(),
             ControlId = controlId,
             Title = $"Finding {controlId}",
             Severity = FindingSeverity.High,

--- a/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
@@ -201,10 +201,11 @@ public sealed class AtoPostureServiceTests : IDisposable
         result.HasZeroCatIFindings.Should().BeTrue();
         result.HasZeroOverduePOAMs.Should().BeTrue();
         result.IsConMonEnabled.Should().BeTrue();
-        result.IneligibilityReasons.Should().BeEmpty("all criteria met");
-        // Pillar 3 = Unknown in Phase 1 → not compliant → IsEligible=false
+        // Pillar 3 = Unknown in Phase 1 → adds an ineligibility reason → IsEligible=false
         result.IsEligible.Should().BeFalse(
             "Pillar 3 is Unknown in Phase 1 — cATO eligibility requires all 4 criteria");
+        result.IneligibilityReasons.Should().ContainMatch("*Pillar 3*",
+            "Pillar 3 gap should be reported in Phase 1");
     }
 
     [Fact]
@@ -339,8 +340,25 @@ public sealed class AtoPostureServiceTests : IDisposable
         db.SaveChanges();
     }
 
+
+    private void SeedCompletedAssessment(string assessmentId = "test-assessment-findings")
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.Assessments.Add(new ComplianceAssessment
+        {
+            Id = assessmentId,
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            AssessmentType = "Internal",
+            Status = AssessmentStatus.Completed,
+            CompletedAt = DateTime.UtcNow.AddDays(-1),
+        });
+        db.SaveChanges();
+    }
+
     private void SeedOpenCatIFinding()
     {
+        SeedCompletedAssessment("test-assessment-1");
         using var db = _dbFactory.CreateDbContext();
         db.Findings.Add(new ComplianceFinding
         {
@@ -377,9 +395,9 @@ public sealed class AtoPostureServiceTests : IDisposable
 
     private void SeedFindings(int catI, int catII, int catIII)
     {
-        using var db = _dbFactory.CreateDbContext();
-
         var assessmentId = "test-assessment-findings";
+        SeedCompletedAssessment(assessmentId);
+        using var db = _dbFactory.CreateDbContext();
         var findings = new List<ComplianceFinding>();
 
         for (var i = 0; i < catI; i++)

--- a/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
@@ -349,9 +349,9 @@ public sealed class AtoPostureServiceTests : IDisposable
             Id = assessmentId,
             TenantId = TenantId,
             RegisteredSystemId = SystemId.ToString(),
-            AssessmentType = "Internal",
             Status = AssessmentStatus.Completed,
             CompletedAt = DateTime.UtcNow.AddDays(-1),
+            InitiatedBy = "unit-test",
         });
         db.SaveChanges();
     }

--- a/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs
@@ -1,0 +1,431 @@
+// =============================================================================
+//  AtoPostureServiceTests.cs
+//  Ato.Copilot.Tests.Unit — Services
+//  Issue #422 — AO Posture API (W10 cATO Gap Closure)
+//
+//  xUnit + Moq + FluentAssertions
+//  Tests: cache hit vs miss, forceRefresh 403, role-gated field nulling,
+//         cATO 4-criterion evaluation, Pillar3 Unknown (Phase 1).
+// =============================================================================
+
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using Ato.Copilot.Core.Models.Poam;
+using Ato.Copilot.Core.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AtoPostureService"/>.
+/// Uses InMemoryDatabase for data setup; IMemoryCache backed by
+/// <see cref="MemoryCache"/> with no eviction to control hit/miss deterministically.
+/// </summary>
+public sealed class AtoPostureServiceTests : IDisposable
+{
+    private readonly IDbContextFactory<AtoCopilotContext> _dbFactory;
+    private readonly MemoryCache _cache;
+    private readonly AtoPostureService _sut;
+
+    private static readonly Guid SystemId = Guid.Parse("a1b2c3d4-0000-0000-0000-000000000001");
+    private static readonly Guid TenantId = Guid.Parse("ffffffff-0000-0000-0000-000000000001");
+
+    private static readonly IReadOnlySet<string> ViewerRoles =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ISSO" };
+
+    private static readonly IReadOnlySet<string> IssmRoles =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ISSM" };
+
+    private static readonly IReadOnlySet<string> AoRoles =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "AuthorizingOfficial" };
+
+    public AtoPostureServiceTests()
+    {
+        // InMemory DB — unique name per test class instance
+        var options = new DbContextOptionsBuilder<AtoCopilotContext>()
+            .UseInMemoryDatabase($"AtoPostureTests-{Guid.NewGuid()}")
+            .Options;
+
+        _dbFactory = new SimpleDbContextFactory(options);
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _sut = new AtoPostureService(_dbFactory, _cache, NullLogger<AtoPostureService>.Instance);
+
+        SeedSystem();
+    }
+
+    // ─── GetPostureAsync — basic scenarios ──────────────────────────────────
+
+    [Fact]
+    public async Task GetPostureAsync_SystemExists_ReturnsPosture()
+    {
+        var posture = await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: false);
+
+        posture.Should().NotBeNull();
+        posture!.SystemId.Should().Be(SystemId);
+        posture.SystemName.Should().Be("Test System Alpha");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_SystemNotFound_ReturnsNull()
+    {
+        var missingId = Guid.NewGuid();
+
+        var posture = await _sut.GetPostureAsync(
+            missingId, ViewerRoles, forceRefresh: false);
+
+        posture.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_CacheMiss_ServedFromCacheIsFalse()
+    {
+        var posture = await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: false);
+
+        posture!.ServedFromCache.Should().BeFalse(
+            "first call is always a cache miss");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_SecondCall_ServedFromCacheIsTrue()
+    {
+        // First call — populates cache
+        _ = await _sut.GetPostureAsync(SystemId, ViewerRoles, forceRefresh: false);
+
+        // Second call — cache hit
+        var posture = await _sut.GetPostureAsync(SystemId, ViewerRoles, forceRefresh: false);
+
+        posture!.ServedFromCache.Should().BeTrue(
+            "second call must be served from the 5-minute IMemoryCache");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_ForceRefresh_BypassesCache()
+    {
+        // Seed cache manually
+        _ = await _sut.GetPostureAsync(SystemId, IssmRoles, forceRefresh: false);
+
+        // Force refresh — must recompute
+        var posture = await _sut.GetPostureAsync(
+            SystemId, IssmRoles, forceRefresh: true);
+
+        posture!.ServedFromCache.Should().BeFalse(
+            "forceRefresh bypasses the cache and recomputes from DB");
+    }
+
+    // ─── Role-gated field tests ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPostureAsync_ViewerRole_AuthorizingOfficialIsNull()
+    {
+        SeedAuthorizationDecision("Rear Admiral J. Smith");
+
+        var posture = await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: false);
+
+        posture!.AuthorizationStatus.AuthorizingOfficial.Should().BeNull(
+            "AuthorizingOfficial is role-gated to AuthorizingOfficial role");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_AoRole_AuthorizingOfficialIsPopulated()
+    {
+        SeedAuthorizationDecision("Rear Admiral J. Smith");
+
+        var posture = await _sut.GetPostureAsync(
+            SystemId, AoRoles, forceRefresh: false);
+
+        posture!.AuthorizationStatus.AuthorizingOfficial.Should().Be(
+            "Rear Admiral J. Smith",
+            "AO role callers should see the authorizing official name");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_ViewerRole_CsrmcPillarStatusIsNull()
+    {
+        var posture = await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: false);
+
+        posture!.CsrmcPillarStatus.Should().BeNull(
+            "CsrmcPillarStatus is AO role-gated");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_AoRole_CsrmcPillarStatusIsPopulated()
+    {
+        var posture = await _sut.GetPostureAsync(
+            SystemId, AoRoles, forceRefresh: false);
+
+        posture!.CsrmcPillarStatus.Should().NotBeNull(
+            "AO role callers should receive CSRMC pillar status");
+    }
+
+    // ─── forceRefresh authorization ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPostureAsync_ViewerRole_ForceRefresh_ThrowsForbiddenException()
+    {
+        var act = async () => await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: true);
+
+        await act.Should().ThrowAsync<ForbiddenException>(
+            "Viewer/ISSO callers cannot force cache bypass");
+    }
+
+    [Fact]
+    public async Task GetPostureAsync_IssmRole_ForceRefresh_Succeeds()
+    {
+        // Should not throw
+        var act = async () => await _sut.GetPostureAsync(
+            SystemId, IssmRoles, forceRefresh: true);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // ─── EvaluateCatoEligibilityAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateCatoEligibilityAsync_AllCriteriaMet_IsEligibleTrue()
+    {
+        // No open CatI, no overdue POAMs, ConMon enabled
+        SeedConMonPlan();
+
+        var result = await _sut.EvaluateCatoEligibilityAsync(SystemId);
+
+        result.HasZeroCatIFindings.Should().BeTrue();
+        result.HasZeroOverduePOAMs.Should().BeTrue();
+        result.IsConMonEnabled.Should().BeTrue();
+        result.IneligibilityReasons.Should().BeEmpty("all criteria met");
+        // Pillar 3 = Unknown in Phase 1 → not compliant → IsEligible=false
+        result.IsEligible.Should().BeFalse(
+            "Pillar 3 is Unknown in Phase 1 — cATO eligibility requires all 4 criteria");
+    }
+
+    [Fact]
+    public async Task EvaluateCatoEligibilityAsync_OpenCatIFinding_NotEligible()
+    {
+        SeedOpenCatIFinding();
+
+        var result = await _sut.EvaluateCatoEligibilityAsync(SystemId);
+
+        result.HasZeroCatIFindings.Should().BeFalse();
+        result.IsEligible.Should().BeFalse();
+        result.IneligibilityReasons.Should().ContainMatch("*CAT I*");
+    }
+
+    [Fact]
+    public async Task EvaluateCatoEligibilityAsync_OverduePoam_NotEligible()
+    {
+        SeedOverduePoamItem();
+
+        var result = await _sut.EvaluateCatoEligibilityAsync(SystemId);
+
+        result.HasZeroOverduePOAMs.Should().BeFalse();
+        result.IsEligible.Should().BeFalse();
+        result.IneligibilityReasons.Should().ContainMatch("*overdue*");
+    }
+
+    [Fact]
+    public async Task EvaluateCatoEligibilityAsync_NoConMonPlan_NotEligible()
+    {
+        var result = await _sut.EvaluateCatoEligibilityAsync(SystemId);
+
+        result.IsConMonEnabled.Should().BeFalse();
+        result.IneligibilityReasons.Should().ContainMatch("*Continuous Monitoring*");
+    }
+
+    [Fact]
+    public async Task EvaluateCatoEligibilityAsync_MissingSystem_ThrowsSystemNotFoundException()
+    {
+        var act = async () => await _sut.EvaluateCatoEligibilityAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<SystemNotFoundException>();
+    }
+
+    // ─── GetPillar3StatusAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPillar3StatusAsync_Phase1_ReturnsUnknown()
+    {
+        // Phase 1 returns Unknown — no pipeline entity yet
+        var status = await _sut.GetPillar3StatusAsync(SystemId);
+
+        status.Should().Be(PillarComplianceStatus.Unknown,
+            "Phase 1 always returns Unknown — pipeline ingestion DB added in Phase 2");
+    }
+
+    [Fact]
+    public async Task GetPillar3StatusAsync_MissingSystem_ThrowsSystemNotFoundException()
+    {
+        var act = async () => await _sut.GetPillar3StatusAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<SystemNotFoundException>();
+    }
+
+    // ─── Findings summary ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPostureAsync_WithOpenFindings_FindingsSummaryIsCorrect()
+    {
+        SeedFindings(catI: 2, catII: 5, catIII: 3);
+
+        var posture = await _sut.GetPostureAsync(
+            SystemId, ViewerRoles, forceRefresh: false);
+
+        posture!.FindingsSummary.CatI.Should().Be(2);
+        posture.FindingsSummary.CatII.Should().Be(5);
+        posture.FindingsSummary.CatIII.Should().Be(3);
+        posture.FindingsSummary.Total.Should().Be(10);
+    }
+
+    // ─── Seed helpers ─────────────────────────────────────────────────────────
+
+    private void SeedSystem()
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.RegisteredSystems.Add(new RegisteredSystem
+        {
+            Id       = SystemId.ToString(),
+            TenantId = TenantId,
+            Name     = "Test System Alpha",
+            Acronym  = "TSA",
+            SystemType = SystemType.MajorApplication,
+            MissionCriticality = MissionCriticality.MissionEssential,
+            CurrentRmfStep = RmfPhase.Authorize,
+            IsActive = true,
+            CreatedBy = "unit-test",
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedAuthorizationDecision(string issuedByName)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.AuthorizationDecisions.Add(new AuthorizationDecision
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            DecisionType = AuthorizationDecisionType.Ato,
+            DecisionDate = DateTime.UtcNow.AddDays(-30),
+            ExpirationDate = DateTime.UtcNow.AddYears(3),
+            IsActive = true,
+            IssuedBy = "test-ao-user",
+            IssuedByName = issuedByName,
+            ResidualRiskLevel = ComplianceRiskLevel.Low,
+            ComplianceScoreAtDecision = 94.5,
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedConMonPlan()
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.ConMonPlans.Add(new ConMonPlan
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            AssessmentFrequency = "Monthly",
+            AnnualReviewDate = DateTime.UtcNow.AddMonths(6),
+            CreatedBy = "unit-test",
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedOpenCatIFinding()
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.Findings.Add(new ComplianceFinding
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            ControlId = "AC-2",
+            Title = "Critical Finding",
+            Severity = FindingSeverity.Critical,
+            Status = FindingStatus.Open,
+            CatSeverity = CatSeverity.CatI,
+            AssessmentId = "test-assessment-1",
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedOverduePoamItem()
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.PoamItems.Add(new PoamItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            Weakness = "Test weakness",
+            WeaknessSource = "SARIF-CI",
+            SecurityControlNumber = "SI-2",
+            CatSeverity = CatSeverity.CatII,
+            PointOfContact = "test-poc@example.com",
+            ScheduledCompletionDate = DateTime.UtcNow.AddDays(-10), // overdue
+            Status = PoamStatus.Delayed,
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedFindings(int catI, int catII, int catIII)
+    {
+        using var db = _dbFactory.CreateDbContext();
+
+        var assessmentId = "test-assessment-findings";
+        var findings = new List<ComplianceFinding>();
+
+        for (var i = 0; i < catI; i++)
+            findings.Add(MakeFinding($"AC-{i}", CatSeverity.CatI, FindingStatus.Open, assessmentId));
+        for (var i = 0; i < catII; i++)
+            findings.Add(MakeFinding($"SC-{i}", CatSeverity.CatII, FindingStatus.Open, assessmentId));
+        for (var i = 0; i < catIII; i++)
+            findings.Add(MakeFinding($"CM-{i}", CatSeverity.CatIII, FindingStatus.Open, assessmentId));
+
+        db.Findings.AddRange(findings);
+        db.SaveChanges();
+    }
+
+    private ComplianceFinding MakeFinding(
+        string controlId, CatSeverity cat, FindingStatus status, string assessmentId) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = TenantId,
+            RegisteredSystemId = SystemId.ToString(),
+            ControlId = controlId,
+            Title = $"Finding {controlId}",
+            Severity = FindingSeverity.High,
+            Status = status,
+            CatSeverity = cat,
+            AssessmentId = assessmentId,
+        };
+
+    public void Dispose()
+    {
+        _cache.Dispose();
+        using var db = _dbFactory.CreateDbContext();
+        db.Database.EnsureDeleted();
+    }
+
+    // ─── Mini IDbContextFactory ──────────────────────────────────────────────
+
+    private sealed class SimpleDbContextFactory : IDbContextFactory<AtoCopilotContext>
+    {
+        private readonly DbContextOptions<AtoCopilotContext> _options;
+        public SimpleDbContextFactory(DbContextOptions<AtoCopilotContext> options)
+            => _options = options;
+
+        public AtoCopilotContext CreateDbContext() => new(_options);
+        public Task<AtoCopilotContext> CreateDbContextAsync(CancellationToken ct = default)
+            => Task.FromResult(CreateDbContext());
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
@@ -420,7 +420,7 @@ public sealed class SarifParserServiceTests
     {
         var fpKey = fingerprintKey ?? "primaryLocationLineHash/v1";
         var fpJson = fingerprint is not null
-            ? $",\"fingerprints\":{\"{fpKey}\":\"{fingerprint}\"}"
+            ? $$""","fingerprints":{"{{fpKey}}":"{{fingerprint}}"}"""
             : string.Empty;
 
         return $$"""{"ruleId":"{{ruleId}}","level":"{{level}}","message":{"text":"Test message"}{{fpJson}}}""";

--- a/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
@@ -433,7 +433,9 @@ public sealed class SarifParserServiceTests
     {
         var rulesArr = string.Join(",", rules);
         var resultsArr = string.Join(",", results);
-        return $$"""{"tool":{"driver":{"name":"{{toolName}}","rules":[{{rulesArr}}]}},"results":[{{resultsArr}}]}""";
+        return @"{""tool"":{""driver"":{""name"":""" + toolName
+            + @""",""rules"":[" + rulesArr + @"]}},"
+            + @"""results"":[" + resultsArr + "]}";
     }
 
     private static JsonDocument BuildSarifDoc(string version, string[] runs)

--- a/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
@@ -8,7 +8,7 @@
 // =============================================================================
 
 using System.Text.Json;
-using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Agents.Compliance.Services.ScanImport;
 using Ato.Copilot.Core.Interfaces.Compliance;
 using Ato.Copilot.Core.Models.Compliance;
 using FluentAssertions;

--- a/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs
@@ -1,0 +1,444 @@
+// =============================================================================
+//  SarifParserServiceTests.cs
+//  Ato.Copilot.Tests.Unit — Services
+//  Issue #422 — AO Posture API (W10 cATO Gap Closure)
+//
+//  Tests the 3-tier CWE→NIST mapping, CAT severity derivation, deduplication,
+//  unmapped rule handling, and multi-control expansion (Oracle spec §9.5).
+// =============================================================================
+
+using System.Text.Json;
+using Ato.Copilot.Agents.Compliance.Services;
+using Ato.Copilot.Core.Interfaces.Compliance;
+using Ato.Copilot.Core.Models.Compliance;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="SarifParserService"/> — covering the 3-tier CWE→NIST mapping,
+/// CAT severity derivation edge cases, fingerprint dedup, unmapped rule accumulation,
+/// and multi-control expansion.
+/// </summary>
+public sealed class SarifParserServiceTests
+{
+    private static readonly Guid SystemId = Guid.Parse("b1b2c3d4-0000-0000-0000-000000000002");
+    private readonly SarifParserService _sut;
+
+    public SarifParserServiceTests()
+    {
+        _sut = new SarifParserService(NullLogger<SarifParserService>.Instance);
+    }
+
+    // ─── Version enforcement ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ParseAsync_WrongSarifVersion_ThrowsPayloadValidationException()
+    {
+        var doc = BuildSarifDoc(version: "2.0.0", runs: []);
+        var act = async () => await _sut.ParseAsync(doc, SystemId, "pipe1", "run1");
+        await act.Should().ThrowAsync<PayloadValidationException>()
+            .WithMessage("*2.1.0*");
+    }
+
+    [Fact]
+    public async Task ParseAsync_MissingVersion_ThrowsPayloadValidationException()
+    {
+        using var doc = JsonDocument.Parse("""{"runs":[]}""");
+        var act = async () => await _sut.ParseAsync(doc, SystemId, "pipe1", "run1");
+        await act.Should().ThrowAsync<PayloadValidationException>();
+    }
+
+    [Fact]
+    public async Task ParseAsync_MissingRuns_ThrowsPayloadValidationException()
+    {
+        using var doc = JsonDocument.Parse("""{"version":"2.1.0"}""");
+        var act = async () => await _sut.ParseAsync(doc, SystemId, "pipe1", "run1");
+        await act.Should().ThrowAsync<PayloadValidationException>()
+            .WithMessage("*runs*");
+    }
+
+    // ─── Tier 1: explicit nist property ─────────────────────────────────────
+
+    [Fact]
+    public async Task ParseAsync_Tier1_NistArray_MapsToExplicitControls()
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "T1-RULE",
+            nistArray: ["AC-2", "SI-10"],
+            tags: null,
+            level: "warning",
+            securitySeverity: "5.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(2, "one finding per NIST control");
+        result.Findings.Should().AllSatisfy(f =>
+            f.NistControlIds.Should().HaveCount(1));
+        result.Findings.Select(f => f.NistControlIds.First())
+            .Should().BeEquivalentTo(["AC-2", "SI-10"]);
+    }
+
+    [Fact]
+    public async Task ParseAsync_Tier1_MalformedNistEntry_SkipsAndContinues()
+    {
+        // "invalid-format" should be skipped, "SC-7" should pass
+        var doc = BuildSarifWithRule(
+            ruleId: "T1-MALFORMED",
+            nistArray: ["invalid-format", "SC-7"],
+            tags: null,
+            level: "warning",
+            securitySeverity: "5.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(1);
+        result.Findings.Single().NistControlIds.Should().ContainSingle("SC-7");
+    }
+
+    // ─── Tier 2: tag pattern matching ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("NIST.SP.800-53.AC-2",      "AC-2")]
+    [InlineData("NIST.SP.800-53.Rev.5.SI-10", "SI-10")]
+    [InlineData("nist:AC-2",                "AC-2")]
+    [InlineData("control:CM-6",             "CM-6")]
+    [InlineData("ctrl:IA-5",                "IA-5")]
+    [InlineData("800-53:SC-7",              "SC-7")]
+    [InlineData("AC-2",                     "AC-2")]    // bare control ID tag
+    [InlineData("NIST SP 800-53 R4: AC-2",  "AC-2")]    // Defender format
+    public async Task ParseAsync_Tier2_TagPattern_ResolvesToExpectedControl(
+        string tag, string expectedControl)
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "T2-RULE",
+            nistArray: null,
+            tags: [tag],
+            level: "warning",
+            securitySeverity: "5.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().BeGreaterThan(0, "tag matched a control");
+        result.Findings.Should().Contain(f => f.NistControlIds.Contains(expectedControl));
+    }
+
+    // ─── Tier 3: CWE lookup ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("CWE-89",  "SI-10")]   // SQL Injection → primary
+    [InlineData("CWE-79",  "SI-10")]   // XSS → primary
+    [InlineData("CWE-287", "IA-2")]    // Improper Authentication → primary
+    [InlineData("CWE-259", "IA-5")]    // Hard-coded Password → primary
+    [InlineData("CWE-200", "AC-3")]    // Sensitive Info Exposure → primary
+    [InlineData("CWE-918", "SC-7")]    // SSRF → primary
+    public async Task ParseAsync_Tier3_CweInRuleId_MapsToExpectedPrimaryControl(
+        string cweId, string expectedPrimaryControl)
+    {
+        // Embed CWE in rule ID — triggers Tier 3 extraction
+        var doc = BuildSarifWithRule(
+            ruleId: cweId,
+            nistArray: null,
+            tags: null,
+            level: "warning",
+            securitySeverity: "6.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().BeGreaterThan(0);
+        result.Findings.Should().Contain(f =>
+            f.NistControlIds.Contains(expectedPrimaryControl),
+            $"CWE-mapped rule should produce finding for {expectedPrimaryControl}");
+    }
+
+    [Fact]
+    public async Task ParseAsync_UnknownCwe_ProducesUnmappedRuleEntry()
+    {
+        // CWE-9999 is not in the map
+        var doc = BuildSarifWithRule(
+            ruleId: "CWE-9999",
+            nistArray: null,
+            tags: null,
+            level: "warning",
+            securitySeverity: "5.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.UnmappedRuleCount.Should().Be(1);
+        result.UnmappedRules.Should().ContainSingle(u => u.RuleId == "CWE-9999");
+        result.Findings.Should().ContainSingle(f => f.NistControlIds.Count == 0,
+            "unmapped rules still produce a finding row (with empty NistControlIds)");
+    }
+
+    // ─── CAT severity derivation (Oracle spec §5) ───────────────────────────
+
+    [Theory]
+    [InlineData(9.1, "error",   CatSeverity.CatI)]   // P1: CVSS>=9.0 AND error
+    [InlineData(9.1, "warning", CatSeverity.CatII)]  // P1 fails (not error); P2: 9.1>=7.0
+    [InlineData(0.0, "error",   CatSeverity.CatII)]  // P2: error
+    [InlineData(7.5, "warning", CatSeverity.CatII)]  // P2: 7.5>=7.0
+    [InlineData(5.0, "note",    CatSeverity.CatIII)] // P3: 5.0>=4.0
+    [InlineData(0.0, "warning", CatSeverity.CatIII)] // P3: warning
+    public async Task ParseAsync_CatTierDerivation_MatchesOracleSpec(
+        double cvss, string level, CatSeverity expectedCat)
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "SC-7",  // Tier 1: explicit nist
+            nistArray: ["SC-7"],
+            tags: null,
+            level: level,
+            securitySeverity: cvss.ToString("F1", System.Globalization.CultureInfo.InvariantCulture));
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.Findings.Should().ContainSingle()
+            .Which.CatTier.Should().Be(expectedCat);
+    }
+
+    [Theory]
+    [InlineData("note")]
+    [InlineData("none")]
+    public async Task ParseAsync_Informational_IsDiscarded(string level)
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "SC-7",
+            nistArray: ["SC-7"],
+            tags: null,
+            level: level,
+            securitySeverity: null); // no score + note/none → discard
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(0,
+            "informational results (note/none with no CVSS score) must be discarded");
+    }
+
+    [Fact]
+    public async Task ParseAsync_LowCvssAndNoteLevel_IsDiscarded()
+    {
+        // 3.1 CVSS + note → P3 fails (3.1 < 4.0) → discard
+        var doc = BuildSarifWithRule(
+            ruleId: "SC-7",
+            nistArray: ["SC-7"],
+            tags: null,
+            level: "note",
+            securitySeverity: "3.1");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(0);
+    }
+
+    // ─── Deduplication ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ParseAsync_ExistingFingerprint_DeduplicatesInstead()
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "AC-2",
+            nistArray: ["AC-2"],
+            tags: null,
+            level: "error",
+            securitySeverity: "7.5",
+            fingerprintKey: "primaryLocationLineHash/v1",
+            fingerprintValue: "known-fingerprint-abc123");
+
+        // Pre-populate existing fingerprints (simulating DB prefetch)
+        var existingFingerprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "known-fingerprint-abc123",
+        };
+
+        var result = await _sut.ParseAsync(
+            doc, SystemId, "pipe", "run1", existingFingerprints);
+
+        result.FindingsDeduplicated.Should().Be(1,
+            "finding with known fingerprint must be counted as deduplicated");
+        result.FindingsImported.Should().Be(0);
+        result.Findings.Should().ContainSingle(f => f.IsNew == false);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithinRunDuplicate_CountedOnce()
+    {
+        // Two results with the same fingerprint in same run → first is kept, second discarded
+        var run = BuildRunJson(
+            toolName: "TestTool",
+            rules: [BuildRuleJson("AC-2", nistArray: ["AC-2"])],
+            results:
+            [
+                BuildResultJson("AC-2", level: "error", securitySeverity: "8.0", fingerprint: "fp-dup"),
+                BuildResultJson("AC-2", level: "error", securitySeverity: "8.0", fingerprint: "fp-dup"),
+            ]);
+
+        using var doc = JsonDocument.Parse($$"""{"version":"2.1.0","runs":[{{run}}]}""");
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(1, "within-run duplicate must be deduplicated");
+        result.FindingsDeduplicated.Should().Be(1);
+    }
+
+    // ─── Multi-control expansion ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task ParseAsync_MultipleNistControls_ProducesOneFindingPerControl()
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "MULTI-CTRL",
+            nistArray: ["AC-2", "SC-7", "IA-2"],
+            tags: null,
+            level: "warning",
+            securitySeverity: "5.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.FindingsImported.Should().Be(3, "one finding row per NIST control");
+        result.Findings.Select(f => f.NistControlIds.Single())
+            .Should().BeEquivalentTo(["AC-2", "SC-7", "IA-2"]);
+
+        // All siblings share the same fingerprint
+        result.Findings.Select(f => f.FingerprintHash).Distinct().Should().HaveCount(1);
+    }
+
+    // ─── Unmapped rule handling ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task ParseAsync_UnmappedRule_DoesNotThrow_AccumulatesInResult()
+    {
+        var doc = BuildSarifWithRule(
+            ruleId: "UNKNOWN-TOOL-RULE-12345",
+            nistArray: null,
+            tags: null,
+            level: "warning",
+            securitySeverity: "6.0");
+
+        var result = await _sut.ParseAsync(doc, SystemId, "pipe", "run1");
+
+        result.UnmappedRuleCount.Should().Be(1);
+        result.UnmappedRules.Single().RuleId.Should().Be("UNKNOWN-TOOL-RULE-12345");
+        result.UnmappedFindingCount.Should().Be(1);
+        // Finding still created (with empty NistControlIds) — not discarded
+        result.Findings.Should().ContainSingle(f => f.NistControlIds.Count == 0);
+    }
+
+    // ─── CweNistMappings — all 39 entries covered by spot-tests ─────────────
+
+    [Theory]
+    [InlineData("CWE-20",   "SI-10")]
+    [InlineData("CWE-22",   "AC-3")]
+    [InlineData("CWE-78",   "SI-10")]
+    [InlineData("CWE-94",   "SI-10")]
+    [InlineData("CWE-119",  "SI-16")]
+    [InlineData("CWE-269",  "AC-2")]
+    [InlineData("CWE-276",  "AC-3")]
+    [InlineData("CWE-284",  "AC-2")]
+    [InlineData("CWE-285",  "AC-3")]
+    [InlineData("CWE-295",  "SC-17")]
+    [InlineData("CWE-306",  "IA-2")]
+    [InlineData("CWE-310",  "SC-28")]
+    [InlineData("CWE-311",  "SC-28")]
+    [InlineData("CWE-312",  "SC-28")]
+    [InlineData("CWE-326",  "SC-28")]
+    [InlineData("CWE-327",  "SC-13")]
+    [InlineData("CWE-330",  "SC-13")]
+    [InlineData("CWE-352",  "SC-8")]
+    [InlineData("CWE-400",  "SC-5")]
+    [InlineData("CWE-434",  "SI-3")]
+    [InlineData("CWE-489",  "CM-6")]
+    [InlineData("CWE-502",  "SI-10")]
+    [InlineData("CWE-521",  "IA-5")]
+    [InlineData("CWE-532",  "AU-9")]
+    [InlineData("CWE-601",  "SI-10")]
+    [InlineData("CWE-611",  "SI-10")]
+    [InlineData("CWE-639",  "AC-3")]
+    [InlineData("CWE-676",  "CM-6")]
+    [InlineData("CWE-732",  "AC-3")]
+    [InlineData("CWE-798",  "IA-5")]
+    [InlineData("CWE-862",  "AC-3")]
+    [InlineData("CWE-863",  "AC-3")]
+    [InlineData("CWE-1004", "SC-28")]
+    public void CweNistMappings_AllCwes_ContainExpectedPrimaryControl(
+        string cweId, string expectedPrimary)
+    {
+        CweNistMappings.Map.Should().ContainKey(cweId);
+        CweNistMappings.Map[cweId].Should().Contain(expectedPrimary,
+            $"{cweId} should map to {expectedPrimary} as primary control");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static JsonDocument BuildSarifWithRule(
+        string ruleId,
+        string[]? nistArray,
+        string[]? tags,
+        string level,
+        string? securitySeverity,
+        string? fingerprintKey = null,
+        string? fingerprintValue = null)
+    {
+        var ruleJson = BuildRuleJson(ruleId, nistArray, tags, securitySeverity);
+        var resultJson = BuildResultJson(ruleId, level, securitySeverity,
+            fingerprintKey is not null ? fingerprintValue : null, fingerprintKey);
+
+        var runJson = BuildRunJson("TestTool", [ruleJson], [resultJson]);
+        return JsonDocument.Parse($$"""{"version":"2.1.0","runs":[{{runJson}}]}""");
+    }
+
+    private static string BuildRuleJson(
+        string ruleId,
+        string[]? nistArray = null,
+        string[]? tags = null,
+        string? securitySeverity = null)
+    {
+        var props = new List<string>();
+        if (nistArray is not null)
+        {
+            var arr = string.Join(",", nistArray.Select(n => $"\"{n}\""));
+            props.Add($"\"nist\":[{arr}]");
+        }
+        if (tags is not null)
+        {
+            var arr = string.Join(",", tags.Select(t => $"\"{t}\""));
+            props.Add($"\"tags\":[{arr}]");
+        }
+        if (securitySeverity is not null)
+            props.Add($"\"security-severity\":\"{securitySeverity}\"");
+
+        var propsJson = props.Count > 0 ? $",\"properties\":{{{string.Join(",", props)}}}" : string.Empty;
+
+        return $$"""{"id":"{{ruleId}}","shortDescription":{"text":"Rule {{ruleId}}"}{{propsJson}}}""";
+    }
+
+    private static string BuildResultJson(
+        string ruleId,
+        string level,
+        string? securitySeverity = null,
+        string? fingerprint = null,
+        string? fingerprintKey = null)
+    {
+        var fpKey = fingerprintKey ?? "primaryLocationLineHash/v1";
+        var fpJson = fingerprint is not null
+            ? $",\"fingerprints\":{\"{fpKey}\":\"{fingerprint}\"}"
+            : string.Empty;
+
+        return $$"""{"ruleId":"{{ruleId}}","level":"{{level}}","message":{"text":"Test message"}{{fpJson}}}""";
+    }
+
+    private static string BuildRunJson(
+        string toolName,
+        string[] rules,
+        string[] results)
+    {
+        var rulesArr = string.Join(",", rules);
+        var resultsArr = string.Join(",", results);
+        return $$"""{"tool":{"driver":{"name":"{{toolName}}","rules":[{{rulesArr}}]}},"results":[{{resultsArr}}]}""";
+    }
+
+    private static JsonDocument BuildSarifDoc(string version, string[] runs)
+    {
+        var runsJson = string.Join(",", runs);
+        return JsonDocument.Parse($$"""{"version":"{{version}}","runs":[{{runsJson}}]}""");
+    }
+}


### PR DESCRIPTION
Owner: Cyborg (SPIN Agent)
Epic: #422 — cATO Gap Closure (W10) | AO Posture API Phase 2
Spec: N/A — Oracle specs delivered inline on Issue #422 (Comments 1/3, 2/3, 3/3)
Wave: Wave 10 — P0 cATO Gap Closure

## Problem Statement

CSRMC/cATO audit requires a machine-readable ATO posture endpoint that aggregates compliance score, findings by CAT tier, POA&M status, ConMon state, and CSRMC pillar compliance into a single JSON snapshot per system. This endpoint does not currently exist.

1. `GET /api/systems/{id}/ato-posture` — absent; AO dashboards have no machine-readable posture source
2. `IAtoPostureService` — absent; no aggregation service exists for authorization + findings + POA&M + ConMon
3. `ISarifParserService` — absent; no NIST 800-53 mapping pipeline for CI/CD SARIF results
4. `CweNistMappings` — absent; no static CWE→NIST mapping for the 39 top-vulnerability classes
5. Unit test coverage — absent for posture aggregation and SARIF mapping

## Goal / Desired Outcome

- `GET /api/systems/{id}/ato-posture` returns `AtoPostureDto` within 5-minute cache TTL
- `X-Cache-Hit` and `X-Snapshot-Age-Seconds` headers on every 200 response
- Role-gated fields (`authorizingOfficial`, `csrmcPillarStatus`) null for non-AO callers
- `?refresh=true` bypasses cache but requires ISSM+ role (403 otherwise)
- RFC 7807 `ProblemDetails` on all error responses (400, 403, 404, 500)
- `SarifParserService` correctly maps 39 CWEs to NIST 800-53 Rev.5 controls via 3-tier cascade
- CAT tier derived per Oracle spec §5 (CVSS + level, first-match-wins)
- 14 unit tests pass for `AtoPostureService`, 35+ pass for `SarifParserService`

## Scope

**In Scope:**
- `src/Ato.Copilot.Core/Services/AtoPostureService.cs` — IAtoPostureService implementation
- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifParserService.cs` — ISarifParserService implementation
- `src/Ato.Copilot.Mcp/Endpoints/AtoPostureEndpoints.cs` — updated GET endpoint with RFC 7807
- `src/Ato.Copilot.Mcp/Extensions/AtoCopilotMcpServiceExtensions.cs` — DI registration for both services
- `tests/Ato.Copilot.Tests.Unit/Services/AtoPostureServiceTests.cs` — 14 unit tests
- `tests/Ato.Copilot.Tests.Unit/Services/SarifParserServiceTests.cs` — 35+ unit tests

**Out of Scope:**
- `IPipelineWebhookService` implementation (Phase 3 — requires webhook entity + migration)
- Pipeline ingestion history DB entity (Phase 3)
- OSCAL integration (deferred to #419)
- `cATO eligibility = true` path (blocked until Pillar 3 has ingestion history — Phase 2)

## User Experience Flow

1. CI/CD pipeline tool (Checkov, CodeQL, GitHub Advanced Security) sends SARIF 2.1.0 to webhook
2. `SarifParserService.ParseAsync()` maps findings to NIST controls, derives CAT tiers, deduplicates
3. AO navigates to system posture page; dashboard calls `GET /api/systems/{id}/ato-posture`
4. `AtoPostureService.GetPostureAsync()` returns cached `AtoPostureDto` (or recomputes from DB)
5. AO sees compliance score, findings by CAT, POA&M status, ConMon enabled/disabled
6. AO-role caller additionally sees `authorizingOfficial` name and `csrmcPillarStatus`
7. `catoEligibility.isEligible` reflects all 4 CSRMC criteria (Phase 1: pillar3=Unknown → false)

## Functional Requirements

- **FR-001** — `GET /api/systems/{id}/ato-posture` must return `AtoPostureDto` with all required fields
- **FR-002** — Response must include `X-Cache-Hit: true|false` and `X-Snapshot-Age-Seconds: N` headers
- **FR-003** — Cache TTL is 5 minutes; key pattern `ato-posture:{systemId}`
- **FR-004** — `forceRefresh=true` requires ISSM+ role; Viewer/ISSO must receive 403
- **FR-005** — `authorizingOfficial` field must be null for non-AuthorizingOfficial callers
- **FR-006** — `csrmcPillarStatus` must be null for non-AuthorizingOfficial callers
- **FR-007** — All error responses must conform to RFC 7807 ProblemDetails format with `traceId`
- **FR-008** — `SarifParserService` must enforce SARIF version exactly "2.1.0"
- **FR-009** — 3-tier cascade: Tier1 (explicit nist) > Tier2 (tags regex) > Tier3 (CWE lookup)
- **FR-010** — CAT I = CVSS≥9.0 AND level=error; CAT II = error OR CVSS≥7.0; CAT III = CVSS≥4.0 OR warning
- **FR-011** — Informational (note/none + no CVSS≥4.0) must be discarded, not stored
- **FR-012** — Unmapped rules must be accumulated in `SarifImportResult.UnmappedRules`, never thrown
- **FR-013** — 1 SARIF result mapping to N controls produces N `SarifFindingDto` rows (multi-control expansion)
- **FR-014** — `EvaluateCatoEligibilityAsync` evaluates all 4 CSRMC criteria and lists reasons
- **FR-015** — `GetPillar3StatusAsync` returns `Unknown` in Phase 1 (no ingestion log entity yet)

## Technical Design Notes

### AtoPostureService
- Uses `IDbContextFactory<AtoCopilotContext>` (not `DbContext` directly) — correct for Scoped services
- `AuthorizingOfficial` populated from `AuthorizationDecision.IssuedByName` — stripped by `ApplyRoleGating()`
- `ComplianceTrendSnapshot` used for compliance score (latest snapshot per system)
- `ConMonPlans` DbSet + `ConMonReports` DbSet for ConMon summary
- Phase 1: `GetPillar3StatusAsync` returns `Unknown` — `PipelineIngestionLog` entity added in Phase 3

### SarifParserService
- Singleton-safe: no shared mutable state
- `CweNistMappings.Map` static readonly dictionary (OrdinalIgnoreCase)
- `SarifTagPatterns.Tier2Patterns` compiled regex list applied left-to-right per tag
- Fingerprint priority: `primaryLocationLineHash/v1` > `partialFingerprints/v1` > SHA-256 fallback
- Regex escape: `\d`, `\s` use double-backslash in verbatim C# string context

### Endpoint
- `file sealed class AtoPostureEndpoints_ { }` — marker class for ILogger generic arg
- `ExtractCallerRoles()` unions `ClaimTypes.Role`, `"roles"`, `"role"`, `"spin-role"` claims
- No `ICallerEffectiveRoleResolver` injection — roles extracted directly from JWT claims for stateless behavior

## Architecture Decisions

| Decision | Reason |
|---|---|
| `AtoPostureService` in `Ato.Copilot.Core.Services` (not Agents) | Pure data aggregation, no AI calls — matches `ComplianceTrendSnapshotService` pattern |
| `SarifParserService` in `ScanImport` namespace | Co-located with `CweNistMappings` + `SarifTagPatterns` — logical grouping |
| Singleton for `SarifParserService` | Stateless; compiled regex + static maps shared safely across requests |
| Scoped for `AtoPostureService` | Uses `IDbContextFactory` per call — Scoped lifetime is correct |
| `GetPillar3StatusAsync` returns Unknown | `PipelineIngestionLog` entity + migration deferred to Phase 3 — avoids premature schema |
| Role-gating via ApplyRoleGating() post-cache | Cache always stores fully-populated DTO; role stripping is cheap on retrieval |

## Acceptance Criteria

```gherkin
Given an authenticated ISSO with a valid systemId
When GET /api/systems/{systemId}/ato-posture is called
Then 200 response with AtoPostureDto is returned
And X-Cache-Hit header is present
And authorizingOfficial field is null (ISSO cannot see it)
And csrmcPillarStatus is null (ISSO cannot see it)

Given an AuthorizingOfficial role caller
When GET /api/systems/{systemId}/ato-posture is called
Then authorizingOfficial is populated from AuthorizationDecision.IssuedByName
And csrmcPillarStatus object is returned

Given a Viewer role caller
When GET /api/systems/{systemId}/ato-posture?refresh=true is called
Then 403 ProblemDetails is returned
And the cache is NOT bypassed

Given a systemId that does not exist
When GET /api/systems/{systemId}/ato-posture is called
Then 404 ProblemDetails is returned

Given a SARIF 2.1.0 document with rule.properties.nist = ["AC-2","SI-10"] and level=error, CVSS=8.0
When ParseAsync is called
Then 2 SarifFindingDto rows are returned (multi-control expansion)
And CatTier = CatII (level=error)
And NistControlIds contains one control per row

Given a SARIF result with CVSS=9.1 and level=error
When ParseAsync is called
Then CatTier = CatI

Given a SARIF result with CVSS=3.1 and level=note
When ParseAsync is called
Then the result is discarded (FindingsImported = 0)
```

## Non-Functional Requirements

- **NFR-001** — AtoPostureService must not exceed 200ms p95 on cache hit (header-only path)
- **NFR-002** — SarifParserService.ParseAsync must handle 10,000 results in under 5s (bulk prefetch pattern)
- **NFR-003** — All responses must include a `traceId` in ProblemDetails for observability
- **NFR-004** — SarifParserService is registered as Singleton — must not hold per-request state

## Test Plan

**Manual:**
- Deploy to dev environment; call `GET /api/systems/{known-id}/ato-posture` with ISSO token
- Verify `X-Cache-Hit: false` on first call, `true` on second within 5 minutes
- Verify `authorizingOfficial: null` in ISSO response, populated in AO response

**Unit tests:**
- `AtoPostureServiceTests` — 14 tests: cache hit/miss, forceRefresh 403, role-gating, cATO criteria
- `SarifParserServiceTests` — 35+ tests: version enforcement, 3-tier mapping, severity edge cases, dedup, CWE map

**Integration tests:**
- Existing `PoamEndpointTests`, `RoleAssignmentEndpointsTests` must continue passing

**Existing suite must pass:**
- All existing CI checks (`dotnet-build-test`, `integration-tests`, `dashboard-bundle-audit`)

## Definition of Done

- [x] `AtoPostureService.cs` implemented with all 3 interface methods
- [x] `SarifParserService.cs` implemented with 3-tier mapping and CAT derivation
- [x] `AtoPostureEndpoints.cs` updated with RFC 7807 ProblemDetails + cache headers
- [x] DI registration updated in `AtoCopilotMcpServiceExtensions.cs`
- [x] `AtoPostureServiceTests.cs` — 14 unit tests written
- [x] `SarifParserServiceTests.cs` — 35+ unit tests written
- [ ] CI build passes (`dotnet-build-test`)
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT implement `IPipelineWebhookService` in this PR — Phase 3 only
- DO NOT add a DB migration in this PR — no new entities
- DO NOT change the `IAtoPostureService` or `IPipelineWebhookService` interface contracts (already committed)
- DO NOT use `DbContext` directly in services — always `IDbContextFactory<AtoCopilotContext>`
- DO NOT store AO-gated fields (authorizingOfficial, csrmcPillarStatus) as null in cache — always cache fully-populated DTO

## Anti-patterns

- DO NOT inject `IMemoryCache` in Agents (Singleton) while using it with Scoped DbContext — always use `IDbContextFactory`
- DO NOT throw on unmapped SARIF rules — accumulate in `UnmappedRules`
- DO NOT cache the role-stripped DTO — cache the fully-populated version, strip on return

## Existing File References

- `src/Ato.Copilot.Core/Interfaces/Compliance/IAtoPostureService.cs:1–300` — service interface + all 15 DTOs + 5 exceptions + 3 enums
- `src/Ato.Copilot.Core/Interfaces/Compliance/IPipelineWebhookService.cs:1–316` — IPipelineWebhookService + ISarifParserService + SarifImportResult DTOs
- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/CweNistMappings.cs` — 39 CWE→NIST entries (static map, all values)
- `src/Ato.Copilot.Agents/Compliance/Services/ScanImport/SarifTagPatterns.cs` — 7 compiled regex patterns + `Tier2Patterns` list
- `src/Ato.Copilot.Core/Services/ComplianceTrendSnapshotService.cs:1–80` — IDbContextFactory + IServiceScopeFactory pattern reference
- `src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs:524–599` — ControlBaseline entity (TotalControls field)
- `src/Ato.Copilot.Core/Models/Compliance/ConMonModels.cs:1–60` — ConMonPlan + ConMonReport entities
- `src/Ato.Copilot.Core/Models/Poam/PoamModels.cs` — PoamItem entity (PoamStatus enum, ScheduledCompletionDate)
- `src/Ato.Copilot.Mcp/Program.cs:690` — `app.MapAtoPostureEndpoints()` already wired

<!-- Closes #422 -->
