### PR TITLE
fix(cd): do not deploy Chat onto the MCP Container App

### DIFF
--- a/.github/workflows/deploy-containerapp-stage.yml
+++ b/.github/workflows/deploy-containerapp-stage.yml
@@ -131,7 +131,14 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${{ vars.AZURE_RESOURCE_GROUP }}" || (echo "Missing environment variable: AZURE_RESOURCE_GROUP" && exit 1)
-          if [ -z "${{ inputs.containerapp_name }}" ] && [ -z "${{ vars.AZURE_CONTAINERAPP_NAME || '' }}" ]; then
+          if [ "${{ inputs.workload }}" = "chat" ]; then
+            if [ -z "${{ inputs.containerapp_name }}" ] && [ -z "${{ vars.AZURE_CHAT_CONTAINERAPP_NAME || '' }}" ]; then
+              echo "Missing environment variable: AZURE_CHAT_CONTAINERAPP_NAME"
+              echo "Refusing to deploy workload=chat onto AZURE_CONTAINERAPP_NAME (the MCP app)."
+              echo "Set AZURE_CHAT_CONTAINERAPP_NAME on the GitHub Environment (example: ca-ato-copilot-chat-dev)."
+              exit 1
+            fi
+          elif [ -z "${{ inputs.containerapp_name }}" ] && [ -z "${{ vars.AZURE_CONTAINERAPP_NAME || '' }}" ]; then
             echo "Missing environment variable: AZURE_CONTAINERAPP_NAME"
             exit 1
           fi
@@ -159,6 +166,16 @@ jobs:
                 if [ "$APP" = "$BASE_APP" ]; then
                   APP="${BASE_APP}-dashboard"
                 fi
+              fi
+            elif [ "$WORKLOAD" = "chat" ]; then
+              # CD 33771928221: empty AZURE_CHAT_CONTAINERAPP_NAME fell through
+              # to BASE_APP and updated ca-ato-copilot-mcp-v2 with the Chat
+              # image + port 8080. Chat must never inherit the MCP app name.
+              APP="${{ vars.AZURE_CHAT_CONTAINERAPP_NAME || '' }}"
+              if [ -z "$APP" ]; then
+                echo "Missing environment variable: AZURE_CHAT_CONTAINERAPP_NAME"
+                echo "Refusing to deploy workload=chat onto the MCP Container App."
+                exit 1
               fi
             else
               APP="$BASE_APP"

--- a/docs/guides/azure-cicd-pipeline.md
+++ b/docs/guides/azure-cicd-pipeline.md
@@ -56,6 +56,7 @@ Set these environment-level variables in each GitHub Environment (`dev`, `test`,
 - `AZURE_ACR_NAME`
 - `AZURE_CONTAINERAPP_ENV_NAME`
 - `AZURE_CONTAINERAPP_NAME`
+- `AZURE_CHAT_CONTAINERAPP_NAME` (required for Chat deploys; without it CD updates the MCP app — see run 33771928221)
 
 Optional environment-level variables:
 

--- a/tests/Ato.Copilot.Tests.Unit/Chat/ChatDeployTargetContractTests.cs
+++ b/tests/Ato.Copilot.Tests.Unit/Chat/ChatDeployTargetContractTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Ato.Copilot.Tests.Unit.Chat;
+
+/// <summary>
+/// Contract tests for Chat Container App targeting in CD.
+/// Run 33771928221 (2026-09-03) showed deploy-dev-chat resolving
+/// <c>APP=ca-ato-copilot-mcp-v2</c> because <c>AZURE_CHAT_CONTAINERAPP_NAME</c>
+/// was empty and resolve-target treated chat as MCP.
+/// </summary>
+public class ChatDeployTargetContractTests
+{
+    [Fact]
+    public void Resolve_target_refuses_to_deploy_chat_onto_mcp_app_name()
+    {
+        // Arrange
+        var path = Path.Combine(FindRepoRoot(), ".github", "workflows", "deploy-containerapp-stage.yml");
+        File.Exists(path).Should().BeTrue();
+        var text = File.ReadAllText(path);
+
+        // Act — contract is the workflow resolve-target script
+
+        // Assert
+        text.Should().Contain(
+            @"WORKLOAD"" = ""chat""",
+            "resolve-target must have an explicit chat branch");
+        text.Should().Contain(
+            "AZURE_CHAT_CONTAINERAPP_NAME",
+            "chat target must come from AZURE_CHAT_CONTAINERAPP_NAME, not AZURE_CONTAINERAPP_NAME");
+        text.Should().Contain(
+            "Refusing to deploy workload=chat",
+            "empty chat name must fail the job instead of updating the MCP app");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Ato.Copilot.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repo root (Ato.Copilot.sln).");
+    }
+}


### PR DESCRIPTION
## Summary
- After #865, CD actually ran ([33771928221](https://github.com/azurenoops/spin_agent/actions/runs/33771928221)): `build-image` succeeded, **dev MCP and dashboard deployed**.
- `deploy-dev-chat` had an empty `AZURE_CHAT_CONTAINERAPP_NAME`, so resolve-target set `APP=ca-ato-copilot-mcp-v2` and updated the **MCP** app (image + ingress port 8080). It then died on Azure `Too Many Requests`.
- This PR fails the Chat job when that variable is missing instead of overwriting MCP.

## Required before the next CD
Set GitHub Environment variable `AZURE_CHAT_CONTAINERAPP_NAME` on `dev`, `test`, and `production` (example: `ca-ato-copilot-chat-dev`).

Also verify the **dev MCP** app (`ca-ato-copilot-mcp-v2`): the failed Chat job may have already pointed it at the Chat image and port 8080.

## Test plan
- [x] `ChatDeployTargetContractTests` pass
- [ ] `AZURE_CHAT_CONTAINERAPP_NAME` set on all three GitHub Environments
- [ ] Confirm MCP ingress is still the MCP target port (3001), not 8080
- [ ] Re-run CD and confirm Chat updates the Chat app only


Made with [Cursor](https://cursor.com)