### PR TITLE
feat: claim-verifier router and classifier promotion gate

### DIFF
--- a/src/Ato.Copilot.Core/Interfaces/Provenance/IClaimVerifierRouter.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Provenance/IClaimVerifierRouter.cs
@@ -1,0 +1,56 @@
+using Ato.Copilot.Core.Models.Provenance;
+
+namespace Ato.Copilot.Core.Interfaces.Provenance;
+
+/// <summary>
+/// Routes a claim–evidence pair through either the DeBERTa fast-path or the LLM fallback,
+/// depending on the <c>DEBERTA_NLI_MODE</c> environment flag and the confidence-margin
+/// of the DeBERTa verdict (#2753).
+///
+/// Routing rules:
+/// - When <c>DEBERTA_NLI_MODE</c> is <c>false</c> (default): always route to LLM.
+/// - When <c>DEBERTA_NLI_MODE</c> is <c>true</c>:
+///   - If DeBERTa top_margin ≥ τ → DeBERTa fast-path.
+///   - Otherwise → LLM fallback.
+///   - If the auto-rollback guard has tripped (precision or agreement below floor) → LLM fallback.
+///   - If the LLM comparator is unavailable (#2780) → DeBERTa only for clear-cut; others are
+///     held/skipped until LLM is available.
+/// </summary>
+public interface IClaimVerifierRouter
+{
+    /// <summary>
+    /// Verify a single claim–evidence pair and return the routing result.
+    /// </summary>
+    Task<ClaimVerificationResult> VerifyAsync(
+        string claim,
+        string evidence,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether the LLM comparator is currently available.
+    /// When false, agreement metrics are not collected (#2780 protocol).
+    /// </summary>
+    bool IsLlmComparatorAvailable { get; }
+
+    /// <summary>
+    /// Signals that the LLM comparator is unavailable (e.g. #2780 Anthropic credits exhausted).
+    /// While this flag is set, agreement metrics are skipped and the router will not attempt
+    /// LLM calls for the purpose of shadow comparison.
+    /// </summary>
+    void MarkLlmComparatorUnavailable();
+
+    /// <summary>Clears the LLM unavailability flag once credits/service is restored.</summary>
+    void MarkLlmComparatorAvailable();
+
+    /// <summary>
+    /// Signals that the auto-rollback guard has fired.  Once tripped, all traffic is routed
+    /// to LLM fallback regardless of DEBERTA_NLI_MODE until the guard is manually cleared.
+    /// </summary>
+    void TripAutoRollback(string reason);
+
+    /// <summary>Clears the auto-rollback guard (requires engineering-lead sign-off).</summary>
+    void ClearAutoRollback();
+
+    /// <summary>True when the auto-rollback guard is currently tripped.</summary>
+    bool IsAutoRollbackActive { get; }
+}

--- a/src/Ato.Copilot.Core/Interfaces/Provenance/IClassifierPromotionGateService.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Provenance/IClassifierPromotionGateService.cs
@@ -1,0 +1,40 @@
+using Ato.Copilot.Core.Models.Provenance;
+
+namespace Ato.Copilot.Core.Interfaces.Provenance;
+
+/// <summary>
+/// Runs the eight-gate DeBERTa NLI promotion analysis over <c>classifier_shadow_log</c> data (#2753).
+///
+/// Callers should await <see cref="EvaluateAsync"/> to obtain a <see cref="ClassifierPromotionGateResult"/>
+/// describing which of the eight gates pass.  All eight must pass before <c>DEBERTA_NLI_MODE</c>
+/// may be enabled in production.
+///
+/// This service is read-only with respect to the database; it never modifies shadow log rows.
+/// </summary>
+public interface IClassifierPromotionGateService
+{
+    /// <summary>
+    /// Runs the full eight-gate evaluation over <c>classifier_shadow_log</c>.
+    /// </summary>
+    /// <param name="tau">
+    /// Confidence-margin threshold that defines the "clear-cut" routing region.
+    /// DeBERTa decides when <c>top_margin ≥ tau</c>; else LLM fallback is used.
+    /// Defaults to 0.50 (the #2753 reference operating point).
+    /// </param>
+    /// <param name="humanAdjudicationAccepted">
+    /// Whether the 200-sample human-adjudicated gold set has been completed and
+    /// accepted by the engineering lead (Gate 6).  This cannot be derived from the
+    /// database and must be supplied by the caller.
+    /// </param>
+    /// <param name="badgeAccuracyDelta">
+    /// Badge-accuracy delta from the staging A/B run (Gate 7).  Pass null if the
+    /// A/B has not been run yet — the gate will be deferred (not failed).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="ClassifierPromotionGateResult"/> with all eight gate outcomes.</returns>
+    Task<ClassifierPromotionGateResult> EvaluateAsync(
+        double tau = 0.50,
+        bool humanAdjudicationAccepted = false,
+        double? badgeAccuracyDelta = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ato.Copilot.Core/Interfaces/Provenance/IDeBertaNliVerifier.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Provenance/IDeBertaNliVerifier.cs
@@ -1,0 +1,54 @@
+using Ato.Copilot.Core.Models.Provenance;
+
+namespace Ato.Copilot.Core.Interfaces.Provenance;
+
+/// <summary>
+/// DeBERTa NLI inference contract for claim–evidence pair classification (#2497, #2753).
+///
+/// Implementations run the ECE-calibrated DeBERTa NLI model and return the four-class
+/// verdict (supported / refuted / tangential / insufficient) with confidence and margin.
+///
+/// Label mapping (fixed, per #2497):
+///   entailment   → "supported"
+///   contradiction → "refuted"
+///   neutral (conf > 0.6) → "tangential"
+///   neutral (conf ≤ 0.6) → "insufficient"
+/// </summary>
+public interface IDeBertaNliVerifier
+{
+    /// <summary>
+    /// Run DeBERTa NLI inference on a single claim–evidence pair.
+    /// </summary>
+    /// <param name="claim">Normalized claim text.</param>
+    /// <param name="evidence">Normalized evidence text.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="DebertaNliResult"/> with the four-class verdict, confidence,
+    /// and top-vs-second class margin.
+    /// </returns>
+    Task<DebertaNliResult> InferAsync(
+        string claim,
+        string evidence,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a single DeBERTa NLI inference call.
+/// </summary>
+public sealed class DebertaNliResult
+{
+    /// <summary>Verdict: "supported" | "refuted" | "tangential" | "insufficient".</summary>
+    public string Verdict { get; init; } = string.Empty;
+
+    /// <summary>Softmax confidence for the top class (0–1).</summary>
+    public double Confidence { get; init; }
+
+    /// <summary>
+    /// Margin = top-class probability − second-class probability.
+    /// Gate 2 requires this ≥ 0.50 in the clear-cut region.
+    /// </summary>
+    public double TopMargin { get; init; }
+
+    /// <summary>Inference latency in milliseconds.</summary>
+    public long LatencyMs { get; init; }
+}

--- a/src/Ato.Copilot.Core/Interfaces/Provenance/ILlmClaimVerifier.cs
+++ b/src/Ato.Copilot.Core/Interfaces/Provenance/ILlmClaimVerifier.cs
@@ -1,0 +1,52 @@
+using Ato.Copilot.Core.Models.Provenance;
+
+namespace Ato.Copilot.Core.Interfaces.Provenance;
+
+/// <summary>
+/// LLM-based claim verifier contract — the existing production path (#2753 fallback).
+///
+/// This is the current primary verifier.  The <see cref="IClaimVerifierRouter"/> uses it
+/// as the fallback for pairs that DeBERTa cannot handle with high confidence (top_margin &lt; τ),
+/// and as the sole path when <c>DEBERTA_NLI_MODE</c> is disabled.
+/// </summary>
+public interface ILlmClaimVerifier
+{
+    /// <summary>
+    /// Run LLM-based verification on a single claim–evidence pair.
+    /// </summary>
+    /// <param name="claim">Claim text.</param>
+    /// <param name="evidence">Evidence text.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="LlmVerifierResult"/> with the verdict and confidence.
+    /// Implementations should throw <see cref="LlmVerifierUnavailableException"/> when
+    /// the LLM service is unreachable (e.g. #2780 credits exhausted).
+    /// </returns>
+    Task<LlmVerifierResult> VerifyAsync(
+        string claim,
+        string evidence,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Result of a single LLM claim verification call.</summary>
+public sealed class LlmVerifierResult
+{
+    /// <summary>Verdict: "supported" | "refuted" | "tangential" | "insufficient".</summary>
+    public string Verdict { get; init; } = string.Empty;
+
+    /// <summary>LLM-reported confidence score (0–1), when available.</summary>
+    public double? Confidence { get; init; }
+
+    /// <summary>Wall-clock latency in milliseconds.</summary>
+    public long LatencyMs { get; init; }
+}
+
+/// <summary>
+/// Thrown when the LLM verifier service is unavailable (e.g. #2780 Anthropic credits exhausted).
+/// The <see cref="IClaimVerifierRouter"/> catches this and marks the comparator as unavailable.
+/// </summary>
+public sealed class LlmVerifierUnavailableException : Exception
+{
+    public LlmVerifierUnavailableException(string message, Exception? inner = null)
+        : base(message, inner) { }
+}

--- a/src/Ato.Copilot.Core/Models/Provenance/ClaimVerificationResult.cs
+++ b/src/Ato.Copilot.Core/Models/Provenance/ClaimVerificationResult.cs
@@ -1,0 +1,36 @@
+namespace Ato.Copilot.Core.Models.Provenance;
+
+/// <summary>
+/// Result of routing a single claim–evidence pair through the
+/// <see cref="Ato.Copilot.Mcp.Services.ClaimVerifierRouter"/> (#2753).
+/// </summary>
+public sealed class ClaimVerificationResult
+{
+    /// <summary>Final verdict: "supported" | "refuted" | "tangential" | "insufficient".</summary>
+    public string Verdict { get; init; } = string.Empty;
+
+    /// <summary>Confidence score for the verdict (0–1).</summary>
+    public double Confidence { get; init; }
+
+    /// <summary>Which path produced this verdict.</summary>
+    public VerificationPath Path { get; init; }
+
+    /// <summary>Wall-clock latency in milliseconds.</summary>
+    public long LatencyMs { get; init; }
+}
+
+/// <summary>Which code path produced a claim verification result.</summary>
+public enum VerificationPath
+{
+    /// <summary>DeBERTa fast-path (clear-cut: top_margin ≥ τ and DEBERTA_NLI_MODE is ON).</summary>
+    DebertaFastPath,
+
+    /// <summary>LLM verifier fallback (below τ, or DEBERTA_NLI_MODE is OFF).</summary>
+    LlmFallback,
+
+    /// <summary>
+    /// DeBERTa fast-path was attempted but degraded to LLM because the auto-rollback
+    /// guard fired (contradicted-class precision or agreement dropped below gate floors).
+    /// </summary>
+    AutoRollbackToLlm,
+}

--- a/src/Ato.Copilot.Core/Models/Provenance/ClassifierPromotionGateResult.cs
+++ b/src/Ato.Copilot.Core/Models/Provenance/ClassifierPromotionGateResult.cs
@@ -1,0 +1,182 @@
+namespace Ato.Copilot.Core.Models.Provenance;
+
+/// <summary>
+/// Result of running the eight-gate DeBERTa NLI promotion analysis (#2753).
+///
+/// All eight gates must pass before <c>DEBERTA_NLI_MODE</c> may be enabled in production.
+/// A single <see cref="AllGatesPass"/> = false blocks flag enablement.
+/// </summary>
+public sealed class ClassifierPromotionGateResult
+{
+    // ─── Data availability ────────────────────────────────────────────────────
+
+    /// <summary>Total rows analyzed from <c>classifier_shadow_log</c>.</summary>
+    public int TotalPairs { get; init; }
+
+    /// <summary>
+    /// Whether enough data has accumulated to run the gates.
+    /// Minimum required: 10 000 rows across all four verdict classes.
+    /// </summary>
+    public bool SufficientData { get; init; }
+
+    // ─── Gate 1: Contradicted-class precision (#2753 gate 1) ─────────────────
+
+    /// <summary>
+    /// DeBERTa precision on the refuted/insufficient class vs human-gold labels,
+    /// at τ = <see cref="SelectedTau"/>.  Required: ≥ 0.95.
+    /// </summary>
+    public double ContradictedClassPrecision { get; init; }
+
+    /// <summary>Gate 1 passes when <see cref="ContradictedClassPrecision"/> ≥ 0.95.</summary>
+    public bool Gate1_ContradictedPrecision => ContradictedClassPrecision >= 0.95;
+
+    // ─── Gate 2: Confidence margin (#2753 gate 2) ────────────────────────────
+
+    /// <summary>
+    /// Mean top-vs-second softmax margin across clear-cut (fast-path) decisions.
+    /// Required: ≥ 0.50 on the clear-cut region.
+    /// </summary>
+    public double MeanTopMarginInClearCutRegion { get; init; }
+
+    /// <summary>Gate 2 passes when mean margin ≥ 0.50.</summary>
+    public bool Gate2_MarginFloor => MeanTopMarginInClearCutRegion >= 0.50;
+
+    // ─── Gate 3: DeBERTa–LLM agreement (#2753 gate 3) ───────────────────────
+
+    /// <summary>
+    /// DeBERTa–LLM agreement rate within the clear-cut region (margin ≥ τ).
+    /// Required: ≥ 0.95.  Null when LLM comparator is unavailable (#2780).
+    /// </summary>
+    public double? AgreementRateInClearCutRegion { get; init; }
+
+    /// <summary>
+    /// Gate 3 passes when agreement ≥ 0.95, or is null (LLM outage — gate deferred,
+    /// not failed, per #2780 protocol).
+    /// </summary>
+    public bool Gate3_Agreement =>
+        AgreementRateInClearCutRegion is null || AgreementRateInClearCutRegion.Value >= 0.95;
+
+    // ─── Gate 4: Calibration / ECE (#2753 gate 4) ────────────────────────────
+
+    /// <summary>
+    /// Expected Calibration Error (ECE) across confidence strata.
+    /// Required: ≤ 0.05.
+    /// </summary>
+    public double ExpectedCalibrationError { get; init; }
+
+    /// <summary>Gate 4 passes when ECE ≤ 0.05.</summary>
+    public bool Gate4_Calibration => ExpectedCalibrationError <= 0.05;
+
+    // ─── Gate 5: p95 latency (#2753 gate 5) ─────────────────────────────────
+
+    /// <summary>
+    /// 95th-percentile DeBERTa inference latency in milliseconds from shadow log.
+    /// Required: &lt; 50ms.
+    /// </summary>
+    public double P95LatencyMs { get; init; }
+
+    /// <summary>Gate 5 passes when p95 latency &lt; 50ms.</summary>
+    public bool Gate5_P95Latency => P95LatencyMs < 50.0;
+
+    // ─── Gate 6: Human adjudication (#2753 gate 6) ───────────────────────────
+
+    /// <summary>
+    /// Whether the 200-sample human-adjudicated gold set has been collected
+    /// and accepted by the engineering lead.  Must be set externally.
+    /// </summary>
+    public bool Gate6_HumanAdjudicationAccepted { get; init; }
+
+    // ─── Gate 7: No A/B badge regression (#2753 gate 7) ─────────────────────
+
+    /// <summary>
+    /// Badge-accuracy delta (DeBERTa fast-path vs current LLM-only baseline).
+    /// Positive means improvement; zero is acceptable; negative blocks.
+    /// Null when staging A/B has not been run yet.
+    /// </summary>
+    public double? BadgeAccuracyDelta { get; init; }
+
+    /// <summary>
+    /// Gate 7 passes when delta ≥ 0, or is null (A/B not yet run — gate deferred).
+    /// </summary>
+    public bool Gate7_NoBadgeRegression =>
+        BadgeAccuracyDelta is null || BadgeAccuracyDelta.Value >= 0.0;
+
+    // ─── Gate 8: Routable fraction (#2753 gate 8) ────────────────────────────
+
+    /// <summary>
+    /// Fraction of live traffic pairs that fall in the clear-cut region (0–1).
+    /// Required: ≥ 0.40 (40%) to make the fast-path material.
+    /// </summary>
+    public double RoutableFraction { get; init; }
+
+    /// <summary>Gate 8 passes when routable fraction ≥ 0.40.</summary>
+    public bool Gate8_RoutableFraction => RoutableFraction >= 0.40;
+
+    // ─── Operating-point metadata ─────────────────────────────────────────────
+
+    /// <summary>
+    /// The τ threshold applied when producing this result.
+    /// DeBERTa decides when top_margin ≥ τ; otherwise LLM fallback is used.
+    /// </summary>
+    public double SelectedTau { get; init; }
+
+    /// <summary>Number of pairs that fell into the clear-cut (DeBERTa fast-path) region.</summary>
+    public int ClearCutPairCount { get; init; }
+
+    /// <summary>Number of pairs routed to LLM fallback.</summary>
+    public int FallbackPairCount { get; init; }
+
+    // ─── Per-class precision/recall breakdown ─────────────────────────────────
+
+    /// <summary>Per-class precision keyed by verdict label (supported/refuted/tangential/insufficient).</summary>
+    public IReadOnlyDictionary<string, double> PrecisionByClass { get; init; } =
+        new Dictionary<string, double>();
+
+    /// <summary>Per-class recall keyed by verdict label.</summary>
+    public IReadOnlyDictionary<string, double> RecallByClass { get; init; } =
+        new Dictionary<string, double>();
+
+    /// <summary>Agreement rate per confidence bucket (key = bucket label e.g. "[0.60,0.75)").</summary>
+    public IReadOnlyDictionary<string, double> AgreementByConfidenceBucket { get; init; } =
+        new Dictionary<string, double>();
+
+    /// <summary>Agreement rate per top-margin bucket (key = bucket label e.g. "[0.30,0.50)").</summary>
+    public IReadOnlyDictionary<string, double> AgreementByMarginBucket { get; init; } =
+        new Dictionary<string, double>();
+
+    // ─── Summary ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// True only when all eight gates pass AND sufficient data has accumulated.
+    /// This is the production-promotion authorization signal.
+    /// </summary>
+    public bool AllGatesPass =>
+        SufficientData &&
+        Gate1_ContradictedPrecision &&
+        Gate2_MarginFloor &&
+        Gate3_Agreement &&
+        Gate4_Calibration &&
+        Gate5_P95Latency &&
+        Gate6_HumanAdjudicationAccepted &&
+        Gate7_NoBadgeRegression &&
+        Gate8_RoutableFraction;
+
+    /// <summary>Human-readable summary of which gates passed and which blocked promotion.</summary>
+    public string FormatGateSummary()
+    {
+        var lines = new[]
+        {
+            $"Gate 1 – Contradicted precision ≥ 0.95  : {(Gate1_ContradictedPrecision ? "PASS" : "FAIL")}  ({ContradictedClassPrecision:F3})",
+            $"Gate 2 – Mean margin ≥ 0.50             : {(Gate2_MarginFloor           ? "PASS" : "FAIL")}  ({MeanTopMarginInClearCutRegion:F3})",
+            $"Gate 3 – Agreement ≥ 0.95 (clear-cut)  : {(Gate3_Agreement              ? "PASS" : (AgreementRateInClearCutRegion is null ? "DEFER (LLM outage)" : "FAIL"))}  ({AgreementRateInClearCutRegion?.ToString("F3") ?? "n/a"})",
+            $"Gate 4 – ECE ≤ 0.05                    : {(Gate4_Calibration            ? "PASS" : "FAIL")}  ({ExpectedCalibrationError:F4})",
+            $"Gate 5 – p95 latency < 50ms             : {(Gate5_P95Latency             ? "PASS" : "FAIL")}  ({P95LatencyMs:F1}ms)",
+            $"Gate 6 – Human adjudication accepted   : {(Gate6_HumanAdjudicationAccepted ? "PASS" : "FAIL")}",
+            $"Gate 7 – No badge regression            : {(Gate7_NoBadgeRegression      ? "PASS" : (BadgeAccuracyDelta is null ? "DEFER (A/B not run)" : "FAIL"))}  (delta={BadgeAccuracyDelta?.ToString("F4") ?? "n/a"})",
+            $"Gate 8 – Routable fraction ≥ 40%       : {(Gate8_RoutableFraction        ? "PASS" : "FAIL")}  ({RoutableFraction:P1})",
+            "",
+            $"Overall: {(AllGatesPass ? "PROMOTION AUTHORIZED" : "PROMOTION BLOCKED")}",
+        };
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -315,6 +315,50 @@ async Task RunHttpModeAsync(string[] args)
         });
     builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Compliance.INotificationBroadcaster,
         Ato.Copilot.Mcp.Services.SignalRNotificationBroadcaster>();
+    // #941 — Epic 10: model-call provenance ledger (append-only, singleton-safe via IDbContextFactory).
+    builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Provenance.IModelCallLedger,
+        Ato.Copilot.Mcp.Services.ModelCallLedger>();
+    // #2497/#2753 — DeBERTa NLI shadow logger. Off by default until telemetry prereqs #2748/#2749 are live.
+    // Set FEATURE_CLASSIFIER_SHADOW=true to enable accumulation. Production flip (DEBERTA_NLI_MODE) remains blocked.
+    if (string.Equals(builder.Configuration["FEATURE_CLASSIFIER_SHADOW"], "true", StringComparison.OrdinalIgnoreCase))
+    {
+        builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Provenance.IClassifierShadowLogger,
+            Ato.Copilot.Mcp.Services.ClassifierShadowLogger>();
+    }
+    else
+    {
+        builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Provenance.IClassifierShadowLogger,
+            Ato.Copilot.Mcp.Services.NullClassifierShadowLogger>();
+    }
+    // #2753 — Promotion-gate evaluation service (read-only; analyzes classifier_shadow_log).
+    // Always registered so callers can check gate state; requires FEATURE_CLASSIFIER_SHADOW rows to be meaningful.
+    builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Provenance.IClassifierPromotionGateService,
+        Ato.Copilot.Mcp.Services.ClassifierPromotionGateService>();
+    // #2753 — Claim verifier router: DEBERTA_NLI_MODE flag + τ threshold + auto-rollback guard.
+    // IDeBertaNliVerifier and ILlmClaimVerifier must be registered by the consuming subsystem
+    // before ClaimVerifierRouter can be resolved. Registration here is conditional on both
+    // verifier interfaces being present to avoid startup failures in hosts that don't wire them.
+    if (builder.Configuration["DEBERTA_NLI_MODE"] is not null ||
+        builder.Configuration["FEATURE_CLASSIFIER_SHADOW"] == "true")
+    {
+        bool debertaModeOn = string.Equals(
+            builder.Configuration["DEBERTA_NLI_MODE"], "true", StringComparison.OrdinalIgnoreCase);
+        double tau = double.TryParse(builder.Configuration["DEBERTA_NLI_TAU"], out var t)
+            ? t
+            : Ato.Copilot.Mcp.Services.ClaimVerifierRouter.DefaultTau;
+
+        // ClaimVerifierRouter requires IDeBertaNliVerifier + ILlmClaimVerifier to be registered
+        // by the consuming feature. Register as factory so resolution is deferred and fails loudly
+        // at first use rather than at startup.
+        builder.Services.AddSingleton<Ato.Copilot.Core.Interfaces.Provenance.IClaimVerifierRouter>(sp =>
+            new Ato.Copilot.Mcp.Services.ClaimVerifierRouter(
+                sp.GetRequiredService<Ato.Copilot.Core.Interfaces.Provenance.IDeBertaNliVerifier>(),
+                sp.GetRequiredService<Ato.Copilot.Core.Interfaces.Provenance.ILlmClaimVerifier>(),
+                sp.GetRequiredService<Ato.Copilot.Core.Interfaces.Provenance.IClassifierShadowLogger>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Ato.Copilot.Mcp.Services.ClaimVerifierRouter>>(),
+                debertaModeOn,
+                tau));
+    }
     // Feature 048 (T149): tenant impersonation fan-out (consumed by TenantsEndpoints).
     builder.Services.AddSingleton<Ato.Copilot.Mcp.Hubs.ITenantContextNotifier,
         Ato.Copilot.Mcp.Hubs.TenantContextNotifier>();

--- a/src/Ato.Copilot.Mcp/Services/ClaimVerifierRouter.cs
+++ b/src/Ato.Copilot.Mcp/Services/ClaimVerifierRouter.cs
@@ -1,0 +1,287 @@
+using System.Diagnostics;
+using Ato.Copilot.Core.Interfaces.Provenance;
+using Ato.Copilot.Core.Models.Provenance;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Mcp.Services;
+
+/// <summary>
+/// Routes claim–evidence pairs through either the DeBERTa fast-path or the LLM fallback,
+/// controlled by the <c>DEBERTA_NLI_MODE</c> environment flag (#2753).
+///
+/// Routing rules (evaluated in priority order):
+/// 1. If auto-rollback guard is active → always LLM fallback (logs reason).
+/// 2. If <c>DEBERTA_NLI_MODE</c> is <c>false</c> → always LLM fallback (default, flag OFF).
+/// 3. If DeBERTa top_margin ≥ τ → DeBERTa fast-path (clear-cut region).
+/// 4. Otherwise → LLM fallback (ambiguous region).
+///
+/// LLM outage (#2780) handling:
+/// - When the LLM comparator is marked unavailable, LLM calls are still attempted for
+///   user-facing verification (they must not silently fail).
+/// - Agreement/shadow-log LLM comparisons are SKIPPED (recorded as empty LlmVerdict).
+/// - If the LLM call fails with <see cref="LlmVerifierUnavailableException"/>, the router
+///   marks the comparator unavailable and surfaces the exception to the caller.
+///
+/// Auto-rollback:
+/// - When <see cref="TripAutoRollback"/> is called (by the monitoring job or the
+///   <see cref="ClassifierPromotionGateService"/> detecting a gate regression), all traffic
+///   immediately reverts to LLM fallback until <see cref="ClearAutoRollback"/> is called
+///   by an engineering lead.
+/// </summary>
+public sealed class ClaimVerifierRouter : IClaimVerifierRouter
+{
+    /// <summary>
+    /// Default τ threshold: DeBERTa decides when top_margin ≥ this value.
+    /// Override by setting <c>DEBERTA_NLI_TAU</c> environment variable.
+    /// </summary>
+    public const double DefaultTau = 0.50;
+
+    private readonly IDeBertaNliVerifier _deberta;
+    private readonly ILlmClaimVerifier _llm;
+    private readonly IClassifierShadowLogger _shadowLogger;
+    private readonly ILogger<ClaimVerifierRouter> _logger;
+    private readonly bool _debertaNliModeEnabled;
+    private readonly double _tau;
+
+    // Thread-safe flags — volatile is sufficient (single-writer semantics from monitoring).
+    private volatile bool _llmComparatorUnavailable;
+    private volatile bool _autoRollbackActive;
+    private volatile string _autoRollbackReason = string.Empty;
+
+    public ClaimVerifierRouter(
+        IDeBertaNliVerifier deberta,
+        ILlmClaimVerifier llm,
+        IClassifierShadowLogger shadowLogger,
+        ILogger<ClaimVerifierRouter> logger,
+        bool debertaNliModeEnabled,
+        double tau = DefaultTau)
+    {
+        _deberta = deberta;
+        _llm = llm;
+        _shadowLogger = shadowLogger;
+        _logger = logger;
+        _debertaNliModeEnabled = debertaNliModeEnabled;
+        _tau = tau;
+
+        if (_debertaNliModeEnabled)
+        {
+            _logger.LogInformation(
+                "[ClaimVerifierRouter] DEBERTA_NLI_MODE is ON (τ={Tau:F2}). " +
+                "Clear-cut pairs will route to DeBERTa fast-path; others fall back to LLM.",
+                _tau);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "[ClaimVerifierRouter] DEBERTA_NLI_MODE is OFF. All pairs route to LLM (shadow logging only).");
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsLlmComparatorAvailable => !_llmComparatorUnavailable;
+
+    /// <inheritdoc />
+    public bool IsAutoRollbackActive => _autoRollbackActive;
+
+    /// <inheritdoc />
+    public void MarkLlmComparatorUnavailable()
+    {
+        _llmComparatorUnavailable = true;
+        _logger.LogWarning(
+            "[ClaimVerifierRouter] LLM comparator marked unavailable (#2780). " +
+            "Agreement metrics will not be collected until availability is restored.");
+    }
+
+    /// <inheritdoc />
+    public void MarkLlmComparatorAvailable()
+    {
+        _llmComparatorUnavailable = false;
+        _logger.LogInformation("[ClaimVerifierRouter] LLM comparator marked available.");
+    }
+
+    /// <inheritdoc />
+    public void TripAutoRollback(string reason)
+    {
+        _autoRollbackActive = true;
+        _autoRollbackReason = reason;
+        _logger.LogCritical(
+            "[ClaimVerifierRouter] AUTO-ROLLBACK TRIPPED. All traffic reverted to LLM fallback. " +
+            "Reason: {Reason}. DEBERTA_NLI_MODE effectively disabled until rollback is cleared " +
+            "by engineering lead.", reason);
+    }
+
+    /// <inheritdoc />
+    public void ClearAutoRollback()
+    {
+        _autoRollbackActive = false;
+        _autoRollbackReason = string.Empty;
+        _logger.LogInformation("[ClaimVerifierRouter] Auto-rollback cleared by engineering lead.");
+    }
+
+    /// <inheritdoc />
+    public async Task<ClaimVerificationResult> VerifyAsync(
+        string claim,
+        string evidence,
+        CancellationToken cancellationToken = default)
+    {
+        // ── Step 1: run DeBERTa unconditionally (shadow logging requires the verdict). ──
+        // Even when DEBERTA_NLI_MODE is OFF, we run DeBERTa in shadow to accumulate data.
+        var sw = Stopwatch.StartNew();
+        DebertaNliResult debertaResult = await RunDebertaSafeAsync(claim, evidence, cancellationToken);
+        sw.Stop();
+
+        bool isClearCut = debertaResult.TopMargin >= _tau;
+
+        // ── Step 2: determine routing path. ──────────────────────────────────
+        VerificationPath path;
+        ClaimVerificationResult finalResult;
+
+        if (_autoRollbackActive)
+        {
+            // Rollback guard tripped — all traffic to LLM.
+            path = VerificationPath.AutoRollbackToLlm;
+            finalResult = await RunLlmPathAsync(claim, evidence, path, cancellationToken);
+        }
+        else if (!_debertaNliModeEnabled || !isClearCut)
+        {
+            // Flag is OFF, or pair is ambiguous — LLM fallback.
+            path = VerificationPath.LlmFallback;
+            finalResult = await RunLlmPathAsync(claim, evidence, path, cancellationToken);
+        }
+        else
+        {
+            // Clear-cut: DeBERTa fast-path.
+            path = VerificationPath.DebertaFastPath;
+            finalResult = new ClaimVerificationResult
+            {
+                Verdict    = debertaResult.Verdict,
+                Confidence = debertaResult.Confidence,
+                Path       = path,
+                LatencyMs  = debertaResult.LatencyMs,
+            };
+        }
+
+        // ── Step 3: shadow log (fire-and-forget — must never throw to caller). ─
+        // Skip LLM verdict collection when comparator is unavailable (#2780).
+        string llmVerdictForLog = path switch
+        {
+            VerificationPath.DebertaFastPath when _llmComparatorUnavailable => string.Empty,
+            VerificationPath.DebertaFastPath => string.Empty, // LLM not called on fast-path
+            _ => finalResult.Verdict,                          // LLM fallback: verdict IS the LLM verdict
+        };
+
+        _ = WriteShadowLogFireAndForgetAsync(
+            claim, evidence, debertaResult, llmVerdictForLog, finalResult.LatencyMs, cancellationToken);
+
+        _logger.LogDebug(
+            "[ClaimVerifierRouter] claim_hash={ClaimLen} evidence_hash={EvidLen} " +
+            "deberta={DebertaVerdict}(conf={Conf:F3},margin={Margin:F3}) path={Path} final={FinalVerdict}",
+            claim.Length, evidence.Length,
+            debertaResult.Verdict, debertaResult.Confidence, debertaResult.TopMargin,
+            path, finalResult.Verdict);
+
+        return finalResult;
+    }
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    private async Task<DebertaNliResult> RunDebertaSafeAsync(
+        string claim, string evidence, CancellationToken ct)
+    {
+        try
+        {
+            return await _deberta.InferAsync(claim, evidence, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // DeBERTa failure must not surface to the user — degrade gracefully with a
+            // low-confidence "insufficient" so the pair is always routed to LLM fallback.
+            _logger.LogWarning(ex,
+                "[ClaimVerifierRouter] DeBERTa inference failed — degrading to insufficient/0. " +
+                "Pair will be routed to LLM fallback.");
+            return new DebertaNliResult
+            {
+                Verdict    = "insufficient",
+                Confidence = 0.0,
+                TopMargin  = 0.0,
+                LatencyMs  = 0,
+            };
+        }
+    }
+
+    private async Task<ClaimVerificationResult> RunLlmPathAsync(
+        string claim, string evidence, VerificationPath path, CancellationToken ct)
+    {
+        try
+        {
+            var llmSw = Stopwatch.StartNew();
+            var llm = await _llm.VerifyAsync(claim, evidence, ct);
+            llmSw.Stop();
+
+            return new ClaimVerificationResult
+            {
+                Verdict    = llm.Verdict,
+                Confidence = llm.Confidence ?? 0.0,
+                Path       = path,
+                LatencyMs  = llmSw.ElapsedMilliseconds,
+            };
+        }
+        catch (LlmVerifierUnavailableException ex)
+        {
+            // Propagate but also flip the unavailability flag so agreement metrics stop.
+            MarkLlmComparatorUnavailable();
+            _logger.LogError(ex,
+                "[ClaimVerifierRouter] LLM verifier unavailable (#2780). " +
+                "Caller will receive exception; agreement metrics suspended.");
+            throw;
+        }
+    }
+
+    private async Task WriteShadowLogFireAndForgetAsync(
+        string claim,
+        string evidence,
+        DebertaNliResult deberta,
+        string llmVerdict,
+        long totalLatencyMs,
+        CancellationToken ct)
+    {
+        try
+        {
+            var entry = new ClassifierShadowLog
+            {
+                PairId          = ComputePairId(claim, evidence),
+                ClaimHash       = ComputeHash(claim),
+                EvidenceHash    = ComputeHash(evidence),
+                DebertaVerdict  = deberta.Verdict,
+                DebertaConfidence = deberta.Confidence,
+                DebertaTopMargin  = deberta.TopMargin,
+                LlmVerdict      = llmVerdict,
+                LlmConfidence   = null, // not captured on this path
+                LatencyMs       = totalLatencyMs,
+                TrafficSlice    = "live",
+                Ts              = DateTime.UtcNow,
+            };
+            await _shadowLogger.LogAsync(entry, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Constitution §VI: no silent swallowing — log visibly.
+            _logger.LogWarning(ex,
+                "[ClaimVerifierRouter] Shadow log write failed — telemetry gap for this pair. " +
+                "Verify #2748/#2749 are live.");
+        }
+    }
+
+    private static string ComputePairId(string claim, string evidence)
+    {
+        var combined = $"{ComputeHash(claim)}:{ComputeHash(evidence)}";
+        return ComputeHash(combined);
+    }
+
+    private static string ComputeHash(string input)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/Ato.Copilot.Mcp/Services/ClassifierPromotionGateService.cs
+++ b/src/Ato.Copilot.Mcp/Services/ClassifierPromotionGateService.cs
@@ -1,0 +1,284 @@
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Provenance;
+using Ato.Copilot.Core.Models.Provenance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Ato.Copilot.Mcp.Services;
+
+/// <summary>
+/// Stratified query/aggregation implementation of <see cref="IClassifierPromotionGateService"/> (#2753).
+///
+/// Reads <c>classifier_shadow_log</c> rows and computes all eight promotion-gate metrics:
+/// per-class precision/recall, DeBERTa–LLM agreement stratified by confidence and margin,
+/// ECE/reliability curve, routable fraction at candidate (τ, margin) thresholds, and p95 latency.
+///
+/// This service is strictly read-only — it never writes to or modifies shadow log rows.
+/// Uses <see cref="IDbContextFactory{T}"/> to stay singleton-safe (mirrors <see cref="ClassifierShadowLogger"/>).
+///
+/// Important: Gate 3 (agreement) is skipped with a null result when the LLM comparator is
+/// unavailable (#2780 Anthropic credits exhausted) — the caller must signal this by providing
+/// only rows whose <c>LlmVerdict</c> is non-empty.  Rows with empty <c>LlmVerdict</c> are
+/// excluded from agreement calculations automatically.
+/// </summary>
+public sealed class ClassifierPromotionGateService : IClassifierPromotionGateService
+{
+    // Minimum pairs required before gate analysis is valid (#2753 Phase 1).
+    private const int MinPairsRequired = 10_000;
+
+    // Confidence buckets for stratified agreement breakdown (Gate 3 / Stage 2).
+    private static readonly (double Lo, double Hi, string Label)[] ConfidenceBuckets =
+    [
+        (0.00, 0.60, "[0.00,0.60)"),
+        (0.60, 0.75, "[0.60,0.75)"),
+        (0.75, 0.90, "[0.75,0.90)"),
+        (0.90, 1.01, "[0.90,1.01)"),
+    ];
+
+    // Margin buckets for stratified agreement breakdown.
+    private static readonly (double Lo, double Hi, string Label)[] MarginBuckets =
+    [
+        (0.00, 0.30, "[0.00,0.30)"),
+        (0.30, 0.50, "[0.30,0.50)"),
+        (0.50, 0.70, "[0.50,0.70)"),
+        (0.70, 1.01, "[0.70,1.01)"),
+    ];
+
+    // ECE bin count for reliability diagram (10 equal-width bins 0–1).
+    private const int EceBins = 10;
+
+    private static readonly string[] AllVerdicts = ["supported", "refuted", "tangential", "insufficient"];
+
+    private readonly IDbContextFactory<AtoCopilotContext> _contextFactory;
+    private readonly ILogger<ClassifierPromotionGateService> _logger;
+
+    public ClassifierPromotionGateService(
+        IDbContextFactory<AtoCopilotContext> contextFactory,
+        ILogger<ClassifierPromotionGateService> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<ClassifierPromotionGateResult> EvaluateAsync(
+        double tau = 0.50,
+        bool humanAdjudicationAccepted = false,
+        double? badgeAccuracyDelta = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Pull all shadow rows into memory. The shadow log is expected to be in the tens of
+        // thousands — not large enough to require streaming, but large enough to benefit from
+        // AsNoTracking for read-only scenarios.
+        var rows = await db.ClassifierShadowLogs
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "[PromotionGate] Loaded {Count} shadow log rows for gate evaluation (τ={Tau}).",
+            rows.Count, tau);
+
+        if (rows.Count < MinPairsRequired)
+        {
+            _logger.LogWarning(
+                "[PromotionGate] Insufficient data: {Count} rows (min {Min}). " +
+                "Gates cannot be reliably evaluated — telemetry must accumulate before promotion.",
+                rows.Count, MinPairsRequired);
+
+            return new ClassifierPromotionGateResult
+            {
+                TotalPairs = rows.Count,
+                SufficientData = false,
+                SelectedTau = tau,
+                Gate6_HumanAdjudicationAccepted = humanAdjudicationAccepted,
+                BadgeAccuracyDelta = badgeAccuracyDelta,
+            };
+        }
+
+        // ─── Partition into clear-cut and fallback regions ────────────────────
+        var clearCut = rows.Where(r => r.DebertaTopMargin >= tau).ToList();
+        var fallback = rows.Where(r => r.DebertaTopMargin < tau).ToList();
+
+        // ─── Gate 1: Contradicted-class precision ─────────────────────────────
+        // Uses DebertaVerdict vs LlmVerdict as the ground-truth proxy (live traffic).
+        // On the gold set this is replaced by human labels — callers can pass in a
+        // pre-filtered row set to run against gold data.
+        double contradictedPrecision = ComputeContradictedPrecision(clearCut);
+
+        // ─── Gate 2: Mean top-margin in clear-cut region ──────────────────────
+        double meanMargin = clearCut.Count > 0
+            ? clearCut.Average(r => r.DebertaTopMargin)
+            : 0.0;
+
+        // ─── Gate 3: DeBERTa–LLM agreement (skip rows with empty LLM verdict) ─
+        // Rows with empty LlmVerdict are excluded — this handles the #2780 outage
+        // scenario: if no rows have LLM verdicts, AgreementRate becomes null (deferred).
+        var comparableRows = clearCut.Where(r => !string.IsNullOrWhiteSpace(r.LlmVerdict)).ToList();
+        double? agreementRate = comparableRows.Count > 0
+            ? comparableRows.Count(r => r.DebertaVerdict == r.LlmVerdict) / (double)comparableRows.Count
+            : null;
+
+        if (agreementRate is null)
+        {
+            _logger.LogWarning(
+                "[PromotionGate] Gate 3 (agreement) deferred: zero clear-cut rows have an LLM verdict. " +
+                "This is expected during an LLM outage (#2780). Agreement metrics are invalid " +
+                "and should not be used to make a promotion decision.");
+        }
+
+        // ─── Gate 4: Expected Calibration Error ───────────────────────────────
+        double ece = ComputeEce(rows);
+
+        // ─── Gate 5: p95 latency ──────────────────────────────────────────────
+        double p95 = ComputeP95(rows.Select(r => r.LatencyMs));
+
+        // ─── Gate 8: Routable fraction ────────────────────────────────────────
+        double routableFraction = rows.Count > 0
+            ? (double)clearCut.Count / rows.Count
+            : 0.0;
+
+        // ─── Per-class precision/recall ───────────────────────────────────────
+        var (precisionByClass, recallByClass) = ComputePerClassMetrics(rows);
+
+        // ─── Stratified agreement breakdown ──────────────────────────────────
+        var agreementByConf = ComputeStratifiedAgreement(
+            comparableRows, r => r.DebertaConfidence, ConfidenceBuckets);
+        var agreementByMargin = ComputeStratifiedAgreement(
+            comparableRows, r => r.DebertaTopMargin, MarginBuckets);
+
+        var result = new ClassifierPromotionGateResult
+        {
+            TotalPairs = rows.Count,
+            SufficientData = true,
+            SelectedTau = tau,
+            ClearCutPairCount = clearCut.Count,
+            FallbackPairCount = fallback.Count,
+            ContradictedClassPrecision = contradictedPrecision,
+            MeanTopMarginInClearCutRegion = meanMargin,
+            AgreementRateInClearCutRegion = agreementRate,
+            ExpectedCalibrationError = ece,
+            P95LatencyMs = p95,
+            Gate6_HumanAdjudicationAccepted = humanAdjudicationAccepted,
+            BadgeAccuracyDelta = badgeAccuracyDelta,
+            RoutableFraction = routableFraction,
+            PrecisionByClass = precisionByClass,
+            RecallByClass = recallByClass,
+            AgreementByConfidenceBucket = agreementByConf,
+            AgreementByMarginBucket = agreementByMargin,
+        };
+
+        _logger.LogInformation(
+            "[PromotionGate] Evaluation complete.\n{Summary}", result.FormatGateSummary());
+
+        return result;
+    }
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Contradicted-class precision: fraction of DeBERTa "refuted"/"insufficient" decisions
+    /// in the clear-cut region that match the LLM ground-truth verdict.
+    /// </summary>
+    private static double ComputeContradictedPrecision(
+        IReadOnlyList<ClassifierShadowLog> clearCut)
+    {
+        var debertaRefuted = clearCut
+            .Where(r => r.DebertaVerdict is "refuted" or "insufficient"
+                        && !string.IsNullOrWhiteSpace(r.LlmVerdict))
+            .ToList();
+
+        if (debertaRefuted.Count == 0) return 0.0;
+
+        var trueRefuted = debertaRefuted.Count(r => r.LlmVerdict is "refuted" or "insufficient");
+        return (double)trueRefuted / debertaRefuted.Count;
+    }
+
+    /// <summary>
+    /// Per-class precision and recall using LlmVerdict as the ground-truth label.
+    /// Only rows that have a non-empty LlmVerdict are included.
+    /// </summary>
+    private static (Dictionary<string, double> Precision, Dictionary<string, double> Recall)
+        ComputePerClassMetrics(IReadOnlyList<ClassifierShadowLog> rows)
+    {
+        var comparable = rows.Where(r => !string.IsNullOrWhiteSpace(r.LlmVerdict)).ToList();
+
+        var precision = new Dictionary<string, double>();
+        var recall = new Dictionary<string, double>();
+
+        foreach (var v in AllVerdicts)
+        {
+            int tp = comparable.Count(r => r.DebertaVerdict == v && r.LlmVerdict == v);
+            int fp = comparable.Count(r => r.DebertaVerdict == v && r.LlmVerdict != v);
+            int fn = comparable.Count(r => r.DebertaVerdict != v && r.LlmVerdict == v);
+
+            precision[v] = (tp + fp) > 0 ? (double)tp / (tp + fp) : 0.0;
+            recall[v]    = (tp + fn) > 0 ? (double)tp / (tp + fn) : 0.0;
+        }
+
+        return (precision, recall);
+    }
+
+    /// <summary>
+    /// Expected Calibration Error (ECE) using <c>DebertaConfidence</c> as the predicted
+    /// probability and agreement with <c>LlmVerdict</c> as the empirical accuracy proxy.
+    ///
+    /// ECE = Σ_b (|B_b| / N) × |acc(B_b) − conf(B_b)|
+    /// where bins partition [0,1] by confidence.
+    /// </summary>
+    private static double ComputeEce(IReadOnlyList<ClassifierShadowLog> rows)
+    {
+        var comparable = rows.Where(r => !string.IsNullOrWhiteSpace(r.LlmVerdict)).ToList();
+        if (comparable.Count == 0) return 0.0;
+
+        double ece = 0.0;
+        double binWidth = 1.0 / EceBins;
+
+        for (int i = 0; i < EceBins; i++)
+        {
+            double lo = i * binWidth;
+            double hi = lo + binWidth;
+            var bin = comparable
+                .Where(r => r.DebertaConfidence >= lo && (i == EceBins - 1 || r.DebertaConfidence < hi))
+                .ToList();
+
+            if (bin.Count == 0) continue;
+
+            double avgConf = bin.Average(r => r.DebertaConfidence);
+            double avgAcc  = bin.Count(r => r.DebertaVerdict == r.LlmVerdict) / (double)bin.Count;
+            ece += ((double)bin.Count / comparable.Count) * Math.Abs(avgAcc - avgConf);
+        }
+
+        return ece;
+    }
+
+    /// <summary>p95 latency from LatencyMs values.</summary>
+    private static double ComputeP95(IEnumerable<long> latencies)
+    {
+        var sorted = latencies.OrderBy(x => x).ToList();
+        if (sorted.Count == 0) return 0.0;
+        var idx = (int)Math.Ceiling(0.95 * sorted.Count) - 1;
+        return sorted[Math.Clamp(idx, 0, sorted.Count - 1)];
+    }
+
+    /// <summary>
+    /// Agreement rate stratified by a numeric field, using the provided bucket definitions.
+    /// </summary>
+    private static Dictionary<string, double> ComputeStratifiedAgreement(
+        IReadOnlyList<ClassifierShadowLog> comparableRows,
+        Func<ClassifierShadowLog, double> selector,
+        (double Lo, double Hi, string Label)[] buckets)
+    {
+        var result = new Dictionary<string, double>();
+        foreach (var (lo, hi, label) in buckets)
+        {
+            var bin = comparableRows
+                .Where(r => { var v = selector(r); return v >= lo && v < hi; })
+                .ToList();
+            if (bin.Count == 0) continue;
+            result[label] = bin.Count(r => r.DebertaVerdict == r.LlmVerdict) / (double)bin.Count;
+        }
+        return result;
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Provenance/ClaimVerifierRouterTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Provenance/ClaimVerifierRouterTests.cs
@@ -1,0 +1,233 @@
+using Ato.Copilot.Core.Interfaces.Provenance;
+using Ato.Copilot.Core.Models.Provenance;
+using Ato.Copilot.Mcp.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Provenance;
+
+/// <summary>
+/// Unit tests for <see cref="ClaimVerifierRouter"/> (#2753).
+///
+/// Verifies routing rules, auto-rollback, LLM-outage (#2780) handling,
+/// and shadow-log fire-and-forget behaviour.
+/// </summary>
+public sealed class ClaimVerifierRouterTests
+{
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static DebertaNliResult MakeDeberta(
+        string verdict = "supported",
+        double confidence = 0.92,
+        double topMargin = 0.81,
+        long latencyMs = 12) =>
+        new() { Verdict = verdict, Confidence = confidence, TopMargin = topMargin, LatencyMs = latencyMs };
+
+    private static LlmVerifierResult MakeLlm(
+        string verdict = "supported",
+        double confidence = 0.90,
+        long latencyMs = 150) =>
+        new() { Verdict = verdict, Confidence = confidence, LatencyMs = latencyMs };
+
+    private static ClaimVerifierRouter BuildRouter(
+        IDeBertaNliVerifier deberta,
+        ILlmClaimVerifier llm,
+        IClassifierShadowLogger? shadow = null,
+        bool debertaModeOn = true,
+        double tau = 0.5)
+    {
+        shadow ??= new NullClassifierShadowLogger();
+        return new ClaimVerifierRouter(
+            deberta, llm, shadow,
+            NullLogger<ClaimVerifierRouter>.Instance,
+            debertaModeOn, tau);
+    }
+
+    // ─── Routing: DEBERTA_NLI_MODE OFF ───────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_RoutesToLlm_WhenDebertaModeOff()
+    {
+        // Arrange
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("supported", topMargin: 0.9));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(MakeLlm("refuted")); // LLM disagrees — should win when mode is OFF
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: false);
+
+        // Act
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert
+        result.Verdict.Should().Be("refuted");
+        result.Path.Should().Be(VerificationPath.LlmFallback);
+        llm.Verify(l => l.VerifyAsync("claim", "evidence", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─── Routing: clear-cut → DeBERTa fast-path ──────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_RoutesToDeberta_WhenModOnAndMarginMeetsTau()
+    {
+        // Arrange — margin 0.82 ≥ τ 0.5
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("refuted", confidence: 0.93, topMargin: 0.82));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+
+        // Act
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert
+        result.Verdict.Should().Be("refuted");
+        result.Path.Should().Be(VerificationPath.DebertaFastPath);
+        llm.Verify(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never, "LLM must not be called on the clear-cut fast-path");
+    }
+
+    // ─── Routing: ambiguous → LLM fallback ───────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_RoutesToLlm_WhenMarginBelowTau()
+    {
+        // Arrange — margin 0.3 < τ 0.5
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("tangential", topMargin: 0.3));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(MakeLlm("insufficient"));
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+
+        // Act
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert
+        result.Verdict.Should().Be("insufficient");
+        result.Path.Should().Be(VerificationPath.LlmFallback);
+    }
+
+    // ─── Auto-rollback ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_RoutesToLlm_WhenAutoRollbackIsActive()
+    {
+        // Arrange — mode ON, margin clear-cut, but rollback tripped
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("supported", topMargin: 0.9));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(MakeLlm("supported"));
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+        sut.TripAutoRollback("contradicted-class precision dropped below 0.95 in monitoring");
+
+        // Act
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert
+        result.Path.Should().Be(VerificationPath.AutoRollbackToLlm);
+        sut.IsAutoRollbackActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RestoresFastPath_WhenRollbackIsCleared()
+    {
+        // Arrange
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("supported", topMargin: 0.9));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(MakeLlm("supported"));
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+        sut.TripAutoRollback("test");
+        sut.ClearAutoRollback();
+
+        // Act
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert — rollback cleared → fast-path restored
+        result.Path.Should().Be(VerificationPath.DebertaFastPath);
+        sut.IsAutoRollbackActive.Should().BeFalse();
+    }
+
+    // ─── LLM outage (#2780) ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_MarksLlmUnavailable_WhenLlmThrowsUnavailableException()
+    {
+        // Arrange — DeBERTa returns low margin → LLM fallback → LLM throws
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(MakeDeberta("tangential", topMargin: 0.2));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ThrowsAsync(new LlmVerifierUnavailableException("Anthropic credits exhausted (#2780)"));
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+
+        // Act
+        Func<Task> act = () => sut.VerifyAsync("claim", "evidence");
+
+        // Assert — exception surfaces to caller AND comparator is flagged unavailable
+        await act.Should().ThrowAsync<LlmVerifierUnavailableException>();
+        sut.IsLlmComparatorAvailable.Should().BeFalse(
+            because: "router must mark LLM unavailable on #2780 so agreement metrics are suspended");
+    }
+
+    [Fact]
+    public void MarkLlmComparatorAvailable_ClearsUnavailableFlag()
+    {
+        // Arrange
+        var sut = BuildRouter(Mock.Of<IDeBertaNliVerifier>(), Mock.Of<ILlmClaimVerifier>());
+        sut.MarkLlmComparatorUnavailable();
+
+        // Act
+        sut.MarkLlmComparatorAvailable();
+
+        // Assert
+        sut.IsLlmComparatorAvailable.Should().BeTrue();
+    }
+
+    // ─── DeBERTa failure degradation ─────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_DegradesToLlm_WhenDebertaInferenceFails()
+    {
+        // Arrange — DeBERTa throws; should degrade to "insufficient" (margin=0) → LLM fallback
+        var deberta = new Mock<IDeBertaNliVerifier>();
+        deberta.Setup(d => d.InferAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ThrowsAsync(new InvalidOperationException("DeBERTa model not loaded"));
+
+        var llm = new Mock<ILlmClaimVerifier>();
+        llm.Setup(l => l.VerifyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(MakeLlm("supported"));
+
+        var sut = BuildRouter(deberta.Object, llm.Object, debertaModeOn: true, tau: 0.5);
+
+        // Act — must not throw
+        var result = await sut.VerifyAsync("claim", "evidence");
+
+        // Assert
+        result.Path.Should().Be(VerificationPath.LlmFallback,
+            because: "DeBERTa failure degrades to margin=0, which is below τ, forcing LLM fallback");
+        result.Verdict.Should().Be("supported");
+    }
+}

--- a/tests/Ato.Copilot.Tests.Unit/Provenance/ClassifierPromotionGateServiceTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Provenance/ClassifierPromotionGateServiceTests.cs
@@ -1,0 +1,268 @@
+using Ato.Copilot.Core.Data.Context;
+using Ato.Copilot.Core.Interfaces.Provenance;
+using Ato.Copilot.Core.Models.Provenance;
+using Ato.Copilot.Mcp.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Provenance;
+
+/// <summary>
+/// Unit tests for <see cref="ClassifierPromotionGateService"/> (#2753).
+///
+/// Tests use an InMemory EF database seeded with synthetic shadow log rows so no
+/// live telemetry is required.  All eight gate outcomes are validated independently.
+/// </summary>
+public sealed class ClassifierPromotionGateServiceTests : IDisposable
+{
+    private readonly AtoCopilotContext _db;
+    private readonly TestDbContextFactory _factory;
+    private readonly ClassifierPromotionGateService _sut;
+
+    public ClassifierPromotionGateServiceTests()
+    {
+        var opts = new DbContextOptionsBuilder<AtoCopilotContext>()
+            .UseInMemoryDatabase($"PromotionGateTest_{Guid.NewGuid()}")
+            .Options;
+        _factory = new TestDbContextFactory(opts);
+        _db = _factory.Context;
+        _db.Database.EnsureCreated();
+        _sut = new ClassifierPromotionGateService(_factory, NullLogger<ClassifierPromotionGateService>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private ClassifierShadowLog MakeRow(
+        string debertaVerdict,
+        string llmVerdict,
+        double confidence,
+        double topMargin,
+        long latencyMs = 12,
+        string trafficSlice = "live") =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            PairId = Guid.NewGuid().ToString(),
+            ClaimHash = Guid.NewGuid().ToString("N"),
+            EvidenceHash = Guid.NewGuid().ToString("N"),
+            DebertaVerdict = debertaVerdict,
+            DebertaConfidence = confidence,
+            DebertaTopMargin = topMargin,
+            LlmVerdict = llmVerdict,
+            LatencyMs = latencyMs,
+            TrafficSlice = trafficSlice,
+            Ts = DateTime.UtcNow,
+        };
+
+    private async Task SeedRowsAsync(IEnumerable<ClassifierShadowLog> rows)
+    {
+        _db.ClassifierShadowLogs.AddRange(rows);
+        await _db.SaveChangesAsync();
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_ReturnsSufficientDataFalse_WhenRowCountBelowMinimum()
+    {
+        // Arrange — seed only 100 rows (minimum is 10 000)
+        await SeedRowsAsync(Enumerable.Range(0, 100)
+            .Select(_ => MakeRow("supported", "supported", 0.9, 0.8)));
+
+        // Act
+        var result = await _sut.EvaluateAsync();
+
+        // Assert
+        result.SufficientData.Should().BeFalse();
+        result.AllGatesPass.Should().BeFalse();
+        result.TotalPairs.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate1_Passes_WhenContradictedPrecisionMeetsFloor()
+    {
+        // Arrange — seed 10k rows; all clear-cut (margin ≥ 0.5); all refuted DeBERTa
+        // decisions are confirmed by LLM (100% contradicted precision).
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(_ => MakeRow("refuted", "refuted", 0.92, 0.81)));
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.SufficientData.Should().BeTrue();
+        result.ContradictedClassPrecision.Should().BeApproximately(1.0, 0.001);
+        result.Gate1_ContradictedPrecision.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate1_Fails_WhenContradictedPrecisionBelowFloor()
+    {
+        // Arrange — 10k rows where DeBERTa says "refuted" but LLM says "supported" (all wrong).
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(_ => MakeRow("refuted", "supported", 0.92, 0.81)));
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.ContradictedClassPrecision.Should().BeApproximately(0.0, 0.001);
+        result.Gate1_ContradictedPrecision.Should().BeFalse();
+        result.AllGatesPass.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate3_IsDeferred_WhenNoLlmVerdicts()
+    {
+        // Arrange — 10k rows with empty LlmVerdict (simulating #2780 LLM outage).
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(_ => MakeRow("supported", "", 0.91, 0.82)));
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert — gate 3 deferred (null), not failed
+        result.AgreementRateInClearCutRegion.Should().BeNull();
+        result.Gate3_Agreement.Should().BeTrue(
+            because: "Gate 3 defers (not fails) when no LLM verdicts are available — #2780 protocol");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate3_Fails_WhenAgreementBelowFloor()
+    {
+        // Arrange — 10k rows in clear-cut region; DeBERTa always disagrees with LLM.
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(_ => MakeRow("supported", "refuted", 0.91, 0.82)));
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.AgreementRateInClearCutRegion.Should().BeApproximately(0.0, 0.001);
+        result.Gate3_Agreement.Should().BeFalse();
+        result.AllGatesPass.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate5_Passes_WhenP95BelowFiftyMs()
+    {
+        // Arrange — 10k rows with latencies in the 5–30ms range (all below 50ms).
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(i => MakeRow("supported", "supported", 0.91, 0.81,
+                latencyMs: 10 + (i % 20)))); // 10–29ms
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.P95LatencyMs.Should().BeLessThan(50.0);
+        result.Gate5_P95Latency.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate5_Fails_WhenP95ExceedsFiftyMs()
+    {
+        // Arrange — 10k rows with latencies; 10% exceed 50ms so p95 is above floor.
+        const int n = 10_000;
+        await SeedRowsAsync(Enumerable.Range(0, n)
+            .Select(i => MakeRow("supported", "supported", 0.91, 0.81,
+                latencyMs: i < (int)(n * 0.94) ? 10L : 200L))); // top 6% = 200ms
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert — p95 sits in the 200ms bucket
+        result.P95LatencyMs.Should().BeGreaterThanOrEqualTo(50.0);
+        result.Gate5_P95Latency.Should().BeFalse();
+        result.AllGatesPass.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate8_RoutableFraction_IsComputed()
+    {
+        // Arrange — half the rows have margin ≥ 0.5 (clear-cut), half below.
+        const int n = 10_000;
+        var rows = Enumerable.Range(0, n).Select(i =>
+            MakeRow("supported", "supported", 0.91,
+                topMargin: i % 2 == 0 ? 0.6 : 0.3)); // 50% clear-cut
+        await SeedRowsAsync(rows);
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.RoutableFraction.Should().BeApproximately(0.5, 0.01);
+        result.Gate8_RoutableFraction.Should().BeTrue(
+            because: "50% routable fraction exceeds the 40% gate floor");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Gate8_Fails_WhenRoutableFractionBelowFloor()
+    {
+        // Arrange — only 10% of rows have margin ≥ 0.5.
+        const int n = 10_000;
+        var rows = Enumerable.Range(0, n).Select(i =>
+            MakeRow("supported", "supported", 0.91,
+                topMargin: i < (int)(n * 0.10) ? 0.6 : 0.3)); // 10% clear-cut
+        await SeedRowsAsync(rows);
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert
+        result.RoutableFraction.Should().BeApproximately(0.1, 0.01);
+        result.Gate8_RoutableFraction.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PerClassMetrics_AreComputed_ForAllVerdicts()
+    {
+        // Arrange — 10k rows evenly spread across all four classes (DeBERTa == LLM).
+        const int n = 10_000;
+        var verdicts = new[] { "supported", "refuted", "tangential", "insufficient" };
+        var rows = Enumerable.Range(0, n).Select(i =>
+        {
+            var v = verdicts[i % 4];
+            return MakeRow(v, v, 0.9, 0.8);
+        });
+        await SeedRowsAsync(rows);
+
+        // Act
+        var result = await _sut.EvaluateAsync(tau: 0.5);
+
+        // Assert — all four classes should have precision = recall = 1.0 (perfect agreement)
+        foreach (var v in verdicts)
+        {
+            result.PrecisionByClass.Should().ContainKey(v);
+            result.RecallByClass.Should().ContainKey(v);
+            result.PrecisionByClass[v].Should().BeApproximately(1.0, 0.001,
+                because: $"DeBERTa always matches LLM for class '{v}'");
+        }
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FormatGateSummary_DoesNotThrow()
+    {
+        // Arrange — minimal data to produce a result
+        await SeedRowsAsync(Enumerable.Range(0, 100)
+            .Select(_ => MakeRow("supported", "supported", 0.9, 0.8)));
+
+        // Act
+        var result = await _sut.EvaluateAsync();
+
+        // Assert
+        var summary = result.FormatGateSummary();
+        summary.Should().Contain("Gate 1");
+        summary.Should().Contain("Gate 8");
+        summary.Should().ContainAny("PASS", "FAIL", "DEFER");
+    }
+}


### PR DESCRIPTION
Closes #2753

## Summary
Implements the DeBERTa NLI fast-path / LLM fallback routing subsystem for claim-evidence verification, including the auto-rollback guard and LLM-comparator unavailability protocol described in #2753 and #2780.

## Files changed
**Core interfaces** (`src/Ato.Copilot.Core/Interfaces/Provenance/`)
- `IClaimVerifierRouter` — routing contract with auto-rollback + LLM-unavailability flags
- `IClassifierPromotionGateService` — gate evaluation contract
- `IDeBertaNliVerifier`, `ILlmClaimVerifier` — verifier contracts

**Core models** (`src/Ato.Copilot.Core/Models/Provenance/`)
- `ClaimVerificationResult`, `ClassifierPromotionGateResult`

**MCP services** (`src/Ato.Copilot.Mcp/Services/`)
- `ClaimVerifierRouter` — reads `DEBERTA_NLI_MODE` + `DEBERTA_NLI_TAU` from config
- `ClassifierPromotionGateService` — reads `classifier_shadow_log`, applies precision + agreement floors

**DI wiring** (`Program.cs`)
- `ClassifierPromotionGateService` registered unconditionally
- `ClaimVerifierRouter` registered conditionally on `DEBERTA_NLI_MODE` or `FEATURE_CLASSIFIER_SHADOW` config flags

**Tests** (`tests/Ato.Copilot.Tests.Unit/Provenance/`)
- `ClaimVerifierRouterTests`, `ClassifierPromotionGateServiceTests`