### PR TITLE
fix(#522): wire /systems/new route to intake wizard

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/App.tsx
+++ b/src/Ato.Copilot.Dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { useIsAuthenticated, useMsal } from '@azure/msal-react';
 import PortfolioRoute from './pages/PortfolioRoute';
 import SystemsRoute from './pages/SystemsRoute';
+import SystemsNewRoute from './pages/SystemsNewRoute';
 import ComponentsRoute from './pages/ComponentsRoute';
 import CapabilitiesRoute from './pages/CapabilitiesRoute';
 import ControlsRoute from './pages/ControlsRoute';
@@ -104,6 +105,10 @@ function AppContent() {
               loginRedirect with the deep-link as `state` when unauthenticated. */}
           <Route path="/" element={<RequireAuth><PortfolioRoute /></RequireAuth>} />
           <Route path="/systems" element={<RequireAuth><SystemsRoute /></RequireAuth>} />
+          {/* fix(#522): /systems/new must be registered BEFORE /systems/:id so React
+              Router does not match it as id="new". SystemsNewRoute redirects to
+              /systems with state.openWizard=true, which opens the intake wizard. */}
+          <Route path="/systems/new" element={<RequireAuth><SystemsNewRoute /></RequireAuth>} />
           <Route path="/systems/:id" element={<RequireAuth><SystemLayout /></RequireAuth>}>
             <Route index element={<SystemDetail />} />
             <Route path="roadmap" element={<Roadmap />} />

--- a/src/Ato.Copilot.Dashboard/src/__tests__/pages/PortfolioDashboard.openWizard.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/pages/PortfolioDashboard.openWizard.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * PortfolioDashboard — auto-open wizard via location.state.openWizard
+ * fix(#522): navigating to /systems/new → /systems with state { openWizard: true }
+ * should cause PortfolioDashboard to open the IntakeWizard immediately.
+ *
+ * TDD: these tests are written first; they will be RED until the useEffect
+ * that reads location.state.openWizard is added to PortfolioDashboard.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+const mockWizardOpen = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../../hooks/useIntakeWizard', () => ({
+  useIntakeWizard: () => ({
+    state: { isOpen: false, currentStep: 1, systemId: null, stepData: {}, validationErrors: {}, completedSteps: [] },
+    open: mockWizardOpen,
+    cancel: vi.fn(),
+    cancelWithCleanup: vi.fn(),
+    reset: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    skipStep: vi.fn(),
+    goToStep: vi.fn(),
+    setSystemId: vi.fn(),
+    setValidationErrors: vi.fn(),
+    clearValidationErrors: vi.fn(),
+    finish: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/layout/PageLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/layout/PageHero', () => ({
+  default: () => <div data-testid="page-hero" />,
+}));
+
+vi.mock('../../hooks/usePolling', () => ({
+  usePolling: (fn: () => void) => { fn(); },
+}));
+
+vi.mock('../../api/portfolio', () => ({
+  getPortfolio: vi.fn().mockResolvedValue({ items: [], totalCount: 0, cursor: null }),
+  getPortfolioLegacy: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+  updateSystem: vi.fn(),
+  generateSystemDescription: vi.fn(),
+}));
+
+vi.mock('../../components/portfolio/AoPendingDecisionsWidget', () => ({
+  default: () => null,
+}));
+
+// ─── Subject ─────────────────────────────────────────────────────────────────
+
+import PortfolioDashboard from '../../pages/PortfolioDashboard';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PortfolioDashboard — auto-open wizard via location.state.openWizard (fix #522)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT call wizard.open() when location.state has no openWizard flag', async () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/systems', state: {} }]}>
+        <Routes>
+          <Route path="/systems" element={<PortfolioDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Give the useEffect time to run
+    await waitFor(() => {
+      expect(mockWizardOpen).not.toHaveBeenCalled();
+    });
+  });
+
+  it('calls wizard.open() when location.state.openWizard is true', async () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/systems', state: { openWizard: true } }]}>
+        <Routes>
+          <Route path="/systems" element={<PortfolioDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockWizardOpen).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('clears location state after opening wizard to prevent re-open on refresh', async () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/systems', state: { openWizard: true } }]}>
+        <Routes>
+          <Route path="/systems" element={<PortfolioDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/systems', { replace: true, state: {} });
+    });
+  });
+});

--- a/src/Ato.Copilot.Dashboard/src/__tests__/pages/PortfolioDashboard.openWizard.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/pages/PortfolioDashboard.openWizard.test.tsx
@@ -7,7 +7,7 @@
  * that reads location.state.openWizard is added to PortfolioDashboard.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────

--- a/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemsNewRoute.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemsNewRoute.test.tsx
@@ -6,7 +6,7 @@
  * design of SystemsNewRoute and the PortfolioDashboard location.state handler.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────

--- a/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemsNewRoute.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemsNewRoute.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * SystemsNewRoute — fix(#522) /systems/new redirects to /systems with
+ * openWizard state so the intake wizard auto-opens on the portfolio page.
+ *
+ * TDD: these tests were written before the implementation; they drive the
+ * design of SystemsNewRoute and the PortfolioDashboard location.state handler.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ─── Subject ─────────────────────────────────────────────────────────────────
+
+import SystemsNewRoute from '../../pages/SystemsNewRoute';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SystemsNewRoute — fix(#522)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('immediately calls navigate("/systems") with replace and openWizard:true state', () => {
+    render(
+      <MemoryRouter initialEntries={['/systems/new']}>
+        <Routes>
+          <Route path="/systems/new" element={<SystemsNewRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(mockNavigate).toHaveBeenCalledOnce();
+    expect(mockNavigate).toHaveBeenCalledWith('/systems', {
+      replace: true,
+      state: { openWizard: true },
+    });
+  });
+
+  it('renders null (no visible DOM output)', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/systems/new']}>
+        <Routes>
+          <Route path="/systems/new" element={<SystemsNewRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // The component should render nothing visible
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('SystemsNewRoute — /systems/new does not bleed into :id route', () => {
+  it('a route registered before /systems/:id prevents id="new" mismatch', async () => {
+    // Regression guard: if /systems/new is routed BEFORE /systems/:id,
+    // we should never reach the :id route with id="new".
+    // Simulate by rendering only the /systems/new route — it should render
+    // SystemsNewRoute (not fall through to any :id handler).
+    render(
+      <MemoryRouter initialEntries={['/systems/new']}>
+        <Routes>
+          <Route path="/systems/new" element={<div data-testid="new-route" />} />
+          <Route path="/systems/:id" element={<div data-testid="id-route" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('new-route')).toBeInTheDocument();
+    expect(screen.queryByTestId('id-route')).toBeNull();
+  });
+});

--- a/src/Ato.Copilot.Dashboard/src/pages/PortfolioDashboard.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/PortfolioDashboard.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import PageLayout from '../components/layout/PageLayout';
 import PageHero from '../components/layout/PageHero';
 import SystemSummaryRow from '../components/cards/SystemSummaryRow';
@@ -31,6 +32,19 @@ export default function PortfolioDashboard() {
 
   // Intake wizard
   const wizard = useIntakeWizard();
+
+  // fix(#522): auto-open the intake wizard when navigated here from
+  // /systems/new (which sets location.state.openWizard = true via redirect).
+  const navigate = useNavigate();
+  const location = useLocation();
+  useEffect(() => {
+    if ((location.state as { openWizard?: boolean } | null)?.openWizard) {
+      wizard.open();
+      // Clear the state so a hard-refresh doesn't re-open the wizard.
+      navigate('/systems', { replace: true, state: {} });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.state]);
 
   // Edit system dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);

--- a/src/Ato.Copilot.Dashboard/src/pages/SystemsNewRoute.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/SystemsNewRoute.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * SystemsNewRoute — fix(#522)
+ *
+ * Handles direct navigation to `/systems/new`. Without this route, React
+ * Router would match the `/systems/:id` route with `id = "new"`, causing
+ * `getSystemDetail("new")` to fail with "Failed to load system detail".
+ *
+ * This component immediately redirects to `/systems` (the portfolio page)
+ * and passes `state.openWizard = true` so that `PortfolioDashboard` can
+ * detect the flag and open the intake wizard automatically.
+ *
+ * The route must be registered **before** `/systems/:id` in `App.tsx` so
+ * that React Router matches this route first.
+ */
+export default function SystemsNewRoute() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate('/systems', { replace: true, state: { openWizard: true } });
+  }, [navigate]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Wires the `/systems/new` route to the existing intake wizard and fixes direct URL navigation.

### Problem
- Navigating to `/systems/new` matched `/systems/:id` with `id="new"`, triggering `getSystemDetail("new")` → "Failed to load system detail" error.
- The `+ Add System` button already called `wizard.open()` correctly, but the URL path was broken.

### Fix

1. **`SystemsNewRoute.tsx`** (new file) — tiny redirect component:
   ```tsx
   navigate('/systems', { replace: true, state: { openWizard: true } })
   ```

2. **`App.tsx`** — register `<Route path="/systems/new" ...>` **before** `/systems/:id` so React Router never matches `"new"` as a system ID.

3. **`PortfolioDashboard.tsx`** — `useEffect` reads `location.state.openWizard`, calls `wizard.open()`, then clears state to prevent re-open on hard-refresh.

### Tests (TDD: RED → GREEN)
- `SystemsNewRoute.test.tsx` — 3 tests: redirects with `replace+openWizard`, renders null, route ordering guards
- `PortfolioDashboard.openWizard.test.tsx` — 3 tests: no flag = no open; flag = open; state cleared after

6/6 GREEN.

Closes #522
