### PR TITLE
fix(m365): add type=commonjs to unblock M365 Teams Extension CI job

### DIFF
--- a/extensions/m365/package.json
+++ b/extensions/m365/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "ATO Copilot M365 Extension — Teams Declarative Agent for compliance assessment and remediation",
   "main": "dist/index.js",
+  "type": "commonjs",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Problem

The `M365 Teams Extension` CI job (step: Run tests) has been failing on main since before the DEF-001 merge. Root cause: `extensions/m365/package.json` was missing `"type": "commonjs"`. Node 20+ ESM resolver intercepts `.ts` files before `ts-node`'s CommonJS require hook can handle them, causing `ERR_UNKNOWN_FILE_EXTENSION`.

The `.mocharc.js` already specifies `--require ts-node/register`, which is a CommonJS hook. Without the explicit `"type": "commonjs"` declaration, Node treats the package as ESM by default and the resolver fails before ts-node is ever invoked.

**This is a pre-existing failure, not introduced by DEF-001.** It was present before the #828 merge and is unrelated to the auth wiring changes.

## Fix

Add `"type": "commonjs"` to `extensions/m365/package.json`.

## Why this unblocks CD

CI on main currently concludes `failure` because M365 Teams Extension fails. The `CD - Azure Container Apps (Promoted)` deploy job is gated on CI passing and is skipped. Once this lands, CI goes green and the DEF-001 security fix (merged via #828, commit b0cc765) auto-deploys to staging.

## Verification

- The same fix has been running on branch `fix/829-aud-001-assessment-findings-persistence` (commit a56feb6). This PR cherry-picks it to a clean hotfix branch.
- Zero other files changed.
- No DEF-001 auth wiring touched.