### PR TITLE
fix(#665): disable OpenTelemetry by default in base appsettings

### DIFF
--- a/src/Ato.Copilot.Mcp/appsettings.json
+++ b/src/Ato.Copilot.Mcp/appsettings.json
@@ -64,11 +64,11 @@
     "KeepaliveIntervalSeconds": 15,
     "BufferEvictionTimeoutSeconds": 60
   },
-  "OpenTelemetry": {
-    "Enabled": true,
-    "OtlpEndpoint": "http://localhost:4317",
-    "EnablePrometheus": false
-  },
+    "OpenTelemetry": {
+        "Enabled": false,
+        "OtlpEndpoint": "http://localhost:4317",
+        "EnablePrometheus": false
+    },
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:3000",


### PR DESCRIPTION
Closes #665

## Summary
`appsettings.json` had OpenTelemetry `Enabled: true` with `OtlpEndpoint: localhost:4317`. Every environment without a local OTEL collector (all dev/CI/staging) logged repeated connection errors at startup, masking real issues.

## Fix
Set `Enabled: false` in base `appsettings.json`. Enable per-environment via `appsettings.Production.json` or `OpenTelemetry__Enabled=true` env var when a collector is available.

## Testing
No build errors. OTEL connection errors will no longer appear in standard dev/CI runs.