### PR TITLE
fix(#594/#598): rebuild NistControl list on ControlsCacheKey eviction — fix split-brain cache

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/NistControlsService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/NistControlsService.cs
@@ -265,17 +265,100 @@ public class NistControlsService : INistControlsService
 
     /// <summary>
     /// Gets the backward-compatible NistControl list from cache, loading if needed.
+    ///
+    /// Fix #594/#598 — lazy-cache split-brain:
+    /// After the initial load, _lazyCatalog is a resolved Lazy&lt;Task&lt;T&gt;&gt; whose
+    /// Value returns the already-completed task immediately without re-executing
+    /// LoadAndCacheCatalogAsync. If ControlsCacheKey has been evicted (e.g. by
+    /// the sliding-expiration window) while CatalogCacheKey is still populated,
+    /// the second TryGetValue still misses and the method falls through to an
+    /// empty list — causing all control lookups to return "not found" even though
+    /// the health check (which calls ValidateControlIdAsync via GetCatalogAsync,
+    /// not GetControlsAsync) continues to report Healthy.
+    ///
+    /// Fix: add a third fallback: when both the lazy path and the second cache
+    /// check fail, attempt to rebuild the NistControl list directly from the
+    /// still-valid CatalogCacheKey entry and re-populate ControlsCacheKey.
+    /// If CatalogCacheKey is also gone, reset _lazyCatalog so the next call
+    /// triggers a full reload rather than returning the stale completed task.
     /// </summary>
     private async Task<List<NistControl>> GetControlsAsync(CancellationToken cancellationToken)
     {
+        // Fast path: both keys populated (common case).
         if (_cache.TryGetValue(ControlsCacheKey, out List<NistControl>? controls) && controls is not null)
             return controls;
 
-        // Trigger lazy catalog load (which also caches controls)
+        // Trigger lazy catalog load (which also populates ControlsCacheKey on
+        // first load). On subsequent calls the Lazy<T> is already resolved and
+        // returns immediately without re-executing the factory.
         await _lazyCatalog.Value;
 
         if (_cache.TryGetValue(ControlsCacheKey, out controls) && controls is not null)
             return controls;
+
+        // ── Fix for #594 / #598 ──────────────────────────────────────────────
+        // ControlsCacheKey was evicted (sliding expiration) while CatalogCacheKey
+        // may still be alive (absolute expiration is longer).  Rebuild the list
+        // directly from the catalog without a full HTTP reload.
+        if (_cache.TryGetValue(CatalogCacheKey, out NistCatalog? catalog) && catalog is not null)
+        {
+            _logger.LogWarning(
+                "ControlsCacheKey evicted while CatalogCacheKey is still valid — " +
+                "rebuilding NistControl list from cached OSCAL catalog (fix #594/#598).");
+
+            var rebuilt = BuildNistControlList(catalog);
+
+            var absoluteExpiration = TimeSpan.FromHours(_options.CacheDurationHours);
+            var slidingExpiration = TimeSpan.FromHours(_options.CacheDurationHours * 0.25);
+
+            var cacheOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = absoluteExpiration,
+                SlidingExpiration = slidingExpiration,
+                Priority = CacheItemPriority.High,
+                Size = 1
+            };
+
+            _cache.Set(ControlsCacheKey, rebuilt, cacheOptions);
+
+            _logger.LogInformation(
+                "Rebuilt {Count} NistControl entries from cached catalog and re-cached ControlsCacheKey.",
+                rebuilt.Count);
+
+            return rebuilt;
+        }
+
+        // Both keys are gone.  Reset the Lazy so the next call re-executes the
+        // full load factory instead of returning the already-completed task.
+        _logger.LogWarning(
+            "Both CatalogCacheKey and ControlsCacheKey are absent — resetting lazy catalog " +
+            "loader so the next request triggers a full reload (fix #594/#598).");
+        _loadLock.Wait(cancellationToken);
+        try
+        {
+            // Double-check while holding the lock
+            if (_cache.TryGetValue(CatalogCacheKey, out NistCatalog? catalog2) && catalog2 is not null)
+            {
+                var rebuilt = BuildNistControlList(catalog2);
+                var opts = new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_options.CacheDurationHours),
+                    SlidingExpiration = TimeSpan.FromHours(_options.CacheDurationHours * 0.25),
+                    Priority = CacheItemPriority.High,
+                    Size = 1
+                };
+                _cache.Set(ControlsCacheKey, rebuilt, opts);
+                return rebuilt;
+            }
+
+            _lazyCatalog = new Lazy<Task<NistCatalog?>>(
+                () => LoadAndCacheCatalogAsync(CancellationToken.None),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
 
         return new List<NistControl>();
     }


### PR DESCRIPTION
## Problem

`kb_explain_nist_control` and `kb_search_nist_controls` return "not found" / 0 results for all controls (#598). Health check reports "Healthy 3/3" because it uses `GetCatalogAsync` (hits `CatalogCacheKey`) while the tools use `GetControlsAsync` (hits `ControlsCacheKey`). The two keys can get out of sync.

## Root Cause: Split-Brain Cache

`NistControlsService` caches two keys independently:
- **`CatalogCacheKey`** — the full typed OSCAL catalog (longer TTL)
- **`ControlsCacheKey`** — the flat `NistControl` list (shorter sliding TTL)

After the initial load, `_lazyCatalog` is a **resolved** `Lazy<Task<T>>` whose `.Value` returns the already-completed task immediately **without re-executing the factory**. When the sliding-expiration window evicts `ControlsCacheKey` while `CatalogCacheKey` is still alive, the second `TryGetValue` misses and the method falls through to `return new List<NistControl>()` — empty list, every lookup returns "not found".

The health check never sees this because `ValidateControlIdAsync` calls `GetCatalogAsync` which hits `CatalogCacheKey` directly.

## Fix: Three-Tier Fallback in GetControlsAsync

1. Fast path: `ControlsCacheKey` hit (common case — no change)
2. Lazy trigger: first-load only (unchanged)
3. **NEW**: rebuild from `CatalogCacheKey` when `ControlsCacheKey` is absent — no HTTP reload
4. **NEW**: reset `_lazyCatalog` (under lock) when both keys are gone

## Spec Compliance
- Closes #594, #598
- Supersedes open PR #590 (never merged; this branch is off latest main)