### PR TITLE
fix(#535): inject FORCE_SINGLE_TENANT='' into CSP dashboard deploy jobs (P0 outage fix)

### DIFF
--- a/.github/workflows/cd-azure-containerapp.yml
+++ b/.github/workflows/cd-azure-containerapp.yml
@@ -155,6 +155,11 @@ jobs:
       include_mcp_env_vars: false
       assign_managed_identity: false
       inject_runtime_secrets: false
+      # Feature 411: FORCE_SINGLE_TENANT must always be set so envsubst in
+      # nginx.conf can substitute ${FORCE_SINGLE_TENANT}. Without this env var
+      # nginx exits with "unknown variable" on startup. CSP dashboard = "" (empty),
+      # org-only dashboard = "true" (see deploy-production-dashboard-org below).
+      extra_env_vars: "FORCE_SINGLE_TENANT="
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -188,6 +193,7 @@ jobs:
       include_mcp_env_vars: false
       assign_managed_identity: false
       inject_runtime_secrets: false
+      extra_env_vars: "FORCE_SINGLE_TENANT="
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -221,6 +227,7 @@ jobs:
       include_mcp_env_vars: false
       assign_managed_identity: false
       inject_runtime_secrets: false
+      extra_env_vars: "FORCE_SINGLE_TENANT="
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

P0 outage root cause fix — both dashboard (`ca-ato-copilot-dashboard-v2`) revisions
entered `ActivationFailed` state due to nginx exiting with:
```
nginx: [emerg] unknown "force_single_tenant" variable
```

## Root Cause

Feature #411 (PR #412) added envsubst substitution of `${FORCE_SINGLE_TENANT}` in
`nginx.conf`. The org dashboard job already set `extra_env_vars: "FORCE_SINGLE_TENANT=true"`.
The 3 CSP dashboard deploy jobs (dev, test, production) had **no `extra_env_vars`**, so
`envsubst` encountered an undefined variable → nginx fatal on startup.

## Fix

Added `extra_env_vars: "FORCE_SINGLE_TENANT="` (empty = CSP mode) to:
- `deploy-dev-dashboard`
- `deploy-test-dashboard`
- `deploy-production-dashboard`

The org-only job already has `FORCE_SINGLE_TENANT=true` — no change needed.

## Hotfix Applied During Incident

`ca-ato-copilot-dashboard-v2` was recovered immediately via:
```bash
az containerapp update --name ca-ato-copilot-dashboard-v2   --resource-group rg-ato-copilot   --set-env-vars "FORCE_SINGLE_TENANT=" 
```
→ Revision `--0000002` Running/Healthy/100% traffic

MCP was separately rolled back to image `8267eac` (revision `--0000087`) due to a
DI circular dependency crash in the newer build.

## Spec Compliance

- No spec changes required — this is a CD pipeline hotfix
- nginx.conf unchanged — variable was already there from PR #412

Closes #535