### PR TITLE
fix(#577,#578): rebuild NistControl list on cache miss — resolve KB control lookup failures

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/NistControlsService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/NistControlsService.cs
@@ -265,17 +265,75 @@ public class NistControlsService : INistControlsService
 
     /// <summary>
     /// Gets the backward-compatible NistControl list from cache, loading if needed.
+    ///
+    /// Fix for #577/#578 — lazy-cache bug:
+    /// After the initial load, _lazyCatalog is a resolved Lazy&lt;Task&lt;T&gt;&gt; whose
+    /// Value returns the already-completed task immediately without re-executing
+    /// LoadAndCacheCatalogAsync. If ControlsCacheKey has been evicted (e.g. by
+    /// the sliding-expiration window) while CatalogCacheKey is still populated,
+    /// the second TryGetValue still misses and the method falls through to an
+    /// empty list — causing all control lookups to return "not found".
+    ///
+    /// The fix adds a third fallback: when both the lazy path and the second
+    /// cache check fail, attempt to rebuild the NistControl list directly from
+    /// the still-valid CatalogCacheKey entry and re-populate ControlsCacheKey.
+    /// If CatalogCacheKey is also gone, reset _lazyCatalog so the next call
+    /// triggers a full reload rather than returning the stale completed task.
     /// </summary>
     private async Task<List<NistControl>> GetControlsAsync(CancellationToken cancellationToken)
     {
+        // Fast path: both keys populated (common case).
         if (_cache.TryGetValue(ControlsCacheKey, out List<NistControl>? controls) && controls is not null)
             return controls;
 
-        // Trigger lazy catalog load (which also caches controls)
+        // Trigger lazy catalog load (which also populates ControlsCacheKey on
+        // first load). On subsequent calls the Lazy<T> is already resolved and
+        // returns immediately without re-executing the factory.
         await _lazyCatalog.Value;
 
         if (_cache.TryGetValue(ControlsCacheKey, out controls) && controls is not null)
             return controls;
+
+        // ── Fix for #577 / #578 ──────────────────────────────────────────────
+        // ControlsCacheKey was evicted (sliding expiration) while CatalogCacheKey
+        // may still be alive (absolute expiration is longer).  Rebuild the list
+        // directly from the catalog without a full HTTP reload.
+        if (_cache.TryGetValue(CatalogCacheKey, out NistCatalog? catalog) && catalog is not null)
+        {
+            _logger.LogWarning(
+                "ControlsCacheKey evicted while CatalogCacheKey is still valid — " +
+                "rebuilding NistControl list from cached OSCAL catalog (fix #577/#578).");
+
+            var rebuilt = BuildNistControlList(catalog);
+
+            var absoluteExpiration = TimeSpan.FromHours(_options.CacheDurationHours);
+            var slidingExpiration = TimeSpan.FromHours(_options.CacheDurationHours * 0.25);
+
+            var cacheOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = absoluteExpiration,
+                SlidingExpiration = slidingExpiration,
+                Priority = CacheItemPriority.High,
+                Size = 1
+            };
+
+            _cache.Set(ControlsCacheKey, rebuilt, cacheOptions);
+
+            _logger.LogInformation(
+                "Rebuilt {Count} NistControl entries from cached catalog and re-cached ControlsCacheKey.",
+                rebuilt.Count);
+
+            return rebuilt;
+        }
+
+        // Both keys are gone.  Reset the Lazy so the next call re-executes the
+        // full load factory instead of returning the already-completed task.
+        _logger.LogWarning(
+            "Both CatalogCacheKey and ControlsCacheKey are absent — resetting lazy catalog " +
+            "loader so the next request triggers a full reload (fix #577/#578).");
+        _lazyCatalog = new Lazy<Task<NistCatalog?>>(
+            () => LoadAndCacheCatalogAsync(CancellationToken.None),
+            LazyThreadSafetyMode.ExecutionAndPublication);
 
         return new List<NistControl>();
     }


### PR DESCRIPTION
## Summary

Fixes #577 and #578 — NIST KB control lookups returning "not found" / 0 results for all valid control IDs after the initial cache warm-up period.

## Root Cause

`GetControlsAsync` in `NistControlsService.cs` had a **lazy-cache bug**:

1. On first call, `_lazyCatalog` (a `Lazy<Task<NistCatalog?>>`) executes `LoadAndCacheCatalogAsync`, which populates both `CatalogCacheKey` **and** `ControlsCacheKey` in `IMemoryCache`.
2. `_lazyCatalog` is now permanently resolved — its `.Value` property returns the already-completed `Task` immediately without re-executing the factory.
3. When `ControlsCacheKey` is evicted (sliding expiration window elapses) while `CatalogCacheKey` is still valid (longer absolute expiration), the sequence is:
   - First `TryGetValue(ControlsCacheKey)` → **miss**
   - `await _lazyCatalog.Value` → returns immediately (task already done), **does NOT re-populate ControlsCacheKey**
   - Second `TryGetValue(ControlsCacheKey)` → **miss**
   - Falls through to `return new List<NistControl>()` ← **all lookups return "not found"**

## Fix

Added a **third fallback** in `GetControlsAsync` (after the second `TryGetValue` miss):

```csharp
// ── Fix for #577 / #578 ──────────────────────────────────────────────
// ControlsCacheKey was evicted (sliding expiration) while CatalogCacheKey
// may still be alive (absolute expiration is longer). Rebuild the list
// directly from the catalog without a full HTTP reload.
if (_cache.TryGetValue(CatalogCacheKey, out NistCatalog? catalog) && catalog is not null)
{
    var rebuilt = BuildNistControlList(catalog);
    _cache.Set(ControlsCacheKey, rebuilt, cacheOptions); // same TTL options
    return rebuilt;
}

// Both keys are gone — reset _lazyCatalog so the next call re-executes
// the full load factory instead of returning the stale completed task.
_lazyCatalog = new Lazy<Task<NistCatalog?>>(
    () => LoadAndCacheCatalogAsync(CancellationToken.None),
    LazyThreadSafetyMode.ExecutionAndPublication);
return new List<NistControl>();
```

The re-cache uses the same `MemoryCacheEntryOptions` as the original load: `AbsoluteExpirationRelativeToNow`, `SlidingExpiration` (25% of TTL), `Priority = CacheItemPriority.High`, `Size = 1`.

## Tool Parameter Verification

Reviewed both affected tools — **no parameter renames needed**:

| Tool class | MCP `Name` | Parameter used in `ExecuteCoreAsync` | Issue curl uses |
|---|---|---|---|
| `NistControlSearchTool` | `search_nist_controls` | `"query"` | N/A (chat endpoint) |
| `NistControlExplainerTool` | `explain_nist_control` | `"control_id"` | N/A (chat endpoint) |

Both tools call `SearchControlsAsync(query, ...)` and `GetControlEnhancementAsync(controlId, ...)` on `INistControlsService`, which both delegate to the now-fixed `GetControlsAsync` / `GetCatalogAsync` path.

## Testing

- `kb_explain_nist_control` for AC-2 should now return the full control explanation after `ControlsCacheKey` TTL elapses
- `search_nist_controls` for "incident response" should return IR-family controls
- `GetCatalogStatusAsync` should report correct `TotalControls` count at all times

Closes #577
Closes #578