### PR TITLE
fix(#657): default ato-chat ASPNETCORE_ENVIRONMENT to Development

### DIFF
--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -167,7 +167,10 @@ services:
     ports:
       - "${CHAT_PORT:-5001}:5001"
     environment:
-      - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Production}
+      # fix(#657): default to Development to match ato-copilot service; prevents auth
+      # mismatch (chat=Production real auth vs MCP=Development CAC simulation) for local dev.
+      # Override to Production via ASPNETCORE_ENVIRONMENT env var in staging/prod deployments.
+      - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}
 
       # ── Chat Database (SQL Server — separate DB) ──────────
       - ATO_CONNECTIONSTRINGS__CHATDB=Server=sqlserver,1433;Database=AtoCopilotChat;User Id=sa;Password=${SQL_SA_PASSWORD};TrustServerCertificate=True;Encrypt=True


### PR DESCRIPTION
Closes #657

## Summary
The `ato-chat` service in `docker-compose.mcp.yml` defaulted `ASPNETCORE_ENVIRONMENT` to `Production`, while `ato-copilot` was hardcoded to `Development`. This caused an auth mismatch in local dev: chat ran with real Azure AD auth while MCP ran with CAC simulation.

## Fix
Changed the default to `Development` to match `ato-copilot`. Staging/prod deployments set `ASPNETCORE_ENVIRONMENT=Production` explicitly in their manifests, which overrides this default correctly.

## Testing
Local `docker compose -f docker-compose.mcp.yml up` without any env override now starts both services in Development mode with consistent auth behavior.