### PR TITLE
fix(469): fix wizard Step 5 persons dropdown to use onboarding persons API

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
@@ -6,7 +6,7 @@ import type { ResolvedRoleAssignment, RmfRole } from '../../../types/roles';
 // Issue #469 — fix persons fetch: use onboarding persons API (not /api/dashboard/components)
 // /api/onboarding/persons returns Person records created during the wizard;
 // /api/dashboard/components?type=Person returns org-level SystemComponents (different table).
-import onboardingApi, { type PersonDto } from '../../../features/onboarding/api/onboardingApi';
+import { onboarding, type PersonDto } from '../../../features/onboarding/api/onboardingApi';
 
 const RMF_ROLES = [
   'AuthorizingOfficial',
@@ -42,7 +42,7 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
       .catch(() => setLoadError('Failed to load role assignments'));
     // Fix #469: fetch from /api/onboarding/persons (wizard Person records)
     // rather than /api/dashboard/components?type=Person (org SystemComponents).
-    onboardingApi.listPersons()
+    onboarding.listPersons()
       .then((data) => setPersons(data))
       .catch(() => setLoadError('Failed to load personnel'));
   }, [systemId]);

--- a/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx
@@ -3,7 +3,10 @@ import { useState, useEffect } from 'react';
 // (FR-008 / FR-010 unified role endpoints, Feature 049).
 import { rolesApi } from '../../../api/roles';
 import type { ResolvedRoleAssignment, RmfRole } from '../../../types/roles';
-import apiClient from '../../../api/client';
+// Issue #469 — fix persons fetch: use onboarding persons API (not /api/dashboard/components)
+// /api/onboarding/persons returns Person records created during the wizard;
+// /api/dashboard/components?type=Person returns org-level SystemComponents (different table).
+import onboardingApi, { type PersonDto } from '../../../features/onboarding/api/onboardingApi';
 
 const RMF_ROLES = [
   'AuthorizingOfficial',
@@ -21,12 +24,6 @@ const ROLE_LABELS: Record<string, string> = {
   SystemOwner: 'System Owner',
 };
 
-interface PersonOption {
-  id: string;
-  name: string;
-  personName: string;
-}
-
 interface AssignRolesProps {
   systemId: string;
   onNext: () => void;
@@ -35,7 +32,7 @@ interface AssignRolesProps {
 
 export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesProps) {
   const [assignments, setAssignments] = useState<ResolvedRoleAssignment[]>([]);
-  const [persons, setPersons] = useState<PersonOption[]>([]);
+  const [persons, setPersons] = useState<PersonDto[]>([]);
   const [saving, setSaving] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -43,14 +40,16 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
     rolesApi.getSystemRoles(systemId)
       .then((res) => setAssignments(res.roles.filter((r) => r.source !== 'not-assigned')))
       .catch(() => setLoadError('Failed to load role assignments'));
-    apiClient.get('/components', { params: { type: 'Person', pageSize: 200 } })
-      .then((res) => setPersons(res.data.items ?? []))
+    // Fix #469: fetch from /api/onboarding/persons (wizard Person records)
+    // rather than /api/dashboard/components?type=Person (org SystemComponents).
+    onboardingApi.listPersons()
+      .then((data) => setPersons(data))
       .catch(() => setLoadError('Failed to load personnel'));
   }, [systemId]);
 
   const getAssignment = (role: string) => assignments.find((a) => a.role === role);
 
-  const handleAssign = async (role: string, person: PersonOption) => {
+  const handleAssign = async (role: string, person: PersonDto) => {
     setSaving(role);
     try {
       const result = await rolesApi.assignSystemRole(systemId, {
@@ -77,7 +76,7 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
         <p className="mb-2 text-sm text-red-600">{loadError}</p>
       )}
       <h2 className="text-xl font-semibold text-gray-900 mb-1">Step 5: Assign RMF Roles</h2>
-      <p className="text-sm text-gray-500 mb-6">Assign personnel to standard RMF roles from existing Person components.</p>
+      <p className="text-sm text-gray-500 mb-6">Assign personnel to standard RMF roles from existing Person records.</p>
 
       <div className="space-y-4">
         {RMF_ROLES.map((role) => {
@@ -106,7 +105,7 @@ export default function AssignRoles({ systemId, onNext, onErrors }: AssignRolesP
                 <option value="">Select person...</option>
                 {persons.map((p) => (
                   <option key={p.id} value={p.id}>
-                    {p.personName || p.name}
+                    {p.displayName}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
Owner: Cyborg
Epic: #469 — Wizard Steps 5/6 "Failed to load role assignments"
Spec: specs/047-onboarding-wizard/
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

Wizard Steps 5 (Assign RMF Roles) and 6 (Verify Roles) both show
"Failed to load role assignments" on every render.

Two root causes:

1. `AssignRoles.tsx:45-48` — The person dropdown calls:
   `apiClient.get('/components', { params: { type: 'Person', pageSize: 200 } })`
   This targets `GET /api/dashboard/components?type=Person` which queries
   `SystemComponents WHERE RegisteredSystemId IS NULL AND ComponentType = 'Person'`.
   Person records created by the onboarding wizard via `POST /api/onboarding/persons`
   are stored in the `Persons` table — completely separate from `SystemComponents`.
   The dropdown was always empty, making role assignment impossible.

2. (Compounded by #470) `GET /api/roles/system/{systemId}` was not proxied
   through nginx — the call returned HTML (SPA fallback) causing a parse error
   that triggered the "Failed to load role assignments" error state.

## Goal / Desired Outcome

- Wizard Step 5 person dropdown shows all Person records created during onboarding.
- Role assignment succeeds and Step 6 shows the assigned roles.

## Scope

**In Scope:**
- Replace `apiClient.get('/components')` with `onboardingApi.listPersons()` in `AssignRoles.tsx`
- Update `PersonOption` to use `PersonDto` (id + displayName)
- Remove unused `apiClient` import

**Out of Scope:**
- VerifyRoles.tsx (only calls rolesApi, no persons fetch needed)
- PersonEndpoints.cs, onboardingApi.ts

## User Experience Flow

1. User reaches wizard Step 5.
2. Step renders and calls `onboardingApi.listPersons()` → `GET /api/onboarding/persons`.
3. Persons created in wizard Step 2 appear in dropdowns.
4. User selects a person for each role and clicks "Assign".
5. `rolesApi.assignSystemRole` writes the role override.
6. User clicks "Next" → Step 6 shows the verified assignments.

## Functional Requirements

- **FR-001** — Wizard Step 5 must load persons from `/api/onboarding/persons`.
- **FR-002** — Each person dropdown entry must show `displayName`.

## Technical Design Notes

`PersonEndpoints.cs` at `/api/onboarding/persons` returns `PersonDto`:
`{ id, displayName, email, phoneNumber?, entraObjectId?, isLinkedToDirectory }`.

`onboardingApi.listPersons()` (from `features/onboarding/api/onboardingApi.ts:156`)
wraps this endpoint and returns `PersonDto[]` directly.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| `onboardingApi.listPersons()` | Targets the correct `Persons` table |
| `PersonDto` type reuse | Avoids a redundant local interface |

## Acceptance Criteria

```gherkin
Given an onboarding wizard with at least one Person created in Step 2
When the user reaches Step 5 (Assign RMF Roles)
Then the person dropdown is populated with all Person records
And the user can successfully assign a person to each role

Given role assignments have been made in Step 5
When the user navigates to Step 6 (Verify Roles)
Then the assigned roles are displayed without error
```

## Non-Functional Requirements

- **NFR-001** — No change to PersonEndpoints.cs or onboardingApi.ts.

## Test Plan

**Manual:**
- Create a person in Step 2, advance to Step 5, verify dropdown shows the person.
- Assign a person to a role, verify role appears in Step 6.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `AssignRoles.tsx` calls `onboardingApi.listPersons()`
- [x] `PersonDto` used instead of custom `PersonOption`
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT modify `PersonEndpoints.cs` or `onboardingApi.ts`
- DO NOT add a new persons API client

## Anti-patterns

- Fetching wizard persons from `/api/dashboard/components` — different table

## Existing File References

- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/AssignRoles.tsx:45-48` — wrong fetch
- `src/Ato.Copilot.Mcp/Endpoints/Onboarding/PersonEndpoints.cs:33` — correct endpoint
- `src/Ato.Copilot.Dashboard/src/features/onboarding/api/onboardingApi.ts:156` — listPersons

<!-- Closes #469 -->