### PR TITLE
fix(#599/#595/#581): navigate on row click even when impersonation API fails

### DIFF
--- a/src/Ato.Copilot.Dashboard/src/features/csp-dashboard/CspSystemsPage.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/csp-dashboard/CspSystemsPage.tsx
@@ -146,13 +146,15 @@ export default function CspSystemsPage({
     setBusySystemId(system.systemId);
     try {
       await startImpersonation(system.tenantId, system.orgDisplayName);
-      navigate(`/systems/${encodeURIComponent(system.systemId)}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Impersonation failed.';
       setError(msg);
+      // fix(#595/#599): navigate even when impersonation API is unavailable so
+      // In Setup systems and all rows remain accessible.
     } finally {
       setBusySystemId(null);
     }
+    navigate(`/systems/${encodeURIComponent(system.systemId)}`);
   };
 
   const totalPages = data

--- a/src/Ato.Copilot.Dashboard/src/features/csp-dashboard/OrgsTable.tsx
+++ b/src/Ato.Copilot.Dashboard/src/features/csp-dashboard/OrgsTable.tsx
@@ -165,13 +165,15 @@ export default function OrgsTable({
     setBusyTenantId(org.tenantId);
     try {
       await startImpersonation(org.tenantId, org.displayName);
-      navigate('/');
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Impersonation failed.';
       setError(msg);
+      // fix(#599): navigate even when impersonation API is unavailable so
+      // the primary discovery flow (org → systems) is never a dead end.
     } finally {
       setBusyTenantId(null);
     }
+    navigate('/');
   };
 
   const totalPages = data


### PR DESCRIPTION
## Summary

Fixes dead row-click navigation in the CSP admin portfolio and systems views.

## Root Cause

`OrgsTable.handleRowClick` and `CspSystemsPage.handleRowClick` both called
`startImpersonation()` inside a try block and placed `navigate()` inside
that same block. When `POST /api/tenants/{id}/impersonate` returned 401/403
or threw a network error, the catch swallowed the error and set an error
banner — but `navigate()` was never reached.

Users saw cursor-pointer rows that did nothing: no navigation, no visible
error (the banner was below the fold), no alternative path.

## Fix

Move `navigate()` outside the try/catch block in both components. The
impersonation attempt is still made (and errors still shown in the banner),
but navigation proceeds regardless of the impersonation result.

## Affected Issues

- #599 — Portfolio org table row clicks dead
- #581 — Portfolio Risk Profile System Risk Summary row clicks dead (CSP path)
- #595 — /systems 'In Setup' rows dead

## Test Plan

- [x] Click org row in CSP portfolio — navigates to `/`
- [x] Click system row in `/systems` CSP view — navigates to `/systems/{id}`
- [x] Click system row in `/systems` per-tenant view — navigates to `/systems/{id}` (unchanged — PortfolioDashboard/SystemSummaryRow uses direct navigate)
- [x] Verify impersonation error banner still appears when API rejects (doesn't suppress error)

Closes #599
Closes #581
Closes #595
