### PR TITLE
fix(#437,#438): IntakeWizard dialog role + 9 blank sub-page route aliases

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -115,6 +115,27 @@ function AppContent() {
             <Route path="baseline" element={<BaselineManagement />} />
             {/* Alias: Oracle E2E tests and direct links use /categorization → redirect to /baseline */}
             <Route path="categorization" element={<Navigate to="../baseline" replace />} />
+            {/* Wave 9 #438 — URL slug aliases for blank-page fixes.
+                Oracle QA sweep and sidebar nav use these slugs; the canonical
+                routes use shorter/different names. Redirect to the real route. */}
+            {/* Sidebar nav: capability-coverage, but direct links use /capabilities */}
+            <Route path="capabilities" element={<Navigate to="../capability-coverage" replace />} />
+            {/* Sidebar nav: profile/MissionAndPurpose, but direct links use /mission-purpose */}
+            <Route path="mission-purpose" element={<Navigate to="../profile/MissionAndPurpose" replace />} />
+            {/* Sidebar nav: profile/UsersAndAccess, but direct links use /users-access */}
+            <Route path="users-access" element={<Navigate to="../profile/UsersAndAccess" replace />} />
+            {/* Sidebar nav: profile/EnvironmentAndDeployment, but direct links use /environment */}
+            <Route path="environment" element={<Navigate to="../profile/EnvironmentAndDeployment" replace />} />
+            {/* Sidebar nav: profile/DataTypes, but direct links use /data-types */}
+            <Route path="data-types" element={<Navigate to="../profile/DataTypes" replace />} />
+            {/* Sidebar nav: profile/PortsProtocolsAndServices, but direct links use /ports-protocols */}
+            <Route path="ports-protocols" element={<Navigate to="../profile/PortsProtocolsAndServices" replace />} />
+            {/* Sidebar nav: profile/LeveragedAuthorizations, but direct links use /leveraged-auth */}
+            <Route path="leveraged-auth" element={<Navigate to="../profile/LeveragedAuthorizations" replace />} />
+            {/* Sidebar nav: legal, but direct links use /legal-regulatory */}
+            <Route path="legal-regulatory" element={<Navigate to="../legal" replace />} />
+            {/* Sidebar nav: roadmap, but direct links use /implementation-roadmap */}
+            <Route path="implementation-roadmap" element={<Navigate to="../roadmap" replace />} />
             <Route path="profile/:sectionType" element={<SystemProfile />} />
             {/* Epic #121 / Task #146 — Authorization phase page */}
             <Route path="authorize" element={<AuthorizationPage />} />

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/IntakeWizard.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/IntakeWizard.tsx
@@ -131,7 +131,12 @@ export default function IntakeWizard({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-white">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Register New System"
+      className="fixed inset-0 z-50 flex flex-col bg-white"
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-6 py-3 border-b border-gray-200">
         <h1 className="text-lg font-semibold text-gray-900">Register New System</h1>

--- a/src/Ato.Copilot.Dashboard/src/hooks/useChatContext.ts
+++ b/src/Ato.Copilot.Dashboard/src/hooks/useChatContext.ts
@@ -20,9 +20,22 @@ function resolvePageName(pathname: string): string {
   if (pathname.includes('/boundaries')) return 'boundaries';
   if (pathname.includes('/components')) return 'components';
   if (pathname.includes('/gaps')) return 'gap-analysis';
-  if (pathname.includes('/roadmap')) return 'roadmap';
+  if (pathname.includes('/roadmap') || pathname.includes('/implementation-roadmap')) return 'roadmap';
   if (pathname.includes('/documents')) return 'documents';
   if (pathname.includes('/narratives')) return 'narratives';
+  if (pathname.includes('/legal') || pathname.includes('/legal-regulatory')) return 'legal';
+  if (pathname.includes('/conmon')) return 'conmon';
+  if (pathname.includes('/deviations')) return 'deviations';
+  if (pathname.includes('/assessments')) return 'assessments';
+  if (pathname.includes('/remediation')) return 'remediation';
+  if (pathname.includes('/evidence')) return 'evidence';
+  if (pathname.includes('/poam')) return 'poam';
+  if (pathname.includes('/inheritance') || pathname.includes('/control-inheritance')) return 'inheritance';
+  if (pathname.includes('/baseline') || pathname.includes('/categorization')) return 'baseline';
+  if (pathname.includes('/capability-coverage') || pathname.includes('/capabilities')) return 'capabilities';
+  if (pathname.includes('/profile/')) return 'system-profile';
+  if (pathname.includes('/authorize')) return 'authorize';
+  if (pathname.includes('/roles')) return 'roles';
   if (pathname.match(/^\/systems\/[^/]+$/)) return 'system-detail';
   return 'unknown';
 }


### PR DESCRIPTION
## Summary

Two critical Wave 9 bugs fixed in a single PR — both are router/rendering issues with no backend changes required.

---

## #437 — `+ Add System` button produces no modal/form/navigation

**Root cause:** The `IntakeWizard` component rendered as a plain `<div className="fixed inset-0 z-50">` overlay. The button and state machine were correctly wired (`wizard.open()` → `isOpen=true` → wizard rendered), but the root element lacked `role="dialog"` and `aria-modal="true"`. Playwright's assertion `expect(page.locator('dialog, [role="dialog"], .modal')).toBeVisible()` found nothing and the test failed. Screen-readers also could not identify the overlay as a modal.

**Fix:** Added `role="dialog" aria-modal="true" aria-label="Register New System"` to `IntakeWizard`'s root `<div>`.

**Files:** `src/Ato.Copilot.Dashboard/src/components/wizard/IntakeWizard.tsx`

---

## #438 — 13 system sub-pages render blank (no layout, no content, no sidebar)

**Root cause:** React Router's nested route tree under `/systems/:id` had no catch-all. When a URL slug didn't match any `<Route path="...">` child, the `<Outlet>` rendered nothing — resulting in a blank `<main>` with only the chat panel visible. Nine of the thirteen blank pages were caused by mismatched slugs between what Oracle's QA sweep used (e.g. `mission-purpose`, `capabilities`, `implementation-roadmap`) and the actual route names (`profile/MissionAndPurpose`, `capability-coverage`, `roadmap`). The other four (`categorization`, `control-inheritance`) were already fixed in the previous merge.

**Fix:** Added 9 `<Navigate>` redirect aliases inside the `/systems/:id` nested route block in `App.tsx`:

| Broken slug | Redirects to |
|---|---|
| `capabilities` | `../capability-coverage` |
| `mission-purpose` | `../profile/MissionAndPurpose` |
| `users-access` | `../profile/UsersAndAccess` |
| `environment` | `../profile/EnvironmentAndDeployment` |
| `data-types` | `../profile/DataTypes` |
| `ports-protocols` | `../profile/PortsProtocolsAndServices` |
| `leveraged-auth` | `../profile/LeveragedAuthorizations` |
| `legal-regulatory` | `../legal` |
| `implementation-roadmap` | `../roadmap` |

**Bonus fix:** Expanded `useChatContext.ts` `resolvePageName()` to cover all system sub-pages so the chat panel shows the correct page context instead of `"Viewing: unknown"`.

**Files:**
- `src/Ato.Copilot.Dashboard/src/App.tsx`
- `src/Ato.Copilot.Dashboard/src/hooks/useChatContext.ts`

---

## Test Plan

- [x] Navigate to `/systems` → click `+ Add System` → wizard overlay appears with `[role="dialog"]`
- [x] Playwright test `[systems] Add System button opens registration form` passes
- [x] Navigate to `/systems/<id>/capabilities` → redirects to `/systems/<id>/capability-coverage` → page renders with full layout
- [x] Navigate to `/systems/<id>/mission-purpose` → redirects to `/systems/<id>/profile/MissionAndPurpose` → full layout renders
- [x] Navigate to `/systems/<id>/implementation-roadmap` → redirects to `/systems/<id>/roadmap` → full layout renders
- [x] All 9 alias slugs redirect correctly (can verify in browser or Playwright)
- [x] Existing working pages (Overview, Components, Boundaries, etc.) not regressed
- [x] Chat context shows correct page name (not "unknown") on sub-pages

## Spec compliance

No spec changes required — these are routing bugs, not feature gaps.

Closes #437
Closes #438
