### PR TITLE
fix(#501): Terraform IaC — sticky sessions + auto transport for SignalR on ACA ingress

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -307,7 +307,11 @@ resource "azurerm_container_app" "mcp" {
   ingress {
     external_enabled = true
     target_port      = 8080
-    transport        = "http"
+    transport        = "auto" # "auto" enables HTTP + WebSocket upgrade (required for SignalR)
+
+    sticky_sessions {
+      affinity = "sticky" # Required for SignalR: connection IDs are server-local; without sticky sessions, negotiate lands on replica A and WebSocket connect hits replica B -> 404
+    }
 
     traffic_weight {
       percentage      = 100


### PR DESCRIPTION
## Summary

Synchronizes Terraform IaC with the live ACA configuration so a future `terraform apply` does not regress the working SignalR state.

## Root Cause

ACA ingress `transport = "http"` blocks the WebSocket upgrade handshake at the ingress layer. `transport = "auto"` is required so ACA allows HTTP/1.1 → WebSocket protocol upgrade.

Without sticky sessions, SignalR's negotiate response assigns a connection ID on replica A but the subsequent WebSocket connect can land on replica B, which has no record of the connection → HTTP 404.

**Live ACA state (verified via `az containerapp show`):**
- `transport`: `Auto` ✅
- `stickySessions.affinity`: `sticky` ✅

These were previously hot-patched directly on the live container app. This PR brings the Terraform IaC in sync so infrastructure-as-code matches reality.

## Changes

`infra/terraform/main.tf` — ingress block:
```hcl
ingress {
  transport = "auto"          # was "http"
  sticky_sessions {
    affinity = "sticky"       # new block
  }
  ...
}
```

## No Application Changes Needed

- ASP.NET Core: `AddSignalR()` + `MapHub<NotificationHub>("/hubs/notifications")` — correct, no changes
- TypeScript: `HubConnectionBuilder().withUrl().withAutomaticReconnect()` with no explicit transport override — correct, no changes

Closes #501