### PR TITLE
fix(459): soft-delete draft system on wizard cancel — add cleanup on cancel

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/api/portfolio.ts
+++ b/src/Ato.Copilot.Dashboard/src/api/portfolio.ts
@@ -96,7 +96,7 @@ export async function generateSystemDescription(
  * Used by wizard cancel cleanup (Issue #459).
  */
 export async function discardSystem(systemId: string): Promise<void> {
-  await apiClient.delete();
+  await apiClient.delete(`/systems/${systemId}`);
 }
 
 // Feature 045: Re-export coverage KPI for Portfolio Risk Profile page

--- a/src/Ato.Copilot.Dashboard/src/api/portfolio.ts
+++ b/src/Ato.Copilot.Dashboard/src/api/portfolio.ts
@@ -90,5 +90,14 @@ export async function generateSystemDescription(
   return data.description;
 }
 
+
+/**
+ * Soft-deletes a system created during the intake wizard but never submitted.
+ * Used by wizard cancel cleanup (Issue #459).
+ */
+export async function discardSystem(systemId: string): Promise<void> {
+  await apiClient.delete();
+}
+
 // Feature 045: Re-export coverage KPI for Portfolio Risk Profile page
 export { getCoverage } from './capabilities';

--- a/src/Ato.Copilot.Dashboard/src/hooks/useIntakeWizard.ts
+++ b/src/Ato.Copilot.Dashboard/src/hooks/useIntakeWizard.ts
@@ -1,8 +1,10 @@
 import { useReducer, useCallback } from 'react';
 import { WizardStep } from '../types/dashboard';
 import type { WizardState, WizardStepData } from '../types/dashboard';
+// Issue #459 — import discardSystem for cancel cleanup
+import { discardSystem } from '../api/portfolio';
 
-// ─── Actions ───────────────────────────────────────────────────────────────────
+// --- Actions ---------------------------------------------------------------
 
 type WizardAction =
   | { type: 'OPEN' }
@@ -17,7 +19,7 @@ type WizardAction =
   | { type: 'CLEAR_VALIDATION_ERRORS' }
   | { type: 'FINISH' };
 
-// ─── Initial state ─────────────────────────────────────────────────────────────
+// --- Initial state ---------------------------------------------------------
 
 const initialStepData: WizardStepData = {
   registration: {
@@ -57,7 +59,7 @@ const initialState: WizardState = {
   isOpen: false,
 };
 
-// ─── Reducer ───────────────────────────────────────────────────────────────────
+// --- Reducer ---------------------------------------------------------------
 
 function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
@@ -145,12 +147,29 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   }
 }
 
-// ─── Hook ──────────────────────────────────────────────────────────────────────
+// --- Hook -----------------------------------------------------------------
 
 export function useIntakeWizard() {
   const [state, dispatch] = useReducer(wizardReducer, initialState);
 
   const open = useCallback(() => dispatch({ type: 'OPEN' }), []);
+
+  // Issue #459: cancelWithCleanup soft-deletes the draft system (if created on
+  // Step 1) before resetting wizard state. The API call is fire-and-forget so
+  // that a network failure doesn't block the modal from closing. Orphaned draft
+  // records are excluded from all dashboard queries by IsActive = false.
+  const cancelWithCleanup = useCallback(async (systemId: string | null): Promise<void> => {
+    if (systemId) {
+      try {
+        await discardSystem(systemId);
+      } catch {
+        // Best-effort: do not block wizard close on network error
+      }
+    }
+    dispatch({ type: 'CANCEL' });
+  }, []);
+
+  // Kept for backward compat (used by FINISH / step completion without cleanup)
   const cancel = useCallback(() => dispatch({ type: 'CANCEL' }), []);
   const reset = useCallback(() => dispatch({ type: 'RESET' }), []);
 
@@ -188,6 +207,7 @@ export function useIntakeWizard() {
     state,
     open,
     cancel,
+    cancelWithCleanup,
     reset,
     nextStep,
     prevStep,

--- a/src/Ato.Copilot.Dashboard/src/pages/PortfolioDashboard.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/PortfolioDashboard.tsx
@@ -175,7 +175,7 @@ export default function PortfolioDashboard() {
           onPrev={wizard.prevStep}
           onSkip={wizard.skipStep}
           onGoToStep={wizard.goToStep}
-          onCancel={() => { wizard.cancel(); fetchPortfolio(); }}
+          onCancel={() => { void wizard.cancelWithCleanup(wizard.state.systemId); fetchPortfolio(); }}
           onFinish={wizard.finish}
           onSystemId={wizard.setSystemId}
           onValidationErrors={wizard.setValidationErrors}

--- a/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
@@ -278,6 +278,39 @@ public static class DashboardEndpoints
             })
             .WithName("UpdateSystem");
 
+        // ─── Discard Draft System (wizard cancel cleanup) — #459 ─────────────
+        // Soft-deletes a system that was created during the intake wizard but
+        // never fully submitted. Sets IsActive = false so the record is excluded
+        // from all dashboard queries without cascading hard-deletes on child rows.
+        group.MapDelete("/systems/{systemId}", async (
+                string systemId,
+                AtoCopilotContext db,
+                CancellationToken ct) =>
+            {
+                var system = await db.RegisteredSystems
+                    .FirstOrDefaultAsync(s => s.Id == systemId && s.IsActive, ct);
+
+                if (system is null)
+                    return Results.NotFound(new ErrorResponse { Error = "System not found", ErrorCode = "SYSTEM_NOT_FOUND" });
+
+                system.IsActive = false;
+                system.ModifiedAt = DateTime.UtcNow;
+
+                db.DashboardActivities.Add(new DashboardActivity
+                {
+                    RegisteredSystemId = systemId,
+                    EventType = "SystemDiscarded",
+                    Actor = "dashboard-user",
+                    Summary = $"System '{system.Name}' discarded (wizard cancelled)",
+                    RelatedEntityType = "RegisteredSystem",
+                    RelatedEntityId = systemId,
+                });
+                await db.SaveChangesAsync(ct);
+
+                return Results.Ok(new { id = systemId, discarded = true });
+            })
+            .WithName("DiscardSystem");
+
         // ─── RMF Role Assignments ────────────────────────────────────────────
         group.MapGet("/systems/{systemId}/roles", async (
                 string systemId,


### PR DESCRIPTION
Owner: Cyborg
Epic: #459 — Wizard creates system DB record on Step 1 Next click, no cleanup on cancel
Spec: N/A — stabilization
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

1. `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemRegistration.tsx:58` —
   `registerSystem(body)` is called when the user clicks "Next" on Step 1. This
   immediately persists a `RegisteredSystem` row in the DB (`IsActive = true`).

2. `src/Ato.Copilot.Dashboard/src/hooks/useIntakeWizard.ts:154` — `cancel()` only
   dispatches `{ type: 'CANCEL' }` which resets local React state. No API call is
   made. The draft system record remains active in the DB forever.

3. No `DELETE /api/dashboard/systems/{systemId}` endpoint existed, so there was no
   server-side mechanism to discard the draft record.

## Goal / Desired Outcome

- Clicking Cancel at any wizard step after Step 1 soft-deletes the draft system.
- Draft system does not appear in the portfolio dashboard or metrics.

## Scope

**In Scope:**
- Add `DELETE /api/dashboard/systems/{systemId}` endpoint (soft-delete, sets `IsActive = false`)
- Add `discardSystem(systemId)` helper to `api/portfolio.ts`
- Add `cancelWithCleanup(systemId)` to `useIntakeWizard` hook
- Update `PortfolioDashboard.tsx` to call `cancelWithCleanup` instead of `cancel`

**Out of Scope:**
- Moving system creation to the final submit step (deferred — requires rearchitecting all
  subsequent wizard steps that depend on `systemId` being available)

## User Experience Flow

1. User opens wizard, fills Step 1, clicks Next (system created).
2. User decides to cancel at any step.
3. UI calls `cancelWithCleanup(systemId)`.
4. Backend `DELETE /api/dashboard/systems/{id}` sets `IsActive = false`.
5. Wizard state resets, modal closes.
6. Portfolio dashboard does not include the discarded system.

## Functional Requirements

- **FR-001** — `DELETE /api/dashboard/systems/{systemId}` must set `IsActive = false`.
- **FR-002** — Cancel must call the delete endpoint when `state.systemId != null`.
- **FR-003** — Network failure in delete must not prevent modal from closing.

## Technical Design Notes

`RegisteredSystem.IsActive` already exists as a soft-delete flag. All dashboard
queries filter `s.IsActive == true`. Setting it to `false` effectively removes
the record from all user-facing surfaces without cascading hard-deletes.

`cancelWithCleanup` is async and fire-and-forget: errors are swallowed so the
modal always closes regardless of network state. Orphan records from edge cases
(browser close mid-cleanup) are acceptable until the full refactor lands.

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Soft-delete via IsActive = false | No cascade risk; audit trail preserved |
| Fire-and-forget discard | Modal must close even on network error |
| Keep Step 1 create-on-next | Full refactor deferred to avoid regressions in steps 2-6 |

## Acceptance Criteria

```gherkin
Given a user completes Step 1 of the intake wizard
When the user clicks Cancel at any subsequent step
Then DELETE /api/dashboard/systems/{id} is called
And the system no longer appears in the portfolio dashboard

Given a network error occurs during discardSystem
When the user clicks Cancel
Then the wizard modal still closes
```

## Non-Functional Requirements

- **NFR-001** — Discard records a `DashboardActivity` audit row (`SystemDiscarded`).

## Test Plan

**Manual:**
- Open wizard, complete Step 1, cancel — verify system not in dashboard.
- Open wizard, complete Step 1, advance to Step 3, cancel — verify system not in dashboard.
- Simulate network error on DELETE, verify modal still closes.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `DELETE /api/dashboard/systems/{systemId}` endpoint added
- [x] `discardSystem` helper added to `portfolio.ts`
- [x] `cancelWithCleanup` added to `useIntakeWizard.ts`
- [x] `PortfolioDashboard.tsx` uses `cancelWithCleanup`
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT hard-delete the system record
- DO NOT block modal close on network failure

## Anti-patterns

- Resetting only local state on cancel without server cleanup

## Existing File References

- `src/Ato.Copilot.Dashboard/src/components/wizard/steps/SystemRegistration.tsx:58` — create-on-next
- `src/Ato.Copilot.Dashboard/src/hooks/useIntakeWizard.ts:154` — cancel dispatch only
- `src/Ato.Copilot.Core/Models/Compliance/RmfModels.cs:139` — IsActive field

<!-- Closes #459 -->