### PR TITLE
fix(#588): add DELETE /api/systems/{id} endpoint — stop orphan accumulation

### DIFF
--- a/src/Ato.Copilot.Mcp/Endpoints/SystemsEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/SystemsEndpoints.cs
@@ -1,0 +1,164 @@
+// =============================================================================
+//  SystemsEndpoints.cs
+//  Ato.Copilot.Mcp — Endpoints
+//  Issue #588 — DELETE /api/systems/{id} — stop orphan accumulation
+//
+//  DELETE /api/systems/{id}             → soft-delete (IsActive = false), 204
+//  DELETE /api/systems/{id}?permanent=true → hard-delete (remove row),   204
+//
+//  404 is returned when the GUID is not found in the current tenant's scope.
+//  The handler mirrors the logic already in DeleteSystemTool
+//  (compliance_delete_system) so behaviour is identical whether the caller
+//  uses the MCP tool or the REST endpoint.
+// =============================================================================
+
+#nullable enable
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Ato.Copilot.Core.Data.Context;
+
+namespace Ato.Copilot.Mcp.Endpoints;
+
+/// <summary>
+/// Maps DELETE /api/systems/{id} — soft-delete (default) and hard-delete
+/// (<c>?permanent=true</c>) for registered information systems.
+///
+/// <para>
+/// <b>Soft-delete</b> (default): sets <c>IsActive = false</c> and
+/// <c>ModifiedAt = UtcNow</c>.  All child rows are preserved; the system is
+/// hidden from every active-only query.  Cascade-safe — no FK violations.
+/// </para>
+/// <para>
+/// <b>Hard-delete</b> (<c>?permanent=true</c>): removes the
+/// <see cref="Ato.Copilot.Core.Models.Compliance.RegisteredSystem"/> row
+/// entirely.  Database-level <c>ON DELETE CASCADE</c> constraints handle all
+/// child tables (boundaries, roles, assessments, POA&amp;Ms, findings).
+/// Use only for QA / orphaned test systems.
+/// </para>
+/// </summary>
+public static class SystemsEndpoints
+{
+    /// <summary>
+    /// Registers <c>DELETE /api/systems/{id}</c> on the supplied route builder.
+    /// Called from <c>Program.cs</c> in HTTP mode alongside the other
+    /// <c>Map*Endpoints</c> extension methods.
+    /// </summary>
+    public static IEndpointRouteBuilder MapSystemsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/systems")
+            .RequireAuthorization()
+            .WithTags("Systems");
+
+        // ─── DELETE /api/systems/{id} ────────────────────────────────────────
+        group.MapDelete("/{id}", DeleteSystemAsync)
+            .WithName("DeleteSystem")
+            .WithSummary("Delete a registered system")
+            .WithDescription(
+                "Soft-deletes (IsActive=false) the specified system by default. " +
+                "Pass ?permanent=true to permanently remove the row and all child data. " +
+                "Returns 204 on success, 404 if the system is not found.");
+
+        return app;
+    }
+
+    // -------------------------------------------------------------------------
+    //  Handler
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Handles <c>DELETE /api/systems/{id}</c>.
+    /// </summary>
+    /// <param name="id">System GUID (string, 36 chars).</param>
+    /// <param name="permanent">
+    ///   <c>true</c> = hard-delete (remove row + cascade children);
+    ///   <c>false</c> (default) = soft-delete (IsActive=false).
+    /// </param>
+    /// <param name="dbFactory">EF Core DbContext factory (injected from DI).</param>
+    /// <param name="logger">Logger (injected from DI).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    ///   204 No Content on success;<br/>
+    ///   404 Not Found when the GUID is not in the database;<br/>
+    ///   400 Bad Request when <paramref name="id"/> is not a valid GUID.
+    /// </returns>
+    private static async Task<IResult> DeleteSystemAsync(
+        string id,
+        IDbContextFactory<AtoCopilotContext> dbFactory,
+        ILogger<LogMarker> logger,
+        bool permanent = false,
+        CancellationToken ct = default)
+    {
+        // ── Validate the id is a well-formed GUID ──────────────────────────
+        if (!Guid.TryParse(id, out _))
+        {
+            return Results.Json(
+                new { ok = false, errorCode = "INVALID_ID", message = $"'{id}' is not a valid GUID." },
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // ── Locate the system ──────────────────────────────────────────────
+        // AtoCopilotContext applies the tenant query-filter automatically, so
+        // this FirstOrDefaultAsync is already scoped to the effective tenant.
+        var system = await db.RegisteredSystems
+            .FirstOrDefaultAsync(s => s.Id == id, ct);
+
+        if (system is null)
+        {
+            logger.LogWarning("DELETE /api/systems/{Id}: not found (permanent={Permanent})", id, permanent);
+
+            return Results.Json(
+                new
+                {
+                    ok = false,
+                    errorCode = "NOT_FOUND",
+                    message = $"System '{id}' was not found."
+                },
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        var systemName = system.Name;
+
+        if (permanent)
+        {
+            // ── Hard-delete: remove row; cascade handles child tables ──────
+            db.RegisteredSystems.Remove(system);
+            await db.SaveChangesAsync(ct);
+
+            logger.LogInformation(
+                "Permanently deleted system {Id} ({Name})", id, systemName);
+
+            return Results.Json(
+                new
+                {
+                    ok = true,
+                    data = new { systemId = id, deleted = true, permanent = true }
+                },
+                statusCode: StatusCodes.Status204NoContent);
+        }
+
+        // ── Soft-delete: flip IsActive flag ─────────────────────────────
+        system.IsActive = false;
+        system.ModifiedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Soft-deleted system {Id} ({Name})", id, systemName);
+
+        return Results.Json(
+            new
+            {
+                ok = true,
+                data = new { systemId = id, deleted = true, permanent = false }
+            },
+            statusCode: StatusCodes.Status204NoContent);
+    }
+
+    /// <summary>Non-static marker class for <see cref="ILogger{T}"/> category.</summary>
+    public sealed class LogMarker { }
+}

--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -687,6 +687,9 @@ async Task RunHttpModeAsync(string[] args)
     // Phase 2: GET /api/systems/{id}/ato-posture
     app.MapAtoPostureEndpoints();
 
+    // Issue #588 — DELETE /api/systems/{id} (soft-delete + hard-delete)
+    app.MapSystemsEndpoints();
+
     // Map SignalR notification hub
     app.MapHub<Ato.Copilot.Mcp.Hubs.NotificationHub>("/hubs/notifications");
     app.MapHub<Ato.Copilot.Mcp.Hubs.PackageHub>("/hubs/package");


### PR DESCRIPTION
## Summary

Closes #588
Closes #586

### Problem
The `DeleteSystemTool` MCP tool (`compliance_delete_system`) already implemented soft-delete and hard-delete logic for registered systems, but there was no REST HTTP endpoint to perform this operation from the dashboard or other HTTP clients — resulting in orphaned inactive systems accumulating in the database with no UI-level way to clean them up.

### Solution
Added **`DELETE /api/systems/{id}`** REST endpoint that mirrors the exact logic already in `DeleteSystemTool`:

| Operation | Trigger | Effect |
|-----------|---------|--------|
| Soft-delete (default) | `DELETE /api/systems/{id}` | Sets `IsActive = false`, `ModifiedAt = UtcNow` — cascade-safe, no FK violations |
| Hard-delete | `DELETE /api/systems/{id}?permanent=true` | Removes the row; DB-level `ON DELETE CASCADE` handles all child tables |

### Response contract

**204 No Content (success):**
```json
{ "ok": true, "data": { "systemId": "...", "deleted": true, "permanent": false } }
```

**404 Not Found:**
```json
{ "ok": false, "errorCode": "NOT_FOUND", "message": "System '...' was not found." }
```

**400 Bad Request (non-GUID id):**
```json
{ "ok": false, "errorCode": "INVALID_ID", "message": "'...' is not a valid GUID." }
```

### Files changed
- **`src/Ato.Copilot.Mcp/Endpoints/SystemsEndpoints.cs`** _(new)_ — Static endpoint class with `MapSystemsEndpoints` extension method, registered under `/api/systems` group with `RequireAuthorization()`
- **`src/Ato.Copilot.Mcp/Program.cs`** _(modified)_ — Added `app.MapSystemsEndpoints();` after `app.MapAtoPostureEndpoints();` in HTTP mode

### Notes
- Uses `IDbContextFactory<AtoCopilotContext>` directly (same pattern as `DeleteSystemTool`) — tenant query-filter is applied automatically by `AtoCopilotContext`
- `RequireAuthorization()` on the group ensures all callers are authenticated (same pattern as `AtoPostureEndpoints`)
- No new DI registrations required — `IDbContextFactory<AtoCopilotContext>` is already registered by `AddAtoCopilotMcp`
- Follows the `AtoPostureEndpoints` naming/structure pattern exactly