### PR TITLE
fix(terraform): use azurerm ~> 3.36, remove sticky_sessions block, document post-deploy workaround

### DIFF
--- a/infra/docs/post-deploy-manual-steps.md
+++ b/infra/docs/post-deploy-manual-steps.md
@@ -1,0 +1,34 @@
+# Post-Deploy Manual Steps
+
+These steps cannot be automated via Terraform because the current azurenoops overlay
+modules require azurerm `~> 3.x`, while the Terraform resources that support these
+features require azurerm `~> 4.x`. Until upstream overlay modules publish 4.x-compatible
+releases, these must be applied manually after `terraform apply`.
+
+## 1. Enable Sticky Sessions (Required for SignalR)
+
+SignalR requires sticky session affinity on the Container App ingress. Without it,
+the SignalR negotiate handshake and WebSocket connection can land on different replicas,
+producing 404 errors.
+
+```bash
+az containerapp ingress sticky-sessions set \
+  --name <container-app-name> \
+  --resource-group <resource-group-name> \
+  --affinity sticky
+```
+
+**When:** After every `terraform apply` that creates or recreates the Container App.
+
+**Background:** `sticky_sessions` block in `azurerm_container_app.ingress` was added
+in azurerm provider 4.x. The overlay modules (overlays-key-vault 2.0, overlays-azsql 2.0,
+overlays-container-registry 2.0) all declare `azurerm ~> 3.x`. Constraint intersection
+`~> 3.x AND ~> 4.x` is unsatisfiable — no provider release matches both.
+
+**Resolution path:** When upstream azurenoops overlay modules publish 4.x releases,
+update `infra/terraform/main.tf` `required_providers.azurerm.version` to `~> 4.0`,
+uncomment the `sticky_sessions` block, and delete this step.
+
+## Tracking
+
+- GitHub issue: open a `P2` infra issue titled "Upgrade overlay modules to azurerm 4.x" to track the upstream dependency.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.117"
+      version = "~> 3.36"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"
@@ -309,9 +309,12 @@ resource "azurerm_container_app" "mcp" {
     target_port      = 8080
     transport        = "auto" # "auto" enables HTTP + WebSocket upgrade (required for SignalR)
 
-    sticky_sessions {
-      affinity = "sticky" # Required for SignalR: connection IDs are server-local; without sticky sessions, negotiate lands on replica A and WebSocket connect hits replica B -> 404
-    }
+    # sticky_sessions is NOT supported in azurerm ~> 3.x (added in 4.x).
+    # The overlay modules (overlays-key-vault, overlays-azsql, overlays-container-registry)
+    # all require azurerm ~> 3.x and cannot be bumped to 4.x until upstream publishes 4.x releases.
+    # Sticky session affinity for SignalR must be enabled via Azure Portal or az CLI post-deploy:
+    #   az containerapp ingress sticky-sessions set -n <app> -g <rg> --affinity sticky
+    # This is tracked in infra/docs/post-deploy-manual-steps.md.
 
     traffic_weight {
       percentage      = 100


### PR DESCRIPTION
Owner: Cyborg
Fixes: CI Terraform Lint `terraform validate` failure on `main` after #514

## Problem Statement

After PR #514 corrected the azurerm provider constraint from `~> 4.0` to `~> 3.117`, CI is still failing at `terraform validate`:

```
Error: Unsupported block type
  on main.tf line 312, in resource "azurerm_container_app" "mcp":
 312:     sticky_sessions {
Blocks of type "sticky_sessions" are not expected here.
```

The `sticky_sessions` block inside `azurerm_container_app.ingress` was added in azurerm **4.x**. It does not exist in the 3.x schema. Root constraint `~> 3.x` makes `terraform validate` reject the block.

**The underlying conflict is unresolvable within current overlay module versions:**

| Overlay Module | azurerm Constraint |
|---|---|
| `azurenoops/overlays-key-vault/azurerm 2.0.0` | `~> 3.22` |
| `azurenoops/overlays-azsql/azurerm 2.0.0` | `~> 3.36` |
| `azurenoops/overlays-container-registry/azurerm 2.0.0` | `~> 3.36` |
| `sticky_sessions` block requirement | `~> 4.x` |

No single azurerm version satisfies all four. The correct fix is:
1. Stay at `~> 3.36` (satisfies all overlay constraints)
2. Remove the `sticky_sessions` block from Terraform
3. Document sticky session enablement as a post-deploy `az CLI` step

## Goal / Desired Outcome

`terraform init -backend=false` + `terraform validate` both pass. CI Terraform Lint job green on `main`. Sticky session requirement for SignalR is documented and enforceable via az CLI post-deploy.

## Scope

**In Scope:**
- `infra/terraform/main.tf` — azurerm version + sticky_sessions block removal
- `infra/docs/post-deploy-manual-steps.md` — new file documenting the az CLI workaround

**Out of Scope:**
- Upgrading overlay modules to azurerm 4.x (no upstream 4.x releases exist)
- Application code

## Technical Design Notes

- `~> 3.36` resolves to `>= 3.36, < 4.0.0` — satisfies all overlay constraints
- Sticky session affinity for SignalR is applied via: `az containerapp ingress sticky-sessions set -n <app> -g <rg> --affinity sticky`
- This is idempotent and survives Container App config updates (it does NOT survive Container App recreation — in that case re-run the az CLI step)
- Resolution path: when upstream azurenoops overlays publish 4.x releases, restore `sticky_sessions` block and bump root to `~> 4.0`

## Architecture Decisions

| Decision | Reason |
|---|---|
| Remove sticky_sessions from Terraform, not disable-on-provision | Keeping the block with a comment causes validate failures; removing it is the only CI-clean option |
| `~> 3.36` not `~> 3.117` | `~> 3.117` passes init but still fails validate on sticky_sessions — no benefit over 3.36 |
| New `infra/docs/post-deploy-manual-steps.md` | Prevents the knowledge loss problem — a future engineer must know to apply sticky sessions after deploy |

## Acceptance Criteria

```gherkin
Given a push to main
When the Terraform Lint job runs
Then terraform fmt --check passes
And terraform init -backend=false exits with code 0
And terraform validate exits with code 0
And the Terraform Lint job conclusion is SUCCESS
```

## Definition of Done

- [x] `infra/terraform/main.tf` azurerm version = `~> 3.36`
- [x] `infra/terraform/main.tf` sticky_sessions block removed, replaced with explanatory comment
- [x] `infra/docs/post-deploy-manual-steps.md` created with az CLI workaround
- [ ] Terraform Lint CI job green on this PR
- [ ] Merged to main, main branch CI fully green

## Existing File References

- `infra/terraform/main.tf:19-23` — azurerm provider version constraint
- `infra/terraform/main.tf:307-320` — ingress block (sticky_sessions removed)
- `infra/docs/post-deploy-manual-steps.md` — new file

Supersedes #513 (bad direction — ~> 4.0), #514 (partial fix — init passes, validate fails)
