### PR TITLE
fix(#575): skip SYSTEM_REQUIRED disambiguation for portfolio-wide tools (compliance_multi_system_dashboard)

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
@@ -1698,8 +1698,25 @@ public class ComplianceAgent : BaseAgent
         // — we extract the system name and look it up in the DB.
         // When no name is given, auto-selects if exactly one active system exists.
         // If multiple exist, returns a disambiguation prompt.
+        //
+        // Fix #575: Portfolio-wide tools operate across ALL systems and never
+        // require a system_id. Skip disambiguation entirely for these intents so
+        // that users with multiple registered systems are not incorrectly blocked
+        // by a SYSTEM_REQUIRED error when requesting a cross-system view.
+        _portfolioWideIntents ??=
+        [
+            // compliance_multi_system_dashboard
+            "multi system dashboard", "all systems dashboard", "portfolio dashboard",
+            // compliance_list_systems  (already routed above, but guard here too)
+            "list systems", "show systems", "registered systems", "all systems", "my systems",
+            // RMF status overview — cross-system
+            "rmf status", "rmf phase", "rmf progress", "where are we in rmf"
+        ];
+
+        var isPortfolioWideIntent = ContainsAny(lowerMessage, _portfolioWideIntents);
+
         _pendingSystemChoices = null;
-        if (string.IsNullOrEmpty(GetContextValue(context, "system_id")))
+        if (!isPortfolioWideIntent && string.IsNullOrEmpty(GetContextValue(context, "system_id")))
         {
             var resolvedId = await ResolveSystemIdFromMessageAsync(lowerMessage, cancellationToken);
             if (resolvedId != null)
@@ -2634,6 +2651,15 @@ public class ComplianceAgent : BaseAgent
     /// Reset after each call to RouteToToolAsync.
     /// </summary>
     private List<object>? _pendingSystemChoices;
+
+    /// <summary>
+    /// Intent keywords whose corresponding tools are portfolio-wide and therefore
+    /// NEVER require a system_id. Populated once (lazy) and reused across calls.
+    /// Fix #575: prevents compliance_multi_system_dashboard (and similar cross-system
+    /// tools) from incorrectly triggering a SYSTEM_REQUIRED disambiguation response
+    /// when the caller has more than one registered system.
+    /// </summary>
+    private string[]? _portfolioWideIntents;
 
     /// <summary>
     /// Builds a friendly JSON response listing active systems so the user can


### PR DESCRIPTION
## Problem

`compliance_multi_system_dashboard` (and similar cross-system tools) incorrectly trigger a `SYSTEM_REQUIRED` disambiguation response when the caller has **more than one** registered system. This is a regression — the tool is portfolio-wide and explicitly does **not** accept or need a `system_id` parameter.

Reproducible: any org with 2+ registered systems → ask for the multi-system dashboard → gets `SYSTEM_REQUIRED` error instead of the dashboard.

## Root Cause

In `ComplianceAgent.RouteToToolAsync`, the guard block at lines ~1700–1712 calls `ResolveSystemIdFromMessageAsync()`. When multiple active systems are found and none is named in the message, the method populates `_pendingSystemChoices` and returns `null`. The caller then **unconditionally** calls `BuildSystemDisambiguationResponse()` — with no check for whether the intended tool actually requires a `system_id`.

```csharp
// BEFORE (broken)
_pendingSystemChoices = null;
if (string.IsNullOrEmpty(GetContextValue(context, "system_id")))
{
    var resolvedId = await ResolveSystemIdFromMessageAsync(lowerMessage, cancellationToken);
    if (resolvedId != null) { ... }
    else if (_pendingSystemChoices is { Count: > 0 })
        return BuildSystemDisambiguationResponse(...)  // ← fires for EVERY tool
}
```

## Fix

Introduce a **`_portfolioWideIntents`** string array (lazy-initialized once) whose values are the keyword phrases that map to cross-system tools. Before entering the disambiguation block, check whether the incoming message matches any of those phrases. If it does, skip `ResolveSystemIdFromMessageAsync` and the disambiguation entirely.

**Portfolio-wide tools exempted:**
| Keywords | Tool |
|---|---|
| `multi system dashboard` / `all systems dashboard` / `portfolio dashboard` | `compliance_multi_system_dashboard` |
| `list systems` / `show systems` / `registered systems` / `all systems` / `my systems` | `compliance_list_systems` |
| `rmf status` / `rmf phase` / `rmf progress` / `where are we in rmf` | `compliance_list_systems` |

```csharp
// AFTER (fixed)
_portfolioWideIntents ??= [ "multi system dashboard", "all systems dashboard", ... ];
var isPortfolioWideIntent = ContainsAny(lowerMessage, _portfolioWideIntents);

_pendingSystemChoices = null;
if (!isPortfolioWideIntent && string.IsNullOrEmpty(GetContextValue(context, "system_id")))
{
    // disambiguation only for tools that actually need system_id
}
```

## Behaviour unchanged for

- Single-system tenants (auto-select still works)
- All system-scoped tools (disambiguation path is untouched)
- Any tool that legitimately requires a `system_id`

## Testing

1. Org with 2+ registered systems, no system named in context
2. Type: *"show me the multi system dashboard"* → should return dashboard data, **not** `SYSTEM_REQUIRED`
3. Type: *"assess control AC-2 for Eagle Eye"* → still prompts for system selection (unchanged)

Closes #575