### PR TITLE
fix(#545): bypass RequireRoleAsync for unauthenticated dashboard-user identity

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Services/SystemProfileService.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Services/SystemProfileService.cs
@@ -848,6 +848,17 @@ public class SystemProfileService : ISystemProfileService
         if (simulatedRole.HasValue && allowedRoles.Contains(simulatedRole.Value))
             return;
 
+        // fix(#545): "dashboard-user" is the unauthenticated dev/QA identity produced by
+        // ResolveDashboardUserId when no MSAL token is present. Every other dashboard
+        // endpoint treats this identity as a pass-through (no role check), consistent
+        // with the dev-only design of the simulated-role header. Without this bypass,
+        // users who haven't set a role in Settings (so X-Simulated-Role is absent) receive
+        // a 403 on every Save Draft click — the error shows as "Save failed" and data is
+        // silently discarded on page reload. Authenticated MSAL users are unaffected
+        // (simulatedRole is always null for authenticated users and userId is their real OID).
+        if (string.Equals(userId, "dashboard-user", StringComparison.OrdinalIgnoreCase))
+            return;
+
         var hasRole = await db.RmfRoleAssignments
             .AnyAsync(r => r.RegisteredSystemId == systemId
                 && r.UserId == userId


### PR DESCRIPTION
## Summary

Fixes Mission Profile Save Draft silently failing — data entered in Mission & Purpose and other profile sections is discarded on page reload.

## Root Cause

`SystemProfileService.RequireRoleAsync` blocked saves from the unauthenticated dev/QA identity `"dashboard-user"`. In environments without MSAL (the v2 QA deployment), two conditions converged:

1. `ResolveDashboardUserId` returns `"dashboard-user"` (no real user OID)
2. `ResolveSimulatedRmfRole` returns `null` when `X-Simulated-Role` header is absent (happens when `settings.role` is not configured in the Settings panel)

With no simulatedRole and no DB role assignments for `"dashboard-user"`, `RequireRoleAsync` threw `UNAUTHORIZED` 403 on every `PUT /profile/{sectionType}` call. The frontend showed `"Save failed"` and discarded the data. On page reload, fields returned empty.

## Fix

Add a bypass in `RequireRoleAsync` for `userId == "dashboard-user"` (case-insensitive), consistent with every other dashboard mutation endpoint (`POST /systems`, `PUT /systems/{id}`, `POST /systems/{id}/roles`, etc.) which already accept this identity without a role check in unauthenticated mode.

**Authenticated MSAL users are unaffected:** when `IsAuthenticated = true`, `simulatedRole` is always `null` and `userId` is the user's real OID — never `"dashboard-user"` — so the bypass never fires in production.

## Test Plan

- [ ] Navigate to `/systems/{id}/profile/MissionAndPurpose` with no role configured in Settings
- [ ] Fill in Mission Statement and Business Purpose
- [ ] Click **Save Draft** — no error shown, success banner appears
- [ ] Navigate away and return to the same page
- [ ] Verify fields retain the saved values
- [ ] Verify governance status badge updates to `Draft`
- [ ] Verify section shows in Profile Completeness progress

Closes #545
