### PR TITLE
fix(#617): register honors full system name with commas before type keyword

### DIFF
--- a/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
+++ b/src/Ato.Copilot.Agents/Compliance/Agents/ComplianceAgent.cs
@@ -2742,10 +2742,14 @@ public class ComplianceAgent : BaseAgent
     /// fix(#572)</summary>
     private static string? ExtractSystemNameFromRegistrationMessage(string message)
     {
-        // Patterns: "named <token>", "name <token>", "called <token>"
-        // Stop at: " with ", " and ", " type ", " acronym ", end of string, punctuation
+        // Patterns: "named X", "name X", "called X", "with name X"
+        // fix(#617): stop at functional parameter keywords only (type, acronym, for, using,
+        // hosted, with, and).  The previous version also stopped at noun words like "platform",
+        // "mission", "major", "enclave" which appear legitimately in system names (e.g.
+        // "Zephyr Test Platform" would truncate to "Zephyr Test" because "Platform" hit the stop).
+        // Also support an optional comma/semicolon before the stop keyword (e.g. ", type").
         var match = Regex.Match(message,
-            @"(?:named|name|called)\s+([A-Za-z0-9_\-\.]+(?:\s+[A-Za-z0-9_\-\.]+){0,4}?)(?=\s+(?:with|and|type|acronym|for|using|hosted|major|enclave|platform|mission)|$)",
+            @"(?:with\s+)?(?:named|name|called)\s+([A-Za-z0-9_\-\.]+(?:\s+[A-Za-z0-9_\-\.]+){0,7}?)(?=[,;]?\s*(?:with\b|and\b|type\b|acronym\b|for\b|using\b|hosted\b)|$)",
             RegexOptions.IgnoreCase);
         if (match.Success)
             return match.Groups[1].Value.Trim();

--- a/tests/Ato.Copilot.Tests.Unit/Agents/ComplianceAgentNameExtractionTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Agents/ComplianceAgentNameExtractionTests.cs
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// fix(#617) — ComplianceAgent name extraction regression tests
+// Verifies that ExtractSystemNameFromRegistrationMessage handles the real-world
+// patterns reported in #617 (comma-delimited "name X, type Y" inputs).
+// ─────────────────────────────────────────────────────────────────────────────
+
+using System.Reflection;
+using Xunit;
+using FluentAssertions;
+using Ato.Copilot.Agents.Compliance.Agents;
+
+namespace Ato.Copilot.Tests.Unit.Agents;
+
+public class ComplianceAgentNameExtractionTests
+{
+    // Reflectively invoke the private static ExtractSystemNameFromRegistrationMessage
+    private static string? Extract(string message)
+    {
+        var method = typeof(ComplianceAgent).GetMethod(
+            "ExtractSystemNameFromRegistrationMessage",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("reflection target must exist");
+        return (string?)method!.Invoke(null, new object[] { message });
+    }
+
+    [Theory]
+    // Quoted values (handled by ExtractQuotedValue, but double-check Extract doesn't break)
+    [InlineData("Register a new system with name Zephyr Test Platform, type MajorApplication", "Zephyr Test Platform")]
+    [InlineData("register a new system named Eagle Eye, type Enclave", "Eagle Eye")]
+    [InlineData("register a system called ACME Portal type MajorApplication", "ACME Portal")]
+    // "with name X" pattern (fix #617)
+    [InlineData("Register a new system with name My Cool System, type Enclave, acronym MCS", "My Cool System")]
+    // Trailing end-of-string (no type suffix)
+    [InlineData("register a new system named SkyNet", "SkyNet")]
+    // Single word names
+    [InlineData("register system named Prometheus type MajorApplication", "Prometheus")]
+    // Multi-word before semicolon
+    [InlineData("register a system named Alpha Bravo; type MajorApplication", "Alpha Bravo")]
+    public void Extract_ShouldCaptureName_ForRegistrationMessages(string message, string expected)
+    {
+        var result = Extract(message);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    // Messages that should NOT match (no "named/name/called" keyword)
+    [InlineData("list systems")]
+    [InlineData("get system details for Foo")]
+    public void Extract_ShouldReturnNull_WhenNoNameKeywordPresent(string message)
+    {
+        var result = Extract(message);
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regex bug where system names containing common nouns (, , , ) were silently truncated during registration.

## Root Cause

`ExtractSystemNameFromRegistrationMessage` used a lazy lookahead that included noun stop-words (`platform|mission|major|enclave`). A name like **"Zephyr Test Platform"** matched `platform` as a stop, returning `"Zephyr Test"` instead of the full name. Additionally, the LLM often emits `, type` (comma-prefixed) before the type keyword — the previous lookahead required bare whitespace, causing it to fall through entirely.

## Changes

- `ComplianceAgent.cs` — `ExtractSystemNameFromRegistrationMessage`: removed noun stop-words; kept only functional keywords (`type`, `acronym`, `for`, `using`, `hosted`, `with`, `and`); added optional comma/semicolon prefix before stop keyword; increased max word capture from 4 → 7 words
- `ComplianceAgentNameExtractionTests.cs` — 9 new unit tests covering multi-word names, comma-delimited type fields, semicolons, and no-match cases (all passing)

## Test

```
dotnet test --filter ComplianceAgentNameExtractionTests
```
All 9 tests pass.

Closes #617