### PR TITLE
fix(470): add nginx proxy block for /api/roles/ to fix 405 on Assign Role

### DIFF
--- a/src/Ato.Copilot.Dashboard/nginx.conf
+++ b/src/Ato.Copilot.Dashboard/nginx.conf
@@ -141,6 +141,29 @@ server {
         proxy_ssl_server_name on;
     }
 
+    # Proxy Feature 049 unified RMF role assignments API (#470)
+    # Covers: /api/roles/system/{systemId}, /api/roles/organization, /api/roles/effective
+    location /api/roles/ {
+        proxy_pass ${MCP_BASE_URL};
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
+    # Proxy AO Posture API (#422 W10 cATO Gap Closure)
+    location /api/systems/ {
+        proxy_pass ${MCP_BASE_URL};
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
     # Proxy SignalR notification hub (WebSocket upgrade support)
     location /hubs/notifications {
         proxy_pass ${MCP_BASE_URL}/hubs/notifications;


### PR DESCRIPTION
Owner: Cyborg
Epic: #470 — RMF Roles "Assign Role" returns HTTP 405
Spec: specs/049-unified-rmf-role-assignments/
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

`POST /api/roles/organization` and `POST /api/roles/system/{systemId}` return HTTP
405 when "Assign Role" is clicked in the RMF Roles management page. The endpoints
are registered correctly in `SystemRolesEndpoints.cs` and are reachable via the
Vite dev proxy. In production (Docker + nginx), however, no `location /api/roles/`
block exists in `nginx.conf` — the request path falls through to the SPA
`try_files` fallback, returning `index.html` (200) which axios mis-parses as 405.

Root cause: `src/Ato.Copilot.Dashboard/nginx.conf` has explicit proxy blocks for:
`/api/dashboard/`, `/api/v1/`, `/api/onboarding/`, `/api/csp/`, `/api/orgs/`,
`/api/tenants`, `/api/deployment/`, `/api/auth/`, `/api/audit/` — but no entry for
`/api/roles/`. The Feature 049 role API landed without a corresponding nginx route.

## Goal / Desired Outcome

- `POST /api/roles/organization` returns HTTP 200 from the MCP server.
- `POST /api/roles/system/{systemId}` returns HTTP 200.
- Assign Role dialog succeeds and updates the 7-row role panel.

## Scope

**In Scope:**
- Add `location /api/roles/` proxy block to `nginx.conf`
- Add `location /api/systems/` proxy block (AO Posture API #422 gap)

**Out of Scope:**
- `SystemRolesEndpoints.cs` changes, authentication, roles.ts changes

## User Experience Flow

1. User opens RMF Roles page, clicks "Assign" on an unassigned role.
2. `AssignRoleDialog` submits `POST /api/roles/organization`.
3. nginx routes to MCP server (now with correct proxy block).
4. MCP returns 200 success envelope.
5. Dialog closes, role panel refreshes with the newly assigned person.

## Functional Requirements

- **FR-001** — nginx must proxy `/api/roles/*` to `${MCP_BASE_URL}`.

## Technical Design Notes

nginx `location /api/dashboard/` uses `proxy_pass ${MCP_BASE_URL}` (no path
stripping). The same pattern is used for all new blocks. The `rolesClient` in
`api/roles.ts` sets `baseURL: '/api/roles'`, so calls arrive at nginx with the
full `/api/roles/...` path which must be proxied verbatim.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| `/api/roles/` prefix block | Matches all SystemRolesEndpoints routes |
| `/api/systems/` prefix block | AO Posture and per-system detail endpoints |

## Acceptance Criteria

```gherkin
Given the nginx container is running with the updated config
When a user clicks "Assign Role" in the RMF Roles page
Then POST /api/roles/organization returns HTTP 200 from the MCP server

Given an authenticated user in the RMF Roles panel
When they remove a per-system override
Then DELETE /api/roles/system/{id}/{role}/{personId} returns HTTP 200
```

## Non-Functional Requirements

- **NFR-001** — No change to other nginx proxy blocks.

## Test Plan

**Manual:**
- Load RMF Roles page, click Assign, fill in Person ID, submit — verify success.
- Check Network tab confirms 200 from /api/roles/organization.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `location /api/roles/` added to nginx.conf
- [x] `location /api/systems/` added to nginx.conf
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT modify `SystemRolesEndpoints.cs` or `roles.ts`
- DO NOT change authentication scheme

## Anti-patterns

- Relying on `/api/dashboard/` to catch `/api/roles/` — different path prefix

## Existing File References

- `src/Ato.Copilot.Dashboard/nginx.conf:134-143` — /api/audit/ block (insertion point)
- `src/Ato.Copilot.Mcp/Endpoints/SystemRolesEndpoints.cs:87` — MapGroup("/api/roles")

<!-- Closes #470 -->