### PR TITLE
fix(466): return 0 instead of null for coveragePercent to fix N/A on dashboard

### DIFF
--- a/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs
@@ -53,7 +53,7 @@ public static class DashboardEndpoints
                 var configuredSystems = items.Count(i => i.IsSetupComplete);
                 var coveragePercent = items.Count > 0
                     ? Math.Round(100.0 * configuredSystems / items.Count, 1)
-                    : (double?)null;
+                    : 0.0;  // Issue #466: return 0 instead of null so frontend shows 0% not N/A
                 return Results.Ok(new
                 {
                     totalSystems = result.TotalCount,
@@ -112,7 +112,7 @@ public static class DashboardEndpoints
                 var configuredSystems = items.Count(i => i.IsSetupComplete);
                 var coveragePercent = items.Count > 0
                     ? Math.Round(100.0 * configuredSystems / items.Count, 1)
-                    : (double?)null;
+                    : 0.0;  // Issue #466: return 0 instead of null so frontend shows 0% not N/A
 
                 return Results.Ok(new
                 {
@@ -139,7 +139,7 @@ public static class DashboardEndpoints
                 var configuredSystems = items.Count(i => i.IsSetupComplete);
                 var coveragePercent = items.Count > 0
                     ? Math.Round(100.0 * configuredSystems / items.Count, 1)
-                    : (double?)null;
+                    : 0.0;  // Issue #466: return 0 instead of null so frontend shows 0% not N/A
 
                 return Results.Ok(new
                 {

--- a/src/Ato.Copilot.Mcp/Services/CapabilityImportService.cs
+++ b/src/Ato.Copilot.Mcp/Services/CapabilityImportService.cs
@@ -706,12 +706,13 @@ public class CapabilityImportService
             }
         }
 
+        // Issue #466: return 0.0 instead of null so frontend shows 0% not N/A
         double? coveragePercent = baselineControlCount > 0
             ? Math.Round((double)mappedControls / baselineControlCount.Value * 100, 1)
-            : null;
+            : 0.0;
         int? unmappedControls = baselineControlCount.HasValue
             ? baselineControlCount.Value - mappedControls
-            : null;
+            : 0;
 
         // Per-family breakdown
         var perFamily = new List<FamilyCoverage>();


### PR DESCRIPTION
Owner: Cyborg
Epic: #466 — Coverage % shows N/A, AVG Compliance shows 0% on dashboard
Spec: N/A — stabilization
Wave: Wave 8 — Stabilization Sprint

## Problem Statement

Two backend API responses returned `null` for numeric metrics, which the
frontend displayed as "N/A":

1. `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:56, 115, 142` —
   `GetDashboardRoot`, `GetDashboardMetricsLegacy`, `GetCoverageLegacy` all
   compute `coveragePercent` as `(double?)null` when `items.Count == 0`
   (no registered systems). React renders `null` as a blank value, and
   downstream string formatting (e.g., `coveragePct.toFixed(1) + '%'`) throws
   or produces "N/A".

2. `src/Ato.Copilot.Mcp/Services/CapabilityImportService.cs:709` —
   `ComputeCoverageAsync` returns `CoveragePercent = null` when no security
   baseline is selected (`baselineControlCount` is null/0). The
   `CoverageCards` component (`line 68`) guards with `coveragePct != null ?
   ... : 'N/A'`, producing "N/A" when the backend returns null.

## Goal / Desired Outcome

- Coverage % card shows "0%" (not "N/A") when no systems or no baseline configured.
- AVG Compliance shows correctly when systems exist; 0% is accurate for systems
  with no assessments.

## Scope

**In Scope:**
- Change `(double?)null` → `0.0` in 3 coveragePercent calculations in `DashboardEndpoints.cs`
- Change `null` → `0.0` for `coveragePercent` in `CapabilityImportService.ComputeCoverageAsync`
- Change `null` → `0` for `unmappedControls` in the same method

**Out of Scope:**
- Frontend rendering changes (backend returning 0 already resolves the N/A display)
- avgCompliance computation logic

## User Experience Flow

1. User opens the Dashboard with no systems registered.
2. Coverage % card shows "0.0%" in gray (no data yet) rather than "N/A".
3. User registers a system — Coverage % updates as data is added.

## Functional Requirements

- **FR-001** — `coveragePercent` must be 0.0 (not null) when no systems exist.
- **FR-002** — `OrgWideCoverage.CoveragePercent` must be 0.0 when no baseline selected.

## Technical Design Notes

The frontend `CoverageCards.tsx:68` already has: 
`value={coveragePct != null ? ${coveragePct.toFixed(1)}% : 'N/A'}`

With backend returning `0.0`, this renders `"0.0%"` with gray color — the
intended "no data" state. The `PortfolioRiskProfile.tsx` Coverage card also
uses `null` to trigger the "0%" fallback display (already working).

## Architecture Decisions

| Decision | Reason |
|----------|--------|
| Return 0.0 not null | 0% is accurate; N/A implies a calculation error |
| Keep 3 dashboard endpoint variants | All share the same fix pattern |

## Acceptance Criteria

```gherkin
Given no registered systems
When the dashboard loads
Then Coverage % displays "0.0%" (not "N/A")

Given systems registered but no baseline selected
When the CapabilityCoverage page loads
Then Coverage % displays "0.0%" (not "N/A")
```

## Non-Functional Requirements

- **NFR-001** — No change to existing assertions on non-null coverage values.

## Test Plan

**Manual:**
- Load dashboard with no systems — Coverage % shows 0%.
- Load Capability Coverage page with no baseline — Coverage % shows 0%.

**Existing suite must pass:**
- All existing CI checks

## Definition of Done

- [x] `DashboardEndpoints.cs` coveragePercent returns 0.0 when no items
- [x] `CapabilityImportService.cs` CoveragePercent/unmappedControls return 0 when no baseline
- [ ] All existing CI jobs still pass
- [ ] PR targets `azurenoops/spin_agent:main`

## Explicit Constraints

- DO NOT change metric aggregation logic for existing systems
- DO NOT change frontend rendering components

## Anti-patterns

- Returning null for a numeric metric when 0 is the correct value

## Existing File References

- `src/Ato.Copilot.Mcp/Endpoints/DashboardEndpoints.cs:54-56, 113-115, 140-142`
- `src/Ato.Copilot.Mcp/Services/CapabilityImportService.cs:709-715`
- `src/Ato.Copilot.Dashboard/src/components/capabilities/CoverageCards.tsx:68`

<!-- Closes #466 -->