### PR TITLE
fix: run terraform fmt to canonically format main.tf (fixes Terraform Lint CI)

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -309,8 +309,8 @@ resource "azurerm_container_app" "mcp" {
     # fix(#767/WM-INFRA-1): Changed from 8080 to 3001 — the app listens on 3001
     # as confirmed by Dockerfile (EXPOSE 3001), appsettings.json (Urls: http://0.0.0.0:3001),
     # and docker-compose.mcp.yml (ASPNETCORE_URLS=http://+:3001).
-    target_port      = 3001
-    transport        = "auto" # "auto" enables HTTP + WebSocket upgrade (required for SignalR)
+    target_port = 3001
+    transport   = "auto" # "auto" enables HTTP + WebSocket upgrade (required for SignalR)
 
     # sticky_sessions is NOT supported in azurerm ~> 3.x (added in 4.x).
     # The overlay modules (overlays-key-vault, overlays-azsql, overlays-container-registry)


### PR DESCRIPTION
Closes #793 (Terraform Lint CI failure)

## What
Run `terraform fmt -recursive` to canonically format `infra/terraform/main.tf`.

## Why
The `terraform fmt --check -recursive` step in the Terraform Lint CI job was exiting with code 3 because two lines in the `ingress` block had extra alignment spaces that don't match Terraform's canonical format.

## Change
Whitespace/alignment only — two lines in the `ingress` block of the `azurerm_container_app` resource. No semantic Terraform changes.

## Verification
`terraform fmt --check -recursive infra/terraform/` exits 0 locally.