### PR TITLE
fix(#526): resolve 'Viewing: unknown' on system sub-pages and spurious degraded banner

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/__tests__/components/chat/AiHealthBanner.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/components/chat/AiHealthBanner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 
 // ── Hoist mocks BEFORE imports that import the real module ────────────────
 // acquireBearer lives in msalInstance; the health check calls it before fetch.

--- a/src/Ato.Copilot.Dashboard/src/__tests__/components/chat/AiHealthBanner.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/components/chat/AiHealthBanner.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ── Hoist mocks BEFORE imports that import the real module ────────────────
+// acquireBearer lives in msalInstance; the health check calls it before fetch.
+// We replace it with a no-op that always resolves to '' so MSAL is not needed.
+vi.mock('../../features/auth/msalInstance', () => ({
+  acquireBearer: vi.fn().mockResolvedValue(''),
+  getMsalInstance: vi.fn(),
+  setMsalInstance: vi.fn(),
+  DEFAULT_API_SCOPES: ['api://ato-copilot/.default'],
+}));
+
+import { useAiHealthCheck } from '../../../components/chat/AiHealthBanner';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeAbortError(): DOMException {
+  return new DOMException('The user aborted a request.', 'AbortError');
+}
+
+function makeTimeoutError(): DOMException {
+  return new DOMException('Signal timed out.', 'TimeoutError');
+}
+
+function makeNetworkError(): TypeError {
+  return new TypeError('Failed to fetch');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('useAiHealthCheck — fix #526: AbortError / TimeoutError must NOT trigger degraded', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sets status to "healthy" when fetch returns HTTP 200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const { result } = renderHook(() => useAiHealthCheck());
+    expect(result.current.status).toBe('unknown');
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    expect(healthy).toBe(true);
+    expect(result.current.status).toBe('healthy');
+  });
+
+  it('sets status to "degraded" on a genuine network error (TypeError)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(makeNetworkError());
+
+    const { result } = renderHook(() => useAiHealthCheck());
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    expect(healthy).toBe(false);
+    expect(result.current.status).toBe('degraded');
+  });
+
+  it('sets status to "unknown" (NOT "degraded") when fetch throws AbortError (fix #526)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(makeAbortError());
+
+    const { result } = renderHook(() => useAiHealthCheck());
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    // AbortError means navigation cancelled the request — not a real failure.
+    expect(result.current.status).toBe('unknown');
+    // Returns true so callers don't treat this as a health failure.
+    expect(healthy).toBe(true);
+  });
+
+  it('sets status to "unknown" (NOT "degraded") when fetch throws TimeoutError (fix #526)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(makeTimeoutError());
+
+    const { result } = renderHook(() => useAiHealthCheck());
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    expect(result.current.status).toBe('unknown');
+    expect(healthy).toBe(true);
+  });
+
+  it('sets status to "unknown" on HTTP 401 (auth not yet resolved, not a provider failure)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+
+    const { result } = renderHook(() => useAiHealthCheck());
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    expect(result.current.status).toBe('unknown');
+    expect(healthy).toBe(true);
+  });
+
+  it('sets status to "degraded" on HTTP 503 (real provider failure)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    const { result } = renderHook(() => useAiHealthCheck());
+
+    let healthy: boolean | undefined;
+    await act(async () => {
+      healthy = await result.current.check();
+    });
+
+    expect(healthy).toBe(false);
+    expect(result.current.status).toBe('degraded');
+  });
+});

--- a/src/Ato.Copilot.Dashboard/src/__tests__/hooks/useChatContext.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/hooks/useChatContext.test.tsx
@@ -11,6 +11,8 @@ function createWrapper(path: string) {
 }
 
 describe('useChatContext', () => {
+  // ── Original baseline tests ───────────────────────────────────────────────
+
   it('returns portfolio context on root path', () => {
     const { result } = renderHook(() => useChatContext(), { wrapper: createWrapper('/') });
     expect(result.current.page).toBe('portfolio');
@@ -32,5 +34,58 @@ describe('useChatContext', () => {
   it('returns unknown for unrecognized paths', () => {
     const { result } = renderHook(() => useChatContext(), { wrapper: createWrapper('/some/random/path') });
     expect(result.current.page).toBe('unknown');
+  });
+
+  // ── Existing sub-page aliases that already work ───────────────────────────
+
+  it('resolves /systems/abc/profile/ to system-profile', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/profile/'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  // ── fix/#526: missing slug aliases → must resolve to system-profile ───────
+
+  it('resolves /systems/abc/mission-purpose to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/mission-purpose'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  it('resolves /systems/abc/users-access to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/users-access'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  it('resolves /systems/abc/environment to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/environment'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  it('resolves /systems/abc/data-types to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/data-types'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  it('resolves /systems/abc/ports-protocols to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/ports-protocols'),
+    });
+    expect(result.current.page).toBe('system-profile');
+  });
+
+  it('resolves /systems/abc/leveraged-auth to system-profile (fix #526)', () => {
+    const { result } = renderHook(() => useChatContext(), {
+      wrapper: createWrapper('/systems/abc/leveraged-auth'),
+    });
+    expect(result.current.page).toBe('system-profile');
   });
 });

--- a/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
+++ b/src/Ato.Copilot.Dashboard/src/components/chat/AiHealthBanner.tsx
@@ -51,7 +51,15 @@ export function useAiHealthCheck() {
         setStatus('degraded');
         return false;
       }
-    } catch {
+    } catch (err: unknown) {
+      // fix(#526): AbortError / TimeoutError means the request was cancelled
+      // during navigation or by AbortSignal.timeout() — this is NOT a genuine
+      // provider failure. Setting 'degraded' here was firing the banner even
+      // when the API returned HTTP 200 on the very next load.
+      if (err instanceof DOMException && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+        setStatus('unknown'); // navigation cancelled the request — not a real failure
+        return true;
+      }
       setStatus('degraded');
       return false;
     }

--- a/src/Ato.Copilot.Dashboard/src/hooks/useChatContext.ts
+++ b/src/Ato.Copilot.Dashboard/src/hooks/useChatContext.ts
@@ -35,7 +35,28 @@ function resolvePageName(pathname: string): string {
   if (pathname.includes('/inheritance') || pathname.includes('/control-inheritance')) return 'inheritance';
   if (pathname.includes('/baseline') || pathname.includes('/categorization')) return 'baseline';
   if (pathname.includes('/capability-coverage') || pathname.includes('/capabilities')) return 'capabilities';
+  // fix(#526): alias sub-pages that live under /systems/:id before the
+  // SystemRedirect fires — the chat context is evaluated while the browser
+  // still shows the alias URL, causing 'Viewing: unknown'.
+  if (
+    pathname.includes('/mission-purpose') ||
+    pathname.includes('/users-access') ||
+    pathname.includes('/environment') ||
+    pathname.includes('/data-types') ||
+    pathname.includes('/ports-protocols') ||
+    pathname.includes('/leveraged-auth')
+  ) return 'system-profile';
   if (pathname.includes('/profile/')) return 'system-profile';
+  // fix(#526,#523): Wave 9 profile slug aliases — must resolve to 'system-profile'
+  // even before React Router performs the SystemRedirect to /systems/:id/profile/…
+  if (
+    pathname.includes('/mission-purpose') ||
+    pathname.includes('/users-access') ||
+    pathname.includes('/environment') ||
+    pathname.includes('/data-types') ||
+    pathname.includes('/ports-protocols') ||
+    pathname.includes('/leveraged-auth')
+  ) return 'system-profile';
   if (pathname.includes('/authorize')) return 'authorize';
   if (pathname.includes('/roles')) return 'roles';
   if (pathname.match(/^\/systems\/[^/]+$/)) return 'system-detail';


### PR DESCRIPTION
## Problem

Two distinct bugs tracked under #526:

### Bug 1 — Chat context shows 'Viewing: unknown' on system sub-pages

`resolvePageName()` in `useChatContext.ts` had no branch for six system-profile alias slugs. While `SystemRedirect` is in-flight, the hook evaluates the alias URL and falls through to `'unknown'`, producing *'Viewing: unknown'* in the chat header.

**Affected slugs:** `/mission-purpose`, `/users-access`, `/environment`, `/data-types`, `/ports-protocols`, `/leveraged-auth`

### Bug 2 — 'AI provider unreachable' banner fires despite healthy API

The bare `catch {}` block in `useAiHealthCheck` set status to `'degraded'` for every exception — including `AbortError` thrown by `AbortSignal.timeout(5000)` when the page-load fetch races against navigation. This triggered the warning banner even when the API returned HTTP 200 on the next request.

## Fix

### `src/hooks/useChatContext.ts`
Added an explicit multi-alias check (before the existing `/profile/` check) mapping all six slugs → `'system-profile'`.

### `src/components/chat/AiHealthBanner.tsx`
Narrowed `catch {}` to `catch (err: unknown)` and returns `'unknown'` (not `'degraded'`) when `err` is a `DOMException` with name `'AbortError'` or `'TimeoutError'`. Genuine network failures still set `'degraded'`.

## Tests (TDD — RED → GREEN)

| File | Tests | Result |
|------|-------|--------|
| `src/__tests__/hooks/useChatContext.test.tsx` | 11 (6 new alias cases + 5 existing) | ✅ all pass |
| `src/__tests__/components/chat/AiHealthBanner.test.tsx` | 6 new (healthy / degraded / AbortError / TimeoutError / 401 / 503) | ✅ all pass |

Both new test files were written **before** the fix (confirmed failing in RED state), then the production code was changed to make them pass (GREEN).

## Checklist
- [x] TDD: tests written first, confirmed RED, then fixed to GREEN
- [x] Branch: `fix/526-chat-context-unknown`
- [x] Single focused commit with conventional-commit message
- [x] No other files modified
- [x] Closes #526