### PR TITLE
fix(#468,#456): gap analysis empty state + health banner auth false positive

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
@@ -41,6 +41,12 @@ export function useAiHealthCheck() {
       if (resp.ok) {
         setStatus('healthy');
         return true;
+      } else if (resp.status === 401 || resp.status === 403) {
+        // Auth issue, not provider issue — MSAL token may not be cached yet.
+        // Don't show the degraded banner; treat as unknown and let the user
+        // retry once the session is fully authenticated.
+        setStatus('unknown');
+        return true;
       } else {
         setStatus('degraded');
         return false;

--- a/src/Ato.Copilot.Dashboard/src/pages/GapAnalysis.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/GapAnalysis.tsx
@@ -55,7 +55,7 @@ export default function GapAnalysis() {
     }
   }, [systemId]);
 
-  const { data: summary, refresh } = usePolling(fetchGaps, 60000);
+  const { data: summary, loading: gapLoading, refresh } = usePolling(fetchGaps, 60000);
 
   if (!systemId) return null;
 
@@ -93,9 +93,14 @@ export default function GapAnalysis() {
         </div>
       )}
 
-      {!summary ? (
+      {gapLoading && !summary ? (
         <div className="rounded-lg border border-gray-200 bg-white p-12 text-center text-gray-400">
           <p className="text-sm">Loading gap analysis…</p>
+        </div>
+      ) : !summary ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-12 text-center text-gray-400">
+          <p className="text-sm">No gap analysis data available. The endpoint may not be configured yet.</p>
+          <button onClick={() => void refresh()} className="mt-3 text-sm text-indigo-600 hover:underline">Retry</button>
         </div>
       ) : summary.items.length === 0 ? (
         <div className="rounded-lg border border-green-200 bg-green-50 p-8 text-center">


### PR DESCRIPTION
## Summary

Fixes 2 issues: Gap Analysis infinite spinner and AI health banner false positive.

## Fixes

### #468 [MEDIUM] — Gap Analysis infinite spinner
- **Root cause**: `usePolling` returns `{ data, loading, error }`. Component used `!summary` to show spinner but if the API returns null (404 or error), `loading` becomes `false` but `summary` stays `null` → spinner never goes away.
- **Fix**: Destructure `loading: gapLoading` from `usePolling`. Show spinner only when `gapLoading && !summary`. Show fallback empty state when `!gapLoading && !summary`.

### #456 [MEDIUM] — AI provider banner false positive
- **Root cause**: Health check fires when chat panel opens. If MSAL token acquisition fails (token not yet cached on page load), the request gets a 401 → `setStatus('degraded')` → banner shows even though the provider is healthy.
- **Fix**: In `useAiHealthCheck.check()`, if response is 401 or 403, set `status = 'unknown'` (not degraded). Auth failure is not a provider failure. The component already suppresses `unknown` status from display.

## Spec Compliance
- Build: ✅ `tsc -b && vite build` passes clean
