### PR TITLE
fix(terraform): upgrade azurerm ~> 4.0 — unblock CI (sticky_sessions requires AzureRM 4.x)

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 4.0"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Problem

CI/CD is completely blocked. `terraform plan` fails with:

```
Error: Unsupported block type
on infra/terraform/main.tf line 312:
312:     sticky_sessions {
Blocks of type "sticky_sessions" are not expected here.
```

## Root Cause

`sticky_sessions` inside `azurerm_container_app` ingress requires AzureRM **≥ 4.0**. The provider constraint was `~> 3.22`.

## Fix

**1 line change:** bump `version = "~> 3.22"` → `version = "~> 4.0"`

## Breaking Change Audit (main.tf)

| Item | Status |
|------|--------|
| `features {}` block in provider | ✅ Already present — 4.x mandatory |
| `key_vault {}` nested features | ✅ Unchanged — valid in both versions |
| `identity[0].principal_id` refs (×2) | ✅ Backward-compatible splat in 4.x |
| `ingress[0].fqdn` ref | ✅ Backward-compatible splat in 4.x |
| All overlay modules (rg, kv, acr, sql, openai) | ✅ Unaffected — module wrappers own their provider calls |

No resource renames, no attribute removals, no state migrations required.

## Why not remove sticky_sessions?

`sticky_sessions { affinity = "sticky" }` is required for SignalR. Without it, the negotiate handshake lands on replica A, the WebSocket upgrade hits replica B, and users get 404s on every reconnect. Removing it would restore CI but break SignalR in any multi-replica deployment.

## Testing

`terraform init && terraform plan -var-file="environments/dev.tfvars"` will confirm the block is accepted once the provider downloads 4.x.