### PR TITLE
fix(#667): remove CSP.Admin from default simulated dev identity

### DIFF
--- a/src/Ato.Copilot.Mcp/appsettings.Development.json
+++ b/src/Ato.Copilot.Mcp/appsettings.Development.json
@@ -5,7 +5,10 @@
       "UserPrincipalName": "dev.user@dev.mil",
       "DisplayName": "Dev User (Simulated)",
       "CertificateThumbprint": "ABC123DEF456",
-      "Roles": ["Global Reader", "ISSO", "CSP.Admin"],
+      // fix(#667): default dev identity is ISSO (not CSP.Admin) to surface RBAC gaps during dev.
+      // To test admin scenarios locally, use the X-Simulated-Role header (ADR-002) or set
+      // CacAuth__SimulatedIdentity__Roles__0=CSP.Admin in your local environment.
+      "Roles": ["Global Reader", "ISSO"],
       "TenantId": "00000000-0000-0000-0000-000000000001",
       "ObjectId": "00000000-0000-0000-0000-000000000002"
     },


### PR DESCRIPTION
Closes #667

## Summary
The default simulated dev identity had `CSP.Admin` in its roles, meaning all developers always tested with max privilege. This masked RBAC bugs that would surface for real users with lower privilege levels.

## Change
Removed `CSP.Admin` from `SimulatedIdentity.Roles` in `appsettings.Development.json`. Default is now `["Global Reader", "ISSO"]`.

## Testing with admin privilege
- Use the `X-Simulated-Role` header (per ADR-002) to simulate elevated roles during a request
- Or set `CacAuth__SimulatedIdentity__Roles__0=CSP.Admin` in your local env/secrets
- The `dev-cspadmin` persona in `SimulatedIdentities` remains for multi-persona testing