### PR TITLE
fix(439): bypass auth/tenant middleware for SignalR /hubs/* to fix 404 on every page load

### DIFF
--- a/src/Ato.Copilot.Mcp/Middleware/CacAuthenticationMiddleware.cs
+++ b/src/Ato.Copilot.Mcp/Middleware/CacAuthenticationMiddleware.cs
@@ -68,8 +68,9 @@ public class CacAuthenticationMiddleware
         ILoginAuditService? loginAudit = null,
         LoginAuditContextAccessor? auditContextAccessor = null)
     {
-        // Skip auth for health checks
-        if (context.Request.Path.StartsWithSegments("/health"))
+        // Skip auth for health checks and SignalR hub endpoints (#439)
+        if (context.Request.Path.StartsWithSegments("/health") ||
+            context.Request.Path.StartsWithSegments("/hubs"))
         {
             await _next(context);
             return;

--- a/src/Ato.Copilot.Mcp/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Ato.Copilot.Mcp/Middleware/TenantResolutionMiddleware.cs
@@ -65,6 +65,7 @@ public sealed class TenantResolutionMiddleware
         "/swagger",
         "/_metrics",
         "/.well-known",
+        "/hubs",   // SignalR hub negotiate/connect (#439)
     };
 
     /// <summary>


### PR DESCRIPTION
Owner: Cyborg
Epic: #439 — SignalR /hubs/notifications returns 404
Spec: N/A — stabilization
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

SignalR `/hubs/notifications` returns HTTP 404 on every page load. Both WebSocket
upgrade and SSE fallback connections fail. The hub IS registered in
`Program.cs:691` (`app.MapHub<NotificationHub>("/hubs/notifications")`), but the
route is never reached because upstream middleware short-circuits the request
before the routing pipeline runs.

1. `src/Ato.Copilot.Mcp/Middleware/TenantResolutionMiddleware.cs:59-69` —
   `BypassPrefixes` did not include `/hubs`. The middleware attempts tenant
   resolution on every SignalR negotiate request. With no tenant claim on the
   WebSocket handshake, the middleware rejects the request before the hub
   endpoint handles it.
2. `src/Ato.Copilot.Mcp/Middleware/CacAuthenticationMiddleware.cs:71-76` —
   The CAC auth bypass only exempted `/health`. SignalR connections arriving
   without a Bearer header (or with it in the query string before the
   `accessTokenFactory` wires up) were rejected at this layer.

## Goal / Desired Outcome

- `GET /hubs/notifications/negotiate?negotiateVersion=1` returns HTTP 200.
- WebSocket upgrade succeeds; SignalR connection state reaches `"Connected"`.
- SSE transport fallback also connects successfully.

## Scope

**In Scope:**
- Add `/hubs` to `TenantResolutionMiddleware.BypassPrefixes`
- Add `/hubs` bypass to `CacAuthenticationMiddleware`

**Out of Scope:**
- SignalR hub logic, notification delivery, auth handler changes

## User Experience Flow

1. Dashboard loads, `useNotifications` hook fires.
2. `HubConnectionBuilder.withUrl("/hubs/notifications")` initiates negotiate.
3. Negotiate request passes through middleware (now bypassed).
4. Hub endpoint responds 200, WebSocket upgrade succeeds.
5. Client receives real-time notifications.

## Functional Requirements

- **FR-001** — Middleware must not block `/hubs/*` paths before hub routing.
- **FR-002** — Hub-level `[Authorize]` attributes remain the auth enforcement point.

## Technical Design Notes

SignalR negotiate is a POST/GET to `/hubs/<name>/negotiate?negotiateVersion=1`
that happens before authentication tokens are available in the WebSocket context.
The pattern for SignalR + JWT is: bypass auth middleware for the hub path prefix,
let the hub's own `[Authorize]` attribute (or method-level checks) enforce
authorization after the WebSocket connection is established.

Both `TenantResolutionMiddleware` and `CacAuthenticationMiddleware` run before
`UseRouting`/`UseAuthorization`, making them the correct place for the bypass.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Bypass at `/hubs` prefix | SignalR negotiate has no Bearer/tenant context; hub handles auth post-connect |
| Keep hub-level auth intact | `SubscribeToWizardJob` still requires `OnboardingAdministratorRequirement` |

## Acceptance Criteria

```gherkin
Given the MCP server is running
When a client sends POST /hubs/notifications/negotiate?negotiateVersion=1
Then the response is HTTP 200 with a connection ID

Given a SignalR connection is established
When the client calls RegisterUser with a valid userId
Then the client joins the user group successfully
```

## Non-Functional Requirements

- **NFR-001** — No regression on `/api/auth/*`, `/api/dashboard/*`, or MCP tool endpoints.

## Test Plan

**Manual:**
- Load dashboard, open DevTools Network tab, verify `/hubs/notifications/negotiate` returns 200.
- Verify WebSocket connection state is `"Connected"` in browser console.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `/hubs` added to `TenantResolutionMiddleware.BypassPrefixes`
- [x] `/hubs` bypass added to `CacAuthenticationMiddleware`
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT remove hub-level authorization checks
- DO NOT change hub registration in Program.cs

## Anti-patterns

- Adding `[AllowAnonymous]` to the hub class — the hub methods still require auth

## Existing File References

- `src/Ato.Copilot.Mcp/Middleware/TenantResolutionMiddleware.cs:59-69` — BypassPrefixes
- `src/Ato.Copilot.Mcp/Middleware/CacAuthenticationMiddleware.cs:71-76` — health bypass
- `src/Ato.Copilot.Mcp/Program.cs:691` — Hub registration

<!-- Closes #439 -->