### PR TITLE
fix(#585/#588): rename duplicate route 'DeleteSystem' → 'DeleteSystemById' — unblock ACA revision 0000093

### DIFF
--- a/src/Ato.Copilot.Mcp/Endpoints/SystemsEndpoints.cs
+++ b/src/Ato.Copilot.Mcp/Endpoints/SystemsEndpoints.cs
@@ -55,7 +55,7 @@ public static class SystemsEndpoints
 
         // ─── DELETE /api/systems/{id} ────────────────────────────────────────
         group.MapDelete("/{id}", DeleteSystemAsync)
-            .WithName("DeleteSystem")
+            .WithName("DeleteSystemById")
             .WithSummary("Delete a registered system")
             .WithDescription(
                 "Soft-deletes (IsActive=false) the specified system by default. " +


### PR DESCRIPTION
## Problem

POST `/api/dashboard/remediation/tasks` returns 405 (allow: GET only). The Create Task button in the Remediation UI fails immediately.

## Root Cause: Duplicate Route Name Crashes Startup

`SystemsEndpoints.cs` (added in #589) registers `.WithName("DeleteSystem")` on `DELETE /api/systems/{id}`. `DashboardEndpoints.cs` already registers `.WithName("DeleteSystem")` on line 324. ASP.NET throws `InvalidOperationException` at startup: **"Duplicate link generation entry with route name 'DeleteSystem'"**.

This causes ACA revision `0000093` (the wave-10 build) to fail its startup probe with **exit code 1** and fall back to the prior revision `0000087`, which **does not have** the `MapPost` for `/api/dashboard/remediation/tasks` — introduced in commit `3383c3d`. The 405 is traffic being served by the old revision.

**Evidence from ACA system logs:**
```
Probe of StartUp failed with status code: 1  (count: 686)
```
Container replica shows: `"ready": false, "restartCount": 2`

## Fix

Rename the route in `SystemsEndpoints.cs` from `"DeleteSystem"` to `"DeleteSystemById"`. 1-line change. No consumer references this name at runtime — it is only used for OpenAPI link generation.

## Outcome

Once this merges and the CD deploys:
- Revision `0000093` startup probe passes
- ACA routes 100% traffic to the new revision
- POST `/api/dashboard/remediation/tasks` is live
- Create Task in the Remediation UI works

## Spec Compliance
- Closes #585
- Fixes deployment regression introduced by #589 (#588)