### PR TITLE
fix(471): fix Azure OpenAI endpoint URL and deployment name breaking chat AI

### DIFF
--- a/src/Ato.Copilot.Dashboard/vite.config.ts
+++ b/src/Ato.Copilot.Dashboard/vite.config.ts
@@ -44,6 +44,11 @@ export default defineConfig({
         target: apiProxyTarget,
         changeOrigin: true,
       },
+      '/hubs': {
+        target: apiProxyTarget,
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
   build: {

--- a/src/Ato.Copilot.Mcp/appsettings.json
+++ b/src/Ato.Copilot.Mcp/appsettings.json
@@ -85,8 +85,8 @@
   "AzureAi": {
     "Enabled": true,
     "Provider": "OpenAi",
-    "Endpoint": "https://ato-copilot-ai.openai.azure.com/openai/v1",
-    "DeploymentName": "gpt-5.4-mini",
+    "Endpoint": "https://ato-copilot-ai.openai.azure.com/",
+    "DeploymentName": "gpt-4o-mini",
     "UseManagedIdentity": true,
     "CloudEnvironment": "AzurePublicCloud",
     "MaxCompletionTokens": 4096,


### PR DESCRIPTION
Owner: Cyborg
Epic: #471 — Chat AI unreachable
Spec: N/A — stabilization
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

1. `src/Ato.Copilot.Mcp/appsettings.json:88` — `AzureAi:Endpoint` was set to
   `https://ato-copilot-ai.openai.azure.com/openai/v1`. The `Azure.AI.OpenAI`
   SDK constructs the full REST path internally from the *base service URL*;
   appending `/openai/v1` causes every chat completion request to 404 on the
   Azure endpoint, making the AI unreachable on every page load.
2. `appsettings.json:89` — `DeploymentName` was `gpt-5.4-mini`, which is not a
   valid Azure OpenAI model identifier.
3. `src/Ato.Copilot.Dashboard/vite.config.ts:42` — The Vite dev-server proxy
   only mapped `/api`, leaving `/hubs/*` unproxied. SignalR WebSocket upgrade
   requests to `/hubs/notifications` and `/hubs/chat` failed with connection
   errors during local development.

## Goal / Desired Outcome

- MCP server can reach Azure OpenAI and return AI responses through `/mcp/chat/stream`.
- Local development SignalR connections succeed without manual port configuration.

## Scope

**In Scope:**
- Fix `AzureAi:Endpoint` to base URL only (`https://ato-copilot-ai.openai.azure.com/`)
- Fix `AzureAi:DeploymentName` to `gpt-4o-mini`
- Add `/hubs` proxy entry with `ws: true` in `vite.config.ts`

**Out of Scope:**
- Chat service refactoring, MCP server logic changes, authentication plumbing

## User Experience Flow

1. User opens the SPIN Agent dashboard.
2. User types a message in the AI chat panel.
3. Frontend POSTs to `/api/mcp/chat/stream` → nginx → MCP server.
4. MCP server calls Azure OpenAI (now using correct base URL).
5. SSE stream returns with AI response — user sees response.

## Functional Requirements

- **FR-001** — `AzureAi:Endpoint` must be the Azure OpenAI *service* base URL only (no path suffix).
- **FR-002** — `AzureAi:DeploymentName` must reference a valid deployment name (`gpt-4o-mini`).
- **FR-003** — Vite dev proxy must forward `/hubs/*` WebSocket connections to the MCP backend.

## Technical Design Notes

The `Azure.AI.OpenAI.AzureOpenAIClient` constructor accepts a URI in the form
`https://<service>.openai.azure.com/`. The SDK then internally constructs:
`https://<service>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=...`

Passing `/openai/v1` as a path suffix caused double-pathing and a 404 on every call.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Base URL only | Azure.AI.OpenAI SDK appends the rest of the path automatically |
| `gpt-4o-mini` deployment | Valid small-cost deployment matching the `AzurePublicCloud` environment |
| Vite `/hubs` proxy with `ws: true` | Required for SignalR WebSocket negotiate in local dev |

## Acceptance Criteria

```gherkin
Given the MCP server is started with the corrected appsettings.json
When a user sends a chat message
Then the Azure OpenAI call succeeds (HTTP 200) and an AI response is streamed back

Given a local dev environment running vite
When the frontend initiates a SignalR connection to /hubs/notifications
Then the WebSocket upgrade succeeds and the connection state reaches "Connected"
```

## Non-Functional Requirements

- **NFR-001** — No change to MCP server startup time.

## Test Plan

**Manual:**
- Start MCP server locally, send a chat message, verify AI response appears.
- Verify `/health` endpoint reports AI provider as configured.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `AzureAi:Endpoint` is corrected to base URL form
- [x] `AzureAi:DeploymentName` is `gpt-4o-mini`
- [x] Vite `/hubs` proxy added with WebSocket support
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT modify `RegisterChatClient` — config-only fix
- DO NOT change the MCP server endpoint routing

## Anti-patterns

- Adding `/openai/v1` path to the Azure OpenAI service URL — the SDK handles this

## Existing File References

- `src/Ato.Copilot.Mcp/appsettings.json:88` — Endpoint (was `/openai/v1` suffix)
- `src/Ato.Copilot.Mcp/appsettings.json:89` — DeploymentName (was `gpt-5.4-mini`)
- `src/Ato.Copilot.Dashboard/vite.config.ts:42-50` — Vite proxy config
- `src/Ato.Copilot.Core/Extensions/CoreServiceExtensions.cs:129-175` — RegisterChatClient

<!-- Closes #471 -->