### PR TITLE
fix(#656): clear hardcoded AzureAI endpoint and add startup validation

### DIFF
--- a/src/Ato.Copilot.Mcp/Program.cs
+++ b/src/Ato.Copilot.Mcp/Program.cs
@@ -207,6 +207,8 @@ async Task RunHttpModeAsync(string[] args)
     ValidateCacSimulationConfig(builder.Configuration, builder.Environment.EnvironmentName);
     // Validate Foundry provider configuration (Task #177 / Epic #132)
     ValidateFoundryConfig(builder.Configuration);
+    // fix(#656): validate AzureAi endpoint is configured when AI is enabled
+    ValidateAzureAiEndpointConfig(builder.Configuration);
     builder.Services.AddHealthChecks()
         .AddCheck<AgentHealthCheck>("compliance-agent")
         .AddCheck<Ato.Copilot.Agents.Observability.NistControlsHealthCheck>("nist-controls");
@@ -1363,6 +1365,38 @@ void ValidateFoundryConfig(IConfiguration configuration)
             "Azure AI Foundry provider active. Project endpoint: {FoundryProjectEndpoint}",
             aiOptions.FoundryProjectEndpoint);
     }
+}
+
+// ────────────────────────────────────────────────────────────────
+//  Azure AI Endpoint Startup Validation  (fix #656)
+// ────────────────────────────────────────────────────────────────
+/// <summary>
+/// Fails fast when AzureAi:Enabled=true but AzureAi:Endpoint is empty.
+/// The base appsettings.json no longer ships a hardcoded endpoint, so any
+/// environment that enables AI must supply the endpoint via environment
+/// variable (ATO_AZUREAI__ENDPOINT) or a secrets override file.
+/// </summary>
+void ValidateAzureAiEndpointConfig(IConfiguration configuration)
+{
+    var aiOptions = configuration.GetSection(Ato.Copilot.Core.Configuration.AzureAiOptions.SectionName)
+                                 .Get<Ato.Copilot.Core.Configuration.AzureAiOptions>();
+
+    if (aiOptions is null || !aiOptions.Enabled) return;
+
+    // Foundry provider has its own endpoint validation in ValidateFoundryConfig
+    if (aiOptions.Provider == Ato.Copilot.Core.Configuration.AiProvider.Foundry) return;
+
+    if (string.IsNullOrWhiteSpace(aiOptions.Endpoint))
+    {
+        throw new InvalidOperationException(
+            "AzureAi:Enabled is true but AzureAi:Endpoint is empty. " +
+            "Set ATO_AZUREAI__ENDPOINT to your Azure OpenAI endpoint " +
+            "(e.g. https://<resource>.openai.azure.com/) via environment variable " +
+            "or appsettings.*.local.json (do not commit the endpoint to appsettings.json). " +
+            "Alternatively set ATO_AZUREAI__ENABLED=false to disable AI features.");
+    }
+
+    Log.Information("Azure AI endpoint configured: {Endpoint}", aiOptions.Endpoint);
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/src/Ato.Copilot.Mcp/appsettings.json
+++ b/src/Ato.Copilot.Mcp/appsettings.json
@@ -85,7 +85,7 @@
   "AzureAi": {
     "Enabled": true,
     "Provider": "OpenAi",
-    "Endpoint": "https://ato-copilot-ai.openai.azure.com/",
+        "Endpoint": "",
     "DeploymentName": "gpt-4o-mini",
     "UseManagedIdentity": true,
     "CloudEnvironment": "AzurePublicCloud",


### PR DESCRIPTION
Closes #656

## Summary
`appsettings.json` hardcoded `AzureAi:Endpoint` to a specific Azure OpenAI URL. Any environment other than the original deployment failed AI client registration without manually patching config.

## Changes
- **`appsettings.json`** — `AzureAi:Endpoint` cleared to empty string
- **`Program.cs`** — added `ValidateAzureAiEndpointConfig()`: fails fast at startup when AI is enabled but endpoint is empty (OpenAI provider). Foundry provider endpoint is already covered by the existing `ValidateFoundryConfig`.

## How to configure
Set `ATO_AZUREAI__ENDPOINT=https://<resource>.openai.azure.com/` via environment variable, or add an `appsettings.Development.local.json` override (never commit endpoint to source).

## Testing
Build: 0 errors. Startup validation path tested by reading the code path — manual smoke test of endpoint rejection is required locally.