### PR TITLE
fix(terraform): downgrade azurerm ~> 3.117 to resolve overlay provider constraint conflict

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 3.117"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
Owner: Cyborg
Fixes: CI Terraform Lint job broken on `main` since merge of #513

## Problem Statement

CI has been failing on every push to `main` since PR #513 merged. The **Terraform Lint** job fails at `terraform init (no backend)` with:

```
Error: Failed to query available provider packages
hashicorp/azurerm: no available releases match the given constraints ~> 3.22, ~> 3.36, ~> 4.0
```

Root cause: PR #513 bumped the root azurerm constraint to `~> 4.0`. The azurenoops overlay modules (overlays-key-vault 2.0, overlays-azsql 2.0, overlays-container-registry 2.0) all declare `~> 3.22` or `~> 3.36`. No azurerm release satisfies `~> 3.x AND ~> 4.0` simultaneously — `terraform init` exits code 1.

Why #513 CI passed: the `terraform-lint` job is gated by an `if:` condition that skips it for PRs not touching `infra/`. The constraint conflict was never exercised in the PR run. Once merged to `main`, every push triggers terraform-lint unconditionally and it fails.

## Goal / Desired Outcome

`terraform init -backend=false` resolves successfully. Terraform Lint CI job green on `main`.

## Scope

In Scope: `infra/terraform/main.tf` — one-line constraint change only.
Out of Scope: upgrading overlay modules to azurerm 4.x.

## Technical Design Notes

`~> 3.117` resolves to `>= 3.117.0, < 4.0.0`. This satisfies all overlay constraints AND is the minimum version that added `sticky_sessions` to `azurerm_container_app.ingress` (the feature that motivated #513). No sticky_sessions regression.

## Architecture Decisions

| Decision | Reason |
|---|---|
| `~> 3.117` not `~> 3.36` | `sticky_sessions` requires >= 3.117; `~> 3.36` would pass init but fail validate |
| No overlay module upgrades | Upstream azurenoops modules have no 4.x release; out of scope for CI hotfix |

## Acceptance Criteria

```gherkin
Given a push to main
When the Terraform Lint job runs
Then terraform init -backend=false exits with code 0
And terraform validate exits with code 0
And no provider constraint conflict error appears in the log
```

## Definition of Done

- [x] `infra/terraform/main.tf:22` changed from `~> 4.0` to `~> 3.117`
- [ ] Terraform Lint CI job green on this PR
- [ ] Merged to main, main branch CI green

## Existing File References

- `infra/terraform/main.tf:22` — azurerm version constraint (changed)
