### PR TITLE
fix: restore Node 22 LTS + enforce heap-ceiling gate in CI (#803)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,10 @@ jobs:
   # global.gc() is available for deterministic GC-before-measure. Without it
   # the heap-ceiling test skips rather than fails (skip rule for local dev).
   # In this job the flag is always set so the gate is enforced on every PR.
+  #
+  # Node 22 LTS is pinned here because Node 24 silently ignores --expose-gc
+  # (global.gc remains undefined), causing the heap-ceiling and anchor-drift
+  # tests to skip rather than run. Tracked and fixed in issue #803.
   # ---------------------------------------------------------------------------
   chat-client-tests:
     name: Chat Client Tests (TraceabilityPanel + heap-ceiling gate)
@@ -383,10 +387,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: src/Ato.Copilot.Chat/ClientApp/package-lock.json
 
@@ -403,26 +407,18 @@ jobs:
           # can force GC before/after the 200-render stress loop (#2820).
           NODE_OPTIONS: "--expose-gc"
 
-      - name: Assert heap-ceiling delta was reported (#2820)
-        # Accepts two outcomes:
-        #   1. GC available — test ran and emitted "[heap-ceiling] delta=X MB"
-        #   2. GC unavailable (Node 24 runner ignores --expose-gc) — heap-ceiling
-        #      tests are explicitly skipped via it.skip; Jest reports N skipped.
-        #      Restoration tracked in issue #804.
-        # Fails only if there is no measurement AND no skipped tests at all
-        # (which would mean the file was somehow not executed).
+      - name: Assert heap-ceiling delta was reported (#2820 / #803)
+        # Gate: the heap-ceiling test MUST run and emit a delta measurement.
+        # Skipped tests are no longer accepted — Node 22 LTS exposes global.gc()
+        # reliably via NODE_OPTIONS=--expose-gc (issue #803 fixed).
         run: |
           if grep -q '\[heap-ceiling\].*delta=' /tmp/jest-output.txt; then
             echo "PASS: heap-ceiling delta measured and reported"
-          elif grep -qE 'Tests:.*[0-9]+ skipped' /tmp/jest-output.txt; then
-            SKIPPED_COUNT=$(grep -oE '[0-9]+ skipped' /tmp/jest-output.txt | grep -oE '[0-9]+')
-            echo "INFO: ${SKIPPED_COUNT} test(s) explicitly skipped (global.gc() unavailable on this runner)."
-            echo "heap-ceiling and anchor-drift tests require --expose-gc / global.gc() to measure heap."
-            echo "Restoration tracked in https://github.com/azurenoops/spin_agent/issues/804"
           else
-            echo "FAIL: [heap-ceiling] delta= line missing and no skipped tests detected."
-            echo "heap-ceiling.test.tsx must either run to completion or be explicitly skipped."
-            echo "Check that global.gc() is available (NODE_OPTIONS=--expose-gc) and the test ran."
+            echo "FAIL: [heap-ceiling] delta= line missing from test output."
+            echo "This means global.gc() was unavailable or heap-ceiling.test.tsx did not execute."
+            echo "Ensure NODE_OPTIONS=--expose-gc is set and the Node version is 22 LTS."
+            echo "Ref: issue #803"
             exit 1
           fi
 

--- a/src/Ato.Copilot.Chat/ClientApp/src/components/Chat/__tests__/heap-ceiling.test.tsx
+++ b/src/Ato.Copilot.Chat/ClientApp/src/components/Chat/__tests__/heap-ceiling.test.tsx
@@ -4,15 +4,16 @@
 // Verifies that rendering TraceabilityPanel across 200 simulated message IDs
 // does not leak heap memory beyond HEAP_CEILING_DELTA_MB (50 MB).
 //
-// Skip rule: if the V8 GC is not exposed (NODE_OPTIONS=--expose-gc not set, or
-// the Node runtime ignores the flag — e.g. the GitHub Actions Node 24 runner
-// as of August 2026), the test is explicitly skipped via it.skip so the skip
-// is visible in CI output rather than silently passing.
+// CI requirement: NODE_OPTIONS=--expose-gc must be set and honoured by the
+// Node runtime. The CI job (chat-client-tests in ci.yml) pins Node 22 LTS,
+// which reliably exposes global.gc() via that flag (issue #803 fix).
 //
-// Follow-up: restore real coverage once --expose-gc is reliably available on
-// the CI runner. Tracked in issue #804.
+// Skip rule: if global.gc() is unavailable (e.g. local dev without the flag),
+// the test is explicitly skipped via it.skip so the skip is visible rather
+// than silently passing. In CI this should never trigger — the gate will fail
+// the assert step if the delta line is absent.
 //
-// Measurement approach (when GC is available):
+// Measurement approach:
 //   1. Force GC before the test loop.
 //   2. Record baseline heap (process.memoryUsage().heapUsed).
 //   3. Mount + unmount TraceabilityPanel 200 times across unique messageIds.
@@ -58,17 +59,17 @@ function heapUsedBytes(): number {
 
 // ─── Conditional test runner ──────────────────────────────────────────────────
 //
-// Use it.skip when GC is unavailable so the skip is honest and visible in CI.
-// The Node 24 GitHub Actions runner ignores --expose-gc as of August 2026;
-// restore to a plain `it` once issue #804 is resolved and CI enforces GC.
+// Use it.skip when GC is unavailable (local dev without --expose-gc) so the
+// skip is honest and visible. In CI (Node 22 LTS, NODE_OPTIONS=--expose-gc)
+// gcAvailable() returns true and gcTest === it, so the gate is enforced.
 //
 const gcTest = gcAvailable() ? it : it.skip;
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('#2820 heap-ceiling — TraceabilityPanel 200-render stress', () => {
-  // SKIPPED on Node 24 CI runner — global.gc() unavailable even with --expose-gc.
-  // Tracked: https://github.com/azurenoops/spin_agent/issues/804
+  // Skips automatically in local dev when --expose-gc is not set.
+  // In CI (Node 22 LTS + NODE_OPTIONS=--expose-gc) this runs as a hard gate.
   gcTest(
     `heap delta after ${RENDER_CYCLES} mount/unmount cycles must be ≤ ${HEAP_CEILING_DELTA_MB} MB`,
     () => {
@@ -128,12 +129,12 @@ describe('#2820 heap-ceiling — TraceabilityPanel 200-render stress', () => {
 // zero orphaned anchors (start >= end) and do not leak significant heap.
 // This enforces the CI drift gate requirement from work item 9e3ff674970d4e4a.
 //
-// SKIPPED on Node 24 CI runner — global.gc() unavailable even with --expose-gc.
-// Tracked: https://github.com/azurenoops/spin_agent/issues/804
+// Skips automatically in local dev when --expose-gc is not set.
+// In CI (Node 22 LTS + NODE_OPTIONS=--expose-gc) this runs as a hard gate.
 
 describe('#2683/9e3ff67 anchor-drift stress — 200 remap cycles, 0 orphans', () => {
-  // SKIPPED on Node 24 CI runner — global.gc() unavailable even with --expose-gc.
-  // Tracked: https://github.com/azurenoops/spin_agent/issues/804
+  // Skips automatically in local dev when --expose-gc is not set.
+  // In CI (Node 22 LTS + NODE_OPTIONS=--expose-gc) this runs as a hard gate.
   gcTest(
     'leaves 0 orphaned anchors and heap delta ≤ 20 MB after 200 insert/delete cycles',
     () => {


### PR DESCRIPTION
## Summary

Restores Node 22 LTS as the runtime and enforces a heap-ceiling gate in CI to prevent Node 24 OOM regressions.

Closes #803