### PR TITLE
fix(#575/#582/#596/#597): exclude portfolio-scoped tools from SYSTEM_REQUIRED guard

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
@@ -1698,8 +1698,21 @@ public class ComplianceAgent : BaseAgent
         // — we extract the system name and look it up in the DB.
         // When no name is given, auto-selects if exactly one active system exists.
         // If multiple exist, returns a disambiguation prompt.
+        //
+        // Fix #575/#582/#596/#597: Portfolio-wide tools operate across ALL systems and
+        // never require a system_id. Skip disambiguation entirely for these intents so
+        // that callers with multiple registered systems are not incorrectly blocked by a
+        // SYSTEM_REQUIRED error when requesting a cross-system / portfolio-scoped view.
         _pendingSystemChoices = null;
-        if (string.IsNullOrEmpty(GetContextValue(context, "system_id")))
+        var isPortfolioWideIntent = ContainsAny(lowerMessage,
+            // compliance_multi_system_dashboard — portfolio view, no system needed
+            "multi system dashboard", "all systems dashboard", "portfolio dashboard",
+            // compliance_list_systems — already routed above but guard here too
+            "list systems", "show systems", "registered systems", "all systems", "my systems",
+            // RMF status overview — cross-system reads, no single system_id
+            "rmf status", "rmf phase", "rmf progress", "where are we in rmf");
+
+        if (!isPortfolioWideIntent && string.IsNullOrEmpty(GetContextValue(context, "system_id")))
         {
             var resolvedId = await ResolveSystemIdFromMessageAsync(lowerMessage, cancellationToken);
             if (resolvedId != null)


### PR DESCRIPTION
## Problem

`compliance_multi_system_dashboard` and related portfolio-wide intents have regressed **4 times** (#575, #582, #596, #597) because the disambiguation block runs unconditionally before any tool routing. Multi-system orgs are blocked by `SYSTEM_REQUIRED` every time.

## Root Cause

In `ComplianceAgent.RouteToToolAsync`, the guard at lines ~1700–1712 calls `ResolveSystemIdFromMessageAsync()` without first checking whether the message targets a portfolio-scoped tool. When multiple registered systems exist, it always returns a disambiguation prompt — even for tools like `compliance_multi_system_dashboard` that explicitly do not accept a `system_id`.

## Fix

Add an `isPortfolioWideIntent` check using `ContainsAny` on the portfolio-scoped keyword set immediately before the disambiguation block. When the intent matches a portfolio tool, skip `ResolveSystemIdFromMessageAsync` and `BuildSystemDisambiguationResponse` entirely.

**Surgical: 14-line insertion, zero deletions in tool routing logic.**

## Affected tools / intents
- `compliance_multi_system_dashboard` — multi/all systems/portfolio dashboard
- `compliance_list_systems` — list/show/registered/all systems
- RMF status overview — rmf status/phase/progress

## Test
```bash
curl -s -X POST -H 'Content-Type: application/json'   -d '{"message":"Show multi-system dashboard"}'   "$BASE/mcp/chat" | jq '.toolsExecuted'
# Should return [{"toolName":"compliance_multi_system_dashboard",...}], NOT []
```

## Spec Compliance
- Closes #575, #582, #596, #597
- Supersedes open PR #591 (never merged; this branch is off latest main)