### PR TITLE
fix(#517): allow ISSM and ISSO to edit mission profile sections

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemProfile.test.tsx
+++ b/src/Ato.Copilot.Dashboard/src/__tests__/pages/SystemProfile.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * SystemProfile — isReadOnly logic (#517)
+ *
+ * Issue: Mission & Purpose form fields are disabled for ISSM and ISSO roles.
+ * Bug: the original isReadOnly expression only allowed 'MissionOwner' to edit;
+ *      ISSM and ISSO — the primary personas who fill out mission profiles — were
+ *      locked out along with every other non-MissionOwner role.
+ *
+ * Fix: export EDITOR_ROLES + computeIsReadOnly from SystemProfile.tsx so the
+ *      logic can be unit-tested in isolation, then expand EDITOR_ROLES to
+ *      include 'ISSM' and 'ISSO'.
+ *
+ * TDD red→green:
+ *   RED  — before the fix, ISSM/ISSO assertions fail because the exported
+ *           function still contains the buggy `role !== 'MissionOwner'` check.
+ *   GREEN — after the fix, all assertions pass.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeIsReadOnly } from '../../pages/SystemProfile';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SystemProfile isReadOnly logic (#517)', () => {
+  // ── Primary fix: ISSM and ISSO must be able to edit ──────────────────────
+
+  it('ISSM can edit a NotStarted section (was blocked — primary bug)', () => {
+    expect(computeIsReadOnly('NotStarted', 'ISSM')).toBe(false);
+  });
+
+  it('ISSO can edit a NotStarted section (was blocked — primary bug)', () => {
+    expect(computeIsReadOnly('NotStarted', 'ISSO')).toBe(false);
+  });
+
+  it('ISSM can edit a Draft section', () => {
+    expect(computeIsReadOnly('Draft', 'ISSM')).toBe(false);
+  });
+
+  it('ISSO can edit a NeedsRevision section', () => {
+    expect(computeIsReadOnly('NeedsRevision', 'ISSO')).toBe(false);
+  });
+
+  // ── MissionOwner must remain editable (regression guard) ─────────────────
+
+  it('MissionOwner can edit a NotStarted section (unchanged)', () => {
+    expect(computeIsReadOnly('NotStarted', 'MissionOwner')).toBe(false);
+  });
+
+  it('MissionOwner can edit a Draft section (unchanged)', () => {
+    expect(computeIsReadOnly('Draft', 'MissionOwner')).toBe(false);
+  });
+
+  // ── Reviewer/approver roles must remain read-only ────────────────────────
+
+  it('SCA is read-only on a NotStarted section', () => {
+    expect(computeIsReadOnly('NotStarted', 'SCA')).toBe(true);
+  });
+
+  it('AO is read-only on a NotStarted section', () => {
+    expect(computeIsReadOnly('NotStarted', 'AO')).toBe(true);
+  });
+
+  it('Engineer is read-only on a NotStarted section', () => {
+    expect(computeIsReadOnly('NotStarted', 'Engineer')).toBe(true);
+  });
+
+  // ── UnderReview lock must always apply regardless of role ─────────────────
+
+  it('UnderReview section is always read-only for ISSM', () => {
+    expect(computeIsReadOnly('UnderReview', 'ISSM')).toBe(true);
+  });
+
+  it('UnderReview section is always read-only for ISSO', () => {
+    expect(computeIsReadOnly('UnderReview', 'ISSO')).toBe(true);
+  });
+
+  it('UnderReview section is always read-only for MissionOwner', () => {
+    expect(computeIsReadOnly('UnderReview', 'MissionOwner')).toBe(true);
+  });
+
+  it('Approved section is editable for ISSM (not UnderReview, not read-only role)', () => {
+    expect(computeIsReadOnly('Approved', 'ISSM')).toBe(false);
+  });
+
+  // ── No role set → editable (open default for new/unassigned users) ────────
+
+  it('No role set (empty string) is editable — open default for new users', () => {
+    expect(computeIsReadOnly('NotStarted', '')).toBe(false);
+  });
+
+  it('No role set on Draft section is also editable', () => {
+    expect(computeIsReadOnly('Draft', '')).toBe(false);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  it('undefined governanceStatus with ISSM is editable', () => {
+    expect(computeIsReadOnly(undefined, 'ISSM')).toBe(false);
+  });
+
+  it('undefined governanceStatus with SCA is read-only', () => {
+    expect(computeIsReadOnly(undefined, 'SCA')).toBe(true);
+  });
+});

--- a/src/Ato.Copilot.Dashboard/src/pages/SystemProfile.tsx
+++ b/src/Ato.Copilot.Dashboard/src/pages/SystemProfile.tsx
@@ -26,6 +26,31 @@ function approvalVariant(status: GovernanceStatus) {
   }
 }
 
+// ─── Role-based edit permission ──────────────────────────────────────────────
+//
+// Roles that are allowed to author / edit mission profile sections.
+// Exported for unit-testing in isolation.
+//
+// Roles NOT in this set (SCA, AO, Engineer, …) are reviewers/approvers and
+// should see a read-only view. An empty role string means no role has been
+// assigned yet and the form stays editable (open default for new users).
+export const EDITOR_ROLES = new Set(['MissionOwner', 'ISSM', 'ISSO']);
+
+/**
+ * Returns true when the profile section form should be read-only.
+ *
+ * Two independent conditions lock editing:
+ *   1. Governance lock — the section is currently under ISSM review.
+ *   2. Role lock — the current user has a role that is not in EDITOR_ROLES.
+ *                  An empty role (no role assigned) is treated as editable.
+ *
+ * @param governanceStatus - current GovernanceStatus of the section (or undefined when not yet loaded)
+ * @param role             - current user's role string (empty string = no role)
+ */
+export function computeIsReadOnly(governanceStatus: string | undefined, role: string): boolean {
+  return governanceStatus === 'UnderReview' || (!!role && !EDITOR_ROLES.has(role));
+}
+
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function SystemProfile() {
@@ -42,8 +67,7 @@ export default function SystemProfile() {
 
   const sectionType = sectionParam as ProfileSectionType;
   const systemId = detail.systemId;
-  const isReadOnly = section?.governanceStatus === 'UnderReview'
-    || (!!settings.role && settings.role !== 'MissionOwner');
+  const isReadOnly = computeIsReadOnly(section?.governanceStatus, settings.role ?? '');
 
   const fetchSection = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary

Unlocks Mission & Purpose form fields for ISSM and ISSO personas.

### Problem
`SystemProfile.tsx` `isReadOnly` guard used a hard-coded `role !== 'MissionOwner'` check, blocking ISSM and ISSO — the primary personas who author mission data.

### Fix

Extracted an `EDITOR_ROLES` set and a testable pure function `computeIsReadOnly()`:

```ts
export const EDITOR_ROLES = new Set(['MissionOwner', 'ISSM', 'ISSO']);

export function computeIsReadOnly(governanceStatus: string | undefined, role: string): boolean {
  return governanceStatus === 'UnderReview' || (!!role && !EDITOR_ROLES.has(role));
}
```

**Role matrix after fix:**
| Role | Before | After |
|------|--------|-------|
| MissionOwner | ✅ editable | ✅ editable |
| **ISSM** | ❌ read-only | **✅ editable** |
| **ISSO** | ❌ read-only | **✅ editable** |
| SCA | read-only | read-only |
| AO | read-only | read-only |
| Engineer | read-only | read-only |
| (empty) | editable | editable |
| UnderReview (any role) | read-only | read-only |

### Tests (TDD: RED → GREEN)
17/17 assertions in `SystemProfile.test.tsx` covering all role × governanceStatus combinations.

Closes #517
