### PR TITLE
fix(#664): enforce SDK 9.0.3xx patch band (rollForward=patch)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.100",
-    "rollForward": "latestFeature",
+    "version": "9.0.300",
+    "rollForward": "patch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Closes #664

## Summary
Changes `rollForward` from `latestFeature` to `patch` and updates the pinned SDK version from `9.0.100` to `9.0.300` to match the installed SDK band (9.0.313). This ensures builds are reproducible — developers and CI can't silently drift to a different feature band.

## Root cause
`latestFeature` allows any 9.0.x feature band. Pinning to `patch` within the correct band (9.0.300) prevents unintended SDK version variation.

## Testing
Build gate run: 0 errors, warnings all pre-existing.